### PR TITLE
Fix Travis issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 rvm:
-  - 2.1
   - 2.2.5
+  - 2.3.1
+
+before_install: gem update bundler
 
 script:
   - rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
+  - 2.1
   - 2.2.5
   - 2.3.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,12 @@
 source 'https://rubygems.org'
 
-gem 'chef', '>=12.0.0'
+gem 'chef', '>= 12.0.0'
 gem 'chefspec'
-gem 'berkshelf'
+if RUBY_VERSION =~ /^2\.[01]/
+  gem 'berkshelf', '~> 4.3' # Use older version of berkshelf for Ruby 2.0 and 2.1
+else
+  gem 'berkshelf'
+end
 gem 'foodcritic'
 gem 'rubocop', '= 0.40.0'
 gem 'oneview-sdk'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,7 +12,7 @@
 # Set which version of the SDK to install and use:
 # Warning: Changing the SDK version may cause issues within the Cookbook
 # Edit only if you know exactly what are you doing
-default['oneview']['ruby_sdk_version'] = '~> 2.0'
+default['oneview']['ruby_sdk_version'] = '~> 2.1'
 
 # Save resource info to a node attribute? Possible values/types:
 #  - true  : Save all info (Merged hash of OneView info and Chef resource properties)


### PR DESCRIPTION
Fixes #18

Instead of locking versions in the Gemfile for gems that are unimportant, this just removes Ruby 2.1, replacing it with 2.3.1. Chef ships with newer versions of Ruby than 2.1 anyways.
