### PR TITLE
Implemented action none for interconnect

### DIFF
--- a/examples/interconnect.rb
+++ b/examples/interconnect.rb
@@ -15,6 +15,11 @@ my_client = {
   password: ''
 }
 
+# Do nothing
+oneview_interconnect 'Encl1, interconnect 1' do
+  client my_client
+end
+
 oneview_interconnect 'Encl1, interconnect 1' do
   client my_client
   action :reset_port_protection

--- a/examples/interconnect.rb
+++ b/examples/interconnect.rb
@@ -15,7 +15,7 @@ my_client = {
   password: ''
 }
 
-# Do nothing
+# It will not do anything if no action is selected
 oneview_interconnect 'Encl1, interconnect 1' do
   client my_client
 end

--- a/resources/interconnect.rb
+++ b/resources/interconnect.rb
@@ -22,6 +22,9 @@ action_class do
   include OneviewCookbook::ResourceBase
 end
 
+action :none do
+end
+
 action :set_uid_light do
   raise "Unspecified property: 'uid_light_state'. Please set it before attempting this action." unless uid_light_state
   item = load_resource


### PR DESCRIPTION
### Description

Implements missing action `:none` for oneview_interconnect
### Issues Resolved

Fixes #59 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
