### PR TITLE
storage_system fixes

### DIFF
--- a/examples/storage_system.rb
+++ b/examples/storage_system.rb
@@ -25,7 +25,7 @@ storage_system_credentials = {
 oneview_storage_system 'StorageSystem1' do
   client my_client
   data(
-    credentials:storage_system_credentials,
+    credentials: storage_system_credentials,
     managedDomain: 'TestDomain'
   )
   action :add
@@ -35,7 +35,7 @@ end
 oneview_storage_system 'StorageSystem1' do
   client my_client
   data(
-    credentials:storage_system_credentials,
+    credentials: storage_system_credentials,
     managedDomain: 'TestDomain'
   )
   action :add_if_missing

--- a/resources/storage_system.rb
+++ b/resources/storage_system.rb
@@ -27,8 +27,12 @@ action :add do
     if item.like? temp
       Chef::Log.info("#{resource_name} '#{name}' is up to date")
     else
-      Chef::Log.info "Editing #{resource_name} '#{name}'"
-      converge_by "#{resource_name} '#{name}' was edited." do
+      Chef::Log.info "Updating #{resource_name} '#{name}'"
+      Chef::Log.debug "#{resource_name} '#{name}' Chef resource differs from OneView resource."
+      Chef::Log.debug "Current state: #{JSON.pretty_generate(item.data)}"
+      Chef::Log.debug "Desired state: #{JSON.pretty_generate(temp)}"
+      diff = get_diff(item, temp)
+      converge_by "Update #{resource_name} '#{name}'#{diff}" do
         item.update(temp)
       end
     end
@@ -39,6 +43,7 @@ action :add do
       item.add
     end
   end
+  save_res_info(save_resource_info, name, item)
 end
 
 action :add_if_missing do
@@ -53,12 +58,11 @@ action :edit_credentials do
   item = load_resource
   temp = {}
   temp['credentials'] = Marshal.load(Marshal.dump(item.data))
-  temp = convert_keys(temp, :to_s)
   if item.exists?
     item.retrieve!
     temp['credentials']['ip_hostname'] ||= item['credentials']['ip_hostname']
-    Chef::Log.info "Editing #{resource_name} '#{name}' credentials"
-    converge_by "#{resource_name} '#{name}' credentials edited" do
+    Chef::Log.info "Updating #{resource_name} '#{name}' credentials"
+    converge_by "Update #{resource_name} '#{name}' credentials" do
       item.update(temp)
     end
   end

--- a/resources/storage_system.rb
+++ b/resources/storage_system.rb
@@ -43,6 +43,7 @@ action :add do
       item.add
     end
   end
+  item.data['credentials'].delete('password') if item.data['credentials']
   save_res_info(save_resource_info, name, item)
 end
 

--- a/spec/unit/resources/firmware/create_custom_spp_spec.rb
+++ b/spec/unit/resources/firmware/create_custom_spp_spec.rb
@@ -26,7 +26,7 @@ describe 'oneview_test::firmware_create_custom_spp_invalid_spp' do
   include_context 'chef context'
 
   it 'spp not given' do
-    expect { real_chef_run }.to raise_error(/Unspecified property: 'spp_name'/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /Unspecified property: 'spp_name'/)
   end
 end
 
@@ -35,6 +35,6 @@ describe 'oneview_test::firmware_create_custom_spp_invalid_hotfix' do
   include_context 'chef context'
 
   it 'hotfix not given' do
-    expect { real_chef_run }.to raise_error(/Unspecified property: 'hotfixes_names'/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /Unspecified property: 'hotfixes_names'/)
   end
 end

--- a/spec/unit/resources/interconnect/set_power_state_spec.rb
+++ b/spec/unit/resources/interconnect/set_power_state_spec.rb
@@ -17,6 +17,6 @@ describe 'oneview_test::interconnect_set_power_state_invalid' do
 
   it 'fails if power_state property is not set' do
     allow_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(true)
-    expect { real_chef_run }.to raise_error(/Unspecified property: 'power_state'/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /Unspecified property: 'power_state'/)
   end
 end

--- a/spec/unit/resources/interconnect/set_uid_light_spec.rb
+++ b/spec/unit/resources/interconnect/set_uid_light_spec.rb
@@ -17,6 +17,6 @@ describe 'oneview_test::interconnect_set_uid_light_invalid' do
 
   it 'fails if uid_light_state property is not set' do
     allow_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(true)
-    expect { real_chef_run }.to raise_error(/Unspecified property: 'uid_light_state'/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /Unspecified property: 'uid_light_state'/)
   end
 end

--- a/spec/unit/resources/interconnect/update_port_spec.rb
+++ b/spec/unit/resources/interconnect/update_port_spec.rb
@@ -42,7 +42,7 @@ describe 'oneview_test::interconnect_update_port' do
     allow_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewSDK::Interconnect).to receive(:[]).with('name')
     allow_any_instance_of(OneviewSDK::Interconnect).to receive(:[]).with('ports').and_return(ports)
-    expect { real_chef_run }.to raise_error(/Could not find port/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /Could not find port/)
   end
 end
 
@@ -52,6 +52,6 @@ describe 'oneview_test::interconnect_update_port_invalid' do
 
   it 'fails if port_options property is not set' do
     allow_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(true)
-    expect { real_chef_run }.to raise_error(/Unspecified property: 'port_options'/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /Unspecified property: 'port_options'/)
   end
 end

--- a/spec/unit/resources/server_hardware_type/edit_spec.rb
+++ b/spec/unit/resources/server_hardware_type/edit_spec.rb
@@ -6,7 +6,7 @@ describe 'oneview_test::server_hardware_type_edit' do
 
   it 'raise error when it does not exists' do
     allow_any_instance_of(OneviewSDK::ServerHardwareType).to receive(:exists?).and_return(false)
-    expect { real_chef_run }.to raise_error(/Resource not found: oneview_server_hardware_type 'ServerHardwareType1'/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /Resource not found: oneview_server_hardware_type 'ServerHardwareType1'/)
   end
 
   it 'updates it when it exists but not alike' do


### PR DESCRIPTION
### Description

Fixes issues with storage_system resource
### Issues Resolved
- Typos in examples
- Show diff for storage_system resources
- Save resource info for storage_system resources
- Removed error output from rspec tests
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
