### PR TITLE
Polished volume resource

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,9 +16,18 @@ Metrics/MethodLength:
 Metrics/AbcSize:
   Enabled: false
 
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
 Style/EmptyLineBetweenDefs:
   Exclude:
     - 'libraries/matchers.rb'
+
+Style/RescueModifier:
+  Enabled: false
 
 Style/WordArray:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ The following are the standard parameters available for all resources. Some reso
 
  - **client**: Hash or OneviewSDK::Client object that contains information about how to connect to the OneView instance. Required attributes are: `url`, `user`, and `password`. See [this](https://github.com/HewlettPackard/oneview-sdk-ruby#configuration) for more options.
  - **data**: Hash specifying options for this resource. Refer to the OneView API docs for what's available and/or required. If no name attribute is given, it will use the name given to the Chef resource.
- - **action**: Symbol specifying what to do with this resource. Options for most resources (some may differ):
+   - In addition to the API docs, you can use the [oneview-sdk gem's CLI](https://github.com/HewlettPackard/oneview-sdk-ruby#cli) to quickly show information about resources. If you're wanting to know which data properties exist for a resource, it might make sense to create a resource on the Web UI, then view the data. For example, after creating a new ethernet network named `eth1`, run `$ oneview-sdk-ruby show EthernetNetwork eth1`
+ - **action**: Symbol specifying what to do with this resource. Options for most resources (**some may differ**):
    - `:create` - (Default) Ensure this resource exists and matches the data given.
    - `:create_if_missing` - Ensure this resource exists, but don't ensure it is up to date on subsequent chef-client runs.
    - `:delete` - Delete this resource from OneView. For this, you only need to specify the resource name or uri in the data section.
@@ -240,7 +241,7 @@ end
   - **volume_template** (String) Optional - Name of the Volume Template.
   - **snapshot_pool** (String) Optional - Name of the Storage Pool containing the snapshots.
 
-:memo: **NOTE**: Only one of `storage_system_name` and `storage_system_ip` need to be provided. If both are specified at once, the `storage_system_ip` prevails, then ignoring `storage_system_name` value.
+:memo: **NOTE**: Only one of `storage_system_name` and `storage_system_ip` need to be provided. If both are specified at once, the `storage_system_ip` prevails, then ignoring the `storage_system_name` value.
 
 ### oneview_volume_template
 
@@ -266,14 +267,12 @@ end
 
  :warning: **WARNING**: The resources `oneview_volume` and `oneview_volume_template` appear to accept the same data, but they have two characteristics that differ:
  1. `oneview_volume_template` does not accepts the property **volume_template**. In other means, you cannot create a Volume template from another Volume template.
- 2. The provisioning data keys are different:
+ 2. The following provisioning data keys are different:
 
     oneview_volume          | oneview_volume_template
     ----------------------- | -------------------------
     :provisioningParameters | :provisioning
     :requestedCapacity      | :capacity
-    :shareable              | :shareable
-    :provisionType          | :provisionType
 
 
 ### oneview_storage_pool
@@ -324,6 +323,8 @@ end
 ```
 
 ## Examples
+
+:information_source: There are plenty more examples in the [examples](examples) directory showing more detailed usage of each resource, but here's a few to get you started:
 
  - **Create an ethernet network**
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ end
 
 :memo: **NOTE**: Only one of `storage_system_name` and `storage_system_ip` need to be provided. If both are specified at once, the `storage_system_ip` prevails, then ignoring the `storage_system_name` value.
 
+:memo: **NOTE**: The OneView API has a provisioningParameters hash for creation, but not updates. In recipes, use same data as you would for an update, and this resource will handle creating the provisioningParameters for you if the volume needs created. (Define the desired state, not how to create it). See the [volume example](examples/volume.rb) for more on this.
+
 ### oneview_volume_template
 
 Volume Template resource for HPE OneView.

--- a/examples/volume.rb
+++ b/examples/volume.rb
@@ -9,30 +9,67 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-client = {
+my_client = {
   url: '',
   user: '',
   password: ''
 }
 
-volume_data_1 = {
-  description: 'Created from Storage Pool + Storage System',
-  provisioningParameters: {
-    provisionType: 'Full',
-    shareable: true,
-    requestedCapacity: 1024 * 1024 * 1024, # 1GB
-  }
-}
-
+# Example: Create a volume
+# In this example, we'll set all the data necessary to create a new volume from scratch.
+# You'll notice that in the OneView API docs, there is a "provisioningParameters" hash that defines
+# most of the data for creating new volumes, but when you retrieve or update them, that hash is
+# gone (and everything has moved to the top level). This model is a little confusing, so we've made
+# it a little easier. All you have to do is define the data attributes like you would for an update,
+# and and the oneview_volume resource automatically populates the provisioningParameters hash for you.
+# This resource also provides some helpful properties that automatically retrieve URIs for the
+# StorageSystem, StoragePool, VolumeTemplate, and SnapshotPool; all you have to do is specify the name.
 oneview_volume 'CHEF_VOL_01' do
-  client client
-  data volume_data_1
-  storage_system_ip '172.18.11.11'
-  storage_pool 'CPG-SSD-AO'
-  action :create
+  client my_client
+  data(
+    description: 'Created by Chef',
+    shareable: true,
+    provisionType: 'Thin', # Or 'Full'
+    provisionedCapacity: 1024 * 1024 * 1024 # 1GB
+  )
+  storage_system_name 'ThreePAR7200-3167' # Name of the storage system
+  storage_pool 'CPG_FC-AO' # Name of the storage pool
+  snapshot_pool 'CPG_FC-AO' # Name of the storage pool used for snapshots
 end
 
-oneview_volume 'CHEF_VOL_01' do
-  client client
+
+# Example: Create a volume (using the storage system IP)
+# This example is identical to the one above, except we use the "storage_system_ip" property instead
+# of the "storage_system_name". You can use either one, but if you provide both, only the IP will be
+# used.
+oneview_volume 'CHEF_VOL_02' do
+  client my_client
+  data(
+    description: 'Created by Chef',
+    shareable: true,
+    provisionType: 'Thin', # Or 'Full'
+    provisionedCapacity: 1024 * 1024 * 1024 # 1GB
+  )
+  storage_system_ip '172.18.11.11' # IP of the storage system
+  storage_pool 'CPG_FC-AO' # Name of the storage pool
+  snapshot_pool 'CPG_FC-AO' # Name of the storage pool used for snapshots
+end
+
+
+# Example: Create a volume using a VolumeTemplate
+# VolumeTemplates are very helpful when you want to (mostly) the same settings for multiple volumes.
+# We can override all the template options, but you really only need to provide the capacity.
+oneview_volume 'CHEF_VOL_03' do
+  client my_client
+  data(
+    description: 'Created by Chef using template',
+    provisionedCapacity: 1024 * 1024 * 1024 * 2 # 2GB
+  )
+  volume_template 'Template1' # Name of the VolumeTemplate
+end
+
+# Example: Make sure a volume does not exist
+oneview_volume 'CHEF_VOL_04' do
+  client my_client
   action :delete
 end

--- a/libraries/oneview_helper.rb
+++ b/libraries/oneview_helper.rb
@@ -40,7 +40,8 @@ module OneviewCookbook
         klass_name.gsub!(/^Oneview/, '')
         klass = get_resource_named(klass_name)
       end
-      item = klass.new(c, data)
+      new_data = JSON.parse(data.to_json) rescue data
+      item = klass.new(c, new_data)
       item['name'] ||= name
       item
     end

--- a/libraries/oneview_resource_base.rb
+++ b/libraries/oneview_resource_base.rb
@@ -31,7 +31,7 @@ module OneviewCookbook
     def create_or_update(item = nil, method_1 = :create, method_2 = :update)
       ret_val = false
       item ||= load_resource
-      temp = item.data.clone
+      temp = Marshal.load(Marshal.dump(item.data))
       if item.exists?
         item.retrieve!
         if item.like? temp

--- a/spec/fixtures/cookbooks/oneview_test/recipes/volume_create.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/volume_create.rb
@@ -1,0 +1,29 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: volume_create
+#
+# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_volume 'VOL1' do
+  client node['oneview_test']['client']
+  data(
+    description: 'Volume created by Chef',
+    shareable: true,
+    provisionType: 'Thin',
+    provisionedCapacity: 1024 * 1024 * 1024 * 2 # 2GB
+  )
+  storage_system_name 'StorageSystem1'
+  storage_pool 'Pool1'
+  snapshot_pool 'Pool2'
+  volume_template 'Template1'
+end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/volume_create_if_missing.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/volume_create_if_missing.rb
@@ -1,0 +1,26 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: volume_create_if_missing
+#
+# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_volume 'VOL1' do
+  client node['oneview_test']['client']
+  data(
+    description: 'Volume created by Chef',
+    shareable: true,
+    provisionType: 'Thin',
+    provisionedCapacity: 1024 * 1024 * 1024 * 2 # 2GB
+  )
+  action :create_if_missing
+end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/volume_delete.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/volume_delete.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: volume_delete
+#
+# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_volume 'VOL1' do
+  client node['oneview_test']['client']
+  action :delete
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,8 @@ SimpleCov.start do
   add_filter 'matchers.rb'
   add_group 'Libraries', 'libraries'
   add_group 'Resources', 'resources'
-  minimum_coverage 97
-  minimum_coverage_by_file 94
+  minimum_coverage 98
+  minimum_coverage_by_file 96
 end
 
 Dir[File.expand_path('../libraries/*.rb', File.dirname(__FILE__))].each { |file| require file }
@@ -51,5 +51,9 @@ RSpec.shared_context 'chef context', a: :b do
     # NOTE: Must define resource_name in each spec file
     runner = ChefSpec::SoloRunner.new(step_into: ["oneview_#{resource_name}"])
     runner.converge(described_recipe)
+  end
+
+  let(:client) do
+    OneviewSDK::Client.new(url: 'https://oneview.example.com', user: 'Administrator', password: 'secret123')
   end
 end

--- a/spec/unit/libraries/oneview_helper_spec.rb
+++ b/spec/unit/libraries/oneview_helper_spec.rb
@@ -60,6 +60,12 @@ RSpec.describe OneviewCookbook::Helper do
       item = helper.load_resource
       expect(item[:name]).to eq('other_net')
     end
+
+    it 'converts the data hash to a json-safe format' do
+      allow(helper).to receive(:data).and_return(name: 'net', key2: { key3: :val3 })
+      item = helper.load_resource
+      expect(item['key2']['key3']).to eq('val3')
+    end
   end
 
   describe '#get_resource_named' do

--- a/spec/unit/resources/storage_pool/add_spec.rb
+++ b/spec/unit/resources/storage_pool/add_spec.rb
@@ -7,9 +7,7 @@ describe 'oneview_test::storage_pool_add_with_ip' do
   before :each do
     allow_any_instance_of(OneviewSDK::StoragePool).to receive(:exists?).and_return(false)
     allow_any_instance_of(OneviewSDK::StoragePool).to receive(:add).and_return(true)
-    # rubocop:disable Style/RescueModifier
     allow_any_instance_of(OneviewSDK::StorageSystem).to receive(:retrieve!).and_call_original rescue nil # This is needed for some strange reason
-    # rubocop:enable Style/RescueModifier
   end
 
   it 'accepts the storage_system_ip parameter' do
@@ -27,9 +25,7 @@ describe 'oneview_test::storage_pool_add_with_name' do
   before :each do
     allow_any_instance_of(OneviewSDK::StoragePool).to receive(:exists?).and_return(false)
     allow_any_instance_of(OneviewSDK::StoragePool).to receive(:add).and_return(true)
-    # rubocop:disable Style/RescueModifier
     allow_any_instance_of(OneviewSDK::StorageSystem).to receive(:retrieve!).and_call_original rescue nil # This is needed for some strange reason
-    # rubocop:enable Style/RescueModifier
   end
 
   it 'accepts the storage_system_name parameter' do

--- a/spec/unit/resources/volume/create_if_missing_spec.rb
+++ b/spec/unit/resources/volume/create_if_missing_spec.rb
@@ -1,0 +1,19 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test::volume_create_if_missing' do
+  let(:resource_name) { 'volume' }
+  include_context 'chef context'
+
+  it 'creates VOL1 when it does not exist' do
+    expect_any_instance_of(OneviewSDK::Volume).to receive(:exists?).at_least(:once).and_return(false)
+    expect_any_instance_of(OneviewSDK::Volume).to receive(:create).and_return(true)
+    expect(real_chef_run).to create_oneview_volume_if_missing('VOL1')
+  end
+
+  it 'does nothing when VOL1 exists' do
+    expect_any_instance_of(OneviewSDK::Volume).to receive(:exists?).at_least(:once).and_return(true)
+    expect_any_instance_of(OneviewSDK::Volume).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(OneviewSDK::Volume).to_not receive(:create)
+    expect(real_chef_run).to create_oneview_volume_if_missing('VOL1')
+  end
+end

--- a/spec/unit/resources/volume/create_spec.rb
+++ b/spec/unit/resources/volume/create_spec.rb
@@ -1,0 +1,20 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test::volume_create' do
+  let(:resource_name) { 'volume' }
+  include_context 'chef context'
+
+  before :each do
+    allow(OneviewSDK::StoragePool).to receive(:find_by).with(kind_of(OneviewSDK::Client), name: 'Pool1')
+      .and_return([OneviewSDK::StoragePool.new(client, uri: '/rest/fake')])
+    allow_any_instance_of(OneviewSDK::Volume).to receive(:exists?).and_return(false)
+  end
+
+  it 'searches for the storage_pool, snapshot_pool, and volume_template' do
+    expect_any_instance_of(OneviewSDK::Volume).to receive(:set_snapshot_pool).and_return(true)
+    expect_any_instance_of(OneviewSDK::Volume).to receive(:set_storage_volume_template).and_return(true)
+    expect_any_instance_of(OneviewSDK::Volume).to receive(:set_storage_system).and_return(true)
+    expect_any_instance_of(OneviewSDK::Volume).to receive(:create).and_return(true)
+    expect(real_chef_run).to create_oneview_volume('VOL1')
+  end
+end

--- a/spec/unit/resources/volume/delete_spec.rb
+++ b/spec/unit/resources/volume/delete_spec.rb
@@ -1,0 +1,18 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test::volume_delete' do
+  let(:resource_name) { 'volume' }
+  include_context 'chef context'
+
+  it 'removes it if it does exist' do
+    expect_any_instance_of(OneviewSDK::Volume).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(OneviewSDK::Volume).to receive(:delete).and_return(true)
+    expect(real_chef_run).to delete_oneview_volume('VOL1')
+  end
+
+  it 'does nothing if it does not exist' do
+    expect_any_instance_of(OneviewSDK::Volume).to receive(:retrieve!).and_return(false)
+    expect_any_instance_of(OneviewSDK::Volume).to_not receive(:delete)
+    expect(real_chef_run).to delete_oneview_volume('VOL1')
+  end
+end


### PR DESCRIPTION
Fixes #21 

Also, it enables you to pass the same data attributes that you would for an update, but for a create. You no longer need the `provisioningParameters`; see the new examples for more of a description on this.

Also, it:
- Adds test for the volume resource. Somehow those were missing...
- Makes a small fix in the oneview_helper library (load_resource) that converts to and from JSON. This fixes issues I was seeing for data with nested hashes containing symbols. The resource `:like` method was reporting they were different when the only difference was the type was a symbol instead of a string.
- Makes a small fix in the base resource to do a real, full clone of the data instead of a shallow copy. For nested data hashes, it would override the copy when we did a retrieve.
