### PR TITLE
Fixed test issues and added Travis build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Cookbook for HPE OneView
 
 [![Cookbook Version](https://img.shields.io/cookbook/v/oneview.svg)](https://supermarket.chef.io/cookbooks/oneview)
+[![Build Status](https://travis-ci.org/HewlettPackard/oneview-chef.svg?branch=master)](https://travis-ci.org/HewlettPackard/oneview-chef)
 
 Chef cookbook that provides resources for managing OneView.
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'simplecov'
 SimpleCov.start do
   add_filter 'spec/'
   add_filter 'matchers.rb'
+  add_filter '.direnv/'
   add_group 'Libraries', 'libraries'
   add_group 'Resources', 'resources'
   minimum_coverage 98

--- a/spec/unit/resources/managed_san/set_policy_spec.rb
+++ b/spec/unit/resources/managed_san/set_policy_spec.rb
@@ -6,7 +6,7 @@ describe 'oneview_test::managed_san_set_policy' do
 
   it 'fails whe it does not exist' do
     allow_any_instance_of(OneviewSDK::ManagedSAN).to receive(:exists?).and_return(false)
-    expect { real_chef_run }.to raise_error(/Resource not found: oneview_managed_san 'ManagedSAN1'/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /Resource not found: oneview_managed_san 'ManagedSAN1'/)
   end
 
   it 'sets the policy if it is no alike' do

--- a/spec/unit/resources/managed_san/set_public_attributes_spec.rb
+++ b/spec/unit/resources/managed_san/set_public_attributes_spec.rb
@@ -6,7 +6,7 @@ describe 'oneview_test::managed_san_set_public_attributes' do
 
   it 'fails whe it does not exist' do
     allow_any_instance_of(OneviewSDK::ManagedSAN).to receive(:exists?).and_return(false)
-    expect { real_chef_run }.to raise_error(/Resource not found: oneview_managed_san 'ManagedSAN1'/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /Resource not found: oneview_managed_san 'ManagedSAN1'/)
   end
 
   it 'sets public attributes if it is no alike' do

--- a/spec/unit/resources/managed_san/set_refresh_state_spec.rb
+++ b/spec/unit/resources/managed_san/set_refresh_state_spec.rb
@@ -6,7 +6,7 @@ describe 'oneview_test::managed_san_set_refresh_state' do
 
   it 'fails whe it does not exist' do
     allow_any_instance_of(OneviewSDK::ManagedSAN).to receive(:exists?).and_return(false)
-    expect { real_chef_run }.to raise_error(/Resource not found: oneview_managed_san 'ManagedSAN1'/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /Resource not found: oneview_managed_san 'ManagedSAN1'/)
   end
 
   it 'sets the policy if it is no alike' do

--- a/spec/unit/resources/volume/create_snapshot_spec.rb
+++ b/spec/unit/resources/volume/create_snapshot_spec.rb
@@ -6,7 +6,7 @@ describe 'oneview_test::volume_create_snapshot' do
 
   it 'raises error when resource does not exists' do
     expect_any_instance_of(OneviewSDK::Volume).to receive(:exists?).and_return(false)
-    expect { real_chef_run }.to raise_error(/Resource not found: oneview_volume 'Volume1'/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /Resource not found: oneview_volume 'Volume1'/)
   end
 
   it 'does nothing when a snapshot already exists with the same name' do
@@ -31,6 +31,6 @@ describe 'oneview_test::volume_create_snapshot_invalid' do
   include_context 'chef context'
 
   it 'needs snapshot_data attribute' do
-    expect { real_chef_run }.to raise_error(/Unspecified property: 'snapshot_data'. Please set it before attempting this action./)
+    expect { real_chef_run }.to raise_error(RuntimeError, /Unspecified property: 'snapshot_data'. Please set it/)
   end
 end

--- a/spec/unit/resources/volume/delete_snapshot_spec.rb
+++ b/spec/unit/resources/volume/delete_snapshot_spec.rb
@@ -6,7 +6,7 @@ describe 'oneview_test::volume_delete_snapshot' do
 
   it 'raises error when resource does not exists' do
     expect_any_instance_of(OneviewSDK::Volume).to receive(:exists?).and_return(false)
-    expect { real_chef_run }.to raise_error(/Resource not found: oneview_volume 'Volume1'/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /Resource not found: oneview_volume 'Volume1'/)
   end
 
   it 'does nothin when it does not exists' do


### PR DESCRIPTION
### Description
- Adds Travis master branch build badge
- Remove unwanted output from tests
- Make simplecov ignore the .direnv (related to #78)

While we're working on sorting out the Chef partner cookbook build badge, lets' at least get these fixes merged in.
### Issues Resolved

(none)
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [ ] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
