### PR TITLE
Fix storage_system action type in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ oneview_storage_system 'ThreePAR7200-8147' do
     credentials: storage_system_credentials,
     managedDomain: 'TestDomain'
   )
-  action [:add, :delete]
+  action [:add, :remove]
 end
 ```
 


### PR DESCRIPTION
Should be :remove, not :delete.

Matches https://github.com/HewlettPackard/oneview-chef/blob/master/resources/storage_system.rb#L27
