### PR TITLE
Make #load_sdk do the right thing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,18 +4,21 @@ case RUBY_VERSION
 when /^2\.0/
   gem 'chef', '~> 12.0', '< 12.9'
   gem 'berkshelf', '~> 4.3'
+  gem 'foodcritic', '~> 6.3'
 when /^2\.1/
   gem 'chef', '~> 12.0', '< 12.14'
   gem 'berkshelf', '~> 4.3'
+  gem 'foodcritic', '~> 7.1'
 when /^2\.2\.[01]/
   gem 'chef', '~> 12.0', '< 12.14'
   gem 'berkshelf'
+  gem 'foodcritic', '~> 7.1'
 else
   gem 'chef', '~> 12.0'
   gem 'berkshelf'
+  gem 'foodcritic'
 end
 gem 'chefspec'
-gem 'foodcritic'
 gem 'rubocop', '= 0.40.0'
 gem 'oneview-sdk'
 gem 'pry'

--- a/spec/unit/libraries/oneview_helper_spec.rb
+++ b/spec/unit/libraries/oneview_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe OneviewCookbook::Helper do
   end
 
   let(:sdk_version) do
-    '~> 2.0'
+    '~> 2.1'
   end
 
   describe '#load_sdk' do
@@ -23,7 +23,17 @@ RSpec.describe OneviewCookbook::Helper do
     end
 
     it 'attempts to install the gem if it is not found' do
-      expect(helper).to receive(:gem).and_raise LoadError
+      expect(helper).to receive(:gem).once.and_raise LoadError
+      expect(helper).to receive(:gem).once.and_return true
+      expect(helper).to receive(:chef_gem).with('oneview-sdk').and_return true
+      expect(helper).to receive(:require).with('oneview-sdk').and_return true
+      helper.load_sdk
+    end
+
+    it 'prints an error message if the gem cannot be loaded either time' do
+      expect(helper).to receive(:gem).twice.and_raise LoadError, 'Blah'
+      expect(Chef::Log).to receive(:error).with(/cannot be loaded. Message: Blah/)
+      expect(Chef::Log).to receive(:error).with(/Loaded version .* instead/)
       expect(helper).to receive(:chef_gem).with('oneview-sdk').and_return true
       expect(helper).to receive(:require).with('oneview-sdk').and_return true
       helper.load_sdk


### PR DESCRIPTION
### Description

This PR make sure that the correct version of the SDK is loaded when possible, and gives you helpful log info if it can't be.
### Issues Resolved

No GH issues, but before, the require in the rescue block would load the latest version of the SDK, not necessarily the one you just installed. You can demonstrate this behavior by setting the version attribute to an older version than is currently installed, and it will install the older version, but actually load the newest one.

Now, it will try to load the correct SDK version, and if it fails, it'll make sure it's installed, and try to load the correct version again. If it fails the second time, it'll print an (error) log statement saying why, and just attempt to load any version it can (and prints out which one it loaded if so).

This also fixes the build issues with Ruby 2.1
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
