### PR TITLE
Added helpful error messages to network_set

### DIFF
--- a/resources/network_set.rb
+++ b/resources/network_set.rb
@@ -23,12 +23,14 @@ action_class do
     item = load_resource
     if native_network
       native_net = OneviewSDK::EthernetNetwork.find_by(item.client, name: native_network).first
+      raise "Native network #{native_network} not found!" unless native_net
       item.set_native_network(native_net)
     end
 
     if ethernet_network_list
       ethernet_network_list.each do |net_name|
         net = OneviewSDK::EthernetNetwork.find_by(item.client, name: net_name).first
+        raise "Network #{net_name} not found!" unless net
         item.add_ethernet_network(net)
       end
     end

--- a/spec/unit/resources/network_set/load_resource_with_properties_spec.rb
+++ b/spec/unit/resources/network_set/load_resource_with_properties_spec.rb
@@ -21,4 +21,16 @@ describe 'oneview_test::network_set_load_resource_with_properties' do
     allow_any_instance_of(OneviewSDK::NetworkSet).to receive(:create).and_return(true)
     expect(real_chef_run).to create_oneview_network_set('NetworkSet4')
   end
+
+  it 'prints a nice error message if the native_set cannot be found' do
+    expect(OneviewSDK::EthernetNetwork).to receive(:find_by).with(anything, name: 'FakeEthernetNetwork0').and_return([])
+    expect { real_chef_run }.to raise_error(RuntimeError, /Native network FakeEthernetNetwork0 not found/)
+  end
+
+  it 'prints a nice error message if a network cannot be found' do
+    fake_eth0 = OneviewSDK::EthernetNetwork.new(@client, name: 'FakeEthernetNetwork0', uri: 'rest/fake0')
+    expect(OneviewSDK::EthernetNetwork).to receive(:find_by).with(anything, name: 'FakeEthernetNetwork0').and_return([fake_eth0])
+    expect(OneviewSDK::EthernetNetwork).to receive(:find_by).with(anything, name: 'FakeEthernetNetwork1').and_return([])
+    expect { real_chef_run }.to raise_error(RuntimeError, /Network FakeEthernetNetwork1 not found/)
+  end
 end


### PR DESCRIPTION
### Description

Gives a helpful error message for network_set errors instead of the ambiguous `undefined method '[]' for nil:NilClass`.
### Issues Resolved

Fixes #73
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [ ] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
