### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - 2.1
-  - 2.2
+  - 2.2.5
 
 script:
   - rake test

--- a/spec/fixtures/cookbooks/oneview_test/attributes/default.rb
+++ b/spec/fixtures/cookbooks/oneview_test/attributes/default.rb
@@ -14,4 +14,4 @@
 # specific language governing permissions and limitations under the License.
 #
 
-default['oneview_test']['client'] = { url: 'oneview.example.com', user: 'Administrator', password: 'secret123' }
+default['oneview_test']['client'] = { url: 'https://oneview.example.com', user: 'Administrator', password: 'secret123' }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,7 @@ end
 # General context for unit testing:
 RSpec.shared_context 'shared context', a: :b do
   before :each do
-    @ov_options = { url: 'oneview.example.com', user: 'Administrator', password: 'secret123' }
+    @ov_options = { url: 'https://oneview.example.com', user: 'Administrator', password: 'secret123' }
     @client = OneviewSDK::Client.new(@ov_options)
     @resource = OneviewSDK::Resource.new(@client)
   end
@@ -43,17 +43,13 @@ end
 # Context for chefspec testing:
 RSpec.shared_context 'chef context', a: :b do
   let(:chef_run) do
-    runner = ChefSpec::ServerRunner.new
+    runner = ChefSpec::SoloRunner.new
     runner.converge(described_recipe)
   end
 
   let(:real_chef_run) do
     # NOTE: Must define resource_name in each spec file
-    runner = ChefSpec::ServerRunner.new(step_into: ["oneview_#{resource_name}"])
+    runner = ChefSpec::SoloRunner.new(step_into: ["oneview_#{resource_name}"])
     runner.converge(described_recipe)
-  end
-
-  before :each do
-    allow_any_instance_of(OneviewSDK::Resource).to receive(:retrieve!).and_return(true)
   end
 end

--- a/spec/unit/resources/enclosure/add_spec.rb
+++ b/spec/unit/resources/enclosure/add_spec.rb
@@ -12,6 +12,7 @@ describe 'oneview_test::enclosure_add' do
 
   it 'updates it when it exists but not alike' do
     expect_any_instance_of(OneviewSDK::Enclosure).to receive(:exists?).and_return(true)
+    expect_any_instance_of(OneviewSDK::Enclosure).to receive(:retrieve!).and_return(true)
     expect_any_instance_of(OneviewSDK::Enclosure).to receive(:like?).and_return(false)
     expect_any_instance_of(OneviewSDK::Enclosure).to receive(:update).and_return(true)
     expect(real_chef_run).to add_oneview_enclosure('Enclosure1')
@@ -19,6 +20,7 @@ describe 'oneview_test::enclosure_add' do
 
   it 'does nothing when it exists and is alike' do
     expect_any_instance_of(OneviewSDK::Enclosure).to receive(:exists?).and_return(true)
+    expect_any_instance_of(OneviewSDK::Enclosure).to receive(:retrieve!).and_return(true)
     expect_any_instance_of(OneviewSDK::Enclosure).to receive(:like?).and_return(true)
     expect_any_instance_of(OneviewSDK::Enclosure).to_not receive(:update)
     expect_any_instance_of(OneviewSDK::Enclosure).to_not receive(:create)

--- a/spec/unit/resources/ethernet_network/create_if_missing_spec.rb
+++ b/spec/unit/resources/ethernet_network/create_if_missing_spec.rb
@@ -12,6 +12,7 @@ describe 'oneview_test::ethernet_network_create_if_missing' do
 
   it 'does nothing when it exists' do
     expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:exists?).and_return(true)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:retrieve!).and_return(true)
     expect_any_instance_of(OneviewSDK::EthernetNetwork).to_not receive(:create)
     expect(real_chef_run).to create_oneview_ethernet_network_if_missing('EthernetNetwork2')
   end

--- a/spec/unit/resources/ethernet_network/create_spec.rb
+++ b/spec/unit/resources/ethernet_network/create_spec.rb
@@ -12,6 +12,7 @@ describe 'oneview_test::ethernet_network_create' do
 
   it 'updates it when it exists but not alike' do
     expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:exists?).and_return(true)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:retrieve!).and_return(true)
     expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:like?).and_return(false)
     expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:update).and_return(true)
     expect(real_chef_run).to create_oneview_ethernet_network('EthernetNetwork1')
@@ -19,6 +20,7 @@ describe 'oneview_test::ethernet_network_create' do
 
   it 'does nothing when it exists and is alike' do
     expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:exists?).and_return(true)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:retrieve!).and_return(true)
     expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:like?).and_return(true)
     expect_any_instance_of(OneviewSDK::EthernetNetwork).to_not receive(:update)
     expect_any_instance_of(OneviewSDK::EthernetNetwork).to_not receive(:create)

--- a/spec/unit/resources/resource/create_if_missing_spec.rb
+++ b/spec/unit/resources/resource/create_if_missing_spec.rb
@@ -5,14 +5,15 @@ describe 'oneview_test::resource_create_if_missing' do
   include_context 'chef context'
 
   it 'creates EthernetNetwork2 when it does not exist' do
-    expect_any_instance_of(OneviewSDK::Resource).to receive(:exists?).and_return(false)
-    expect_any_instance_of(OneviewSDK::Resource).to receive(:create).and_return(true)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:exists?).and_return(false)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:create).and_return(true)
     expect(real_chef_run).to create_oneview_resource_if_missing('EthernetNetwork2')
   end
 
   it 'does nothing when EthernetNetwork2 exists' do
-    expect_any_instance_of(OneviewSDK::Resource).to receive(:exists?).and_return(true)
-    expect_any_instance_of(OneviewSDK::Resource).to_not receive(:create)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:exists?).and_return(true)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to_not receive(:create)
     expect(real_chef_run).to create_oneview_resource_if_missing('EthernetNetwork2')
   end
 end

--- a/spec/unit/resources/resource/create_spec.rb
+++ b/spec/unit/resources/resource/create_spec.rb
@@ -5,23 +5,25 @@ describe 'oneview_test::resource_create' do
   include_context 'chef context'
 
   it 'creates EthernetNetwork1 when it does not exist' do
-    expect_any_instance_of(OneviewSDK::Resource).to receive(:exists?).and_return(false)
-    expect_any_instance_of(OneviewSDK::Resource).to receive(:create).and_return(true)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:exists?).and_return(false)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:create).and_return(true)
     expect(real_chef_run).to create_oneview_resource('EthernetNetwork1')
   end
 
   it 'updates EthernetNetwork1 when it exists but not alike' do
-    expect_any_instance_of(OneviewSDK::Resource).to receive(:exists?).and_return(true)
-    expect_any_instance_of(OneviewSDK::Resource).to receive(:like?).and_return(false)
-    expect_any_instance_of(OneviewSDK::Resource).to receive(:update).and_return(true)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:exists?).and_return(true)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:like?).and_return(false)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:update).and_return(true)
     expect(real_chef_run).to create_oneview_resource('EthernetNetwork1')
   end
 
   it 'does nothing when EthernetNetwork1 exists and is alike' do
-    expect_any_instance_of(OneviewSDK::Resource).to receive(:exists?).and_return(true)
-    expect_any_instance_of(OneviewSDK::Resource).to receive(:like?).and_return(true)
-    expect_any_instance_of(OneviewSDK::Resource).to_not receive(:update)
-    expect_any_instance_of(OneviewSDK::Resource).to_not receive(:create)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:exists?).and_return(true)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:like?).and_return(true)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to_not receive(:update)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to_not receive(:create)
     expect(real_chef_run).to create_oneview_resource('EthernetNetwork1')
   end
 end

--- a/spec/unit/resources/resource/delete_spec.rb
+++ b/spec/unit/resources/resource/delete_spec.rb
@@ -5,14 +5,14 @@ describe 'oneview_test::resource_delete' do
   include_context 'chef context'
 
   it 'deletes it when it exists' do
-    expect_any_instance_of(OneviewSDK::Resource).to receive(:retrieve!).and_return(true)
-    expect_any_instance_of(OneviewSDK::Resource).to receive(:delete).and_return(true)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:delete).and_return(true)
     expect(real_chef_run).to delete_oneview_resource('EthernetNetwork3')
   end
 
   it 'does nothing when it does not exist' do
-    expect_any_instance_of(OneviewSDK::Resource).to receive(:retrieve!).and_return(false)
-    expect_any_instance_of(OneviewSDK::Resource).to_not receive(:delete)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:retrieve!).and_return(false)
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to_not receive(:delete)
     expect(real_chef_run).to delete_oneview_resource('EthernetNetwork3')
   end
 end


### PR DESCRIPTION
Fixes issues with Travis tests. Needed Ruby 2.2.5, and fixed some mocking issues that only appear in rspec 3.5
