### PR TITLE
Added Ruby version to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,26 +1,10 @@
 source 'https://rubygems.org'
 
-case RUBY_VERSION
-when /^2\.0/
-  gem 'chef', '~> 12.0', '< 12.9'
-  gem 'berkshelf', '~> 4.3'
-  gem 'foodcritic', '~> 6.3'
-  gem 'fauxhai', '< 3.7.0'
-when /^2\.1/
-  gem 'chef', '~> 12.0', '< 12.14'
-  gem 'berkshelf', '~> 4.3'
-  gem 'foodcritic', '~> 7.1'
-  gem 'fauxhai', '< 3.10.0'
-when /^2\.2\.[01]/
-  gem 'chef', '~> 12.0', '< 12.14'
-  gem 'berkshelf'
-  gem 'foodcritic', '~> 7.1'
-  gem 'fauxhai', '< 3.10.0'
-else
-  gem 'chef', '~> 12.0'
-  gem 'berkshelf'
-  gem 'foodcritic'
-end
+ruby RUBY_VERSION # Needed to consider & solve for Ruby version requirements
+
+gem 'chef', '~> 12.0'
+gem 'berkshelf'
+gem 'foodcritic'
 gem 'chefspec'
 gem 'rubocop', '= 0.40.0'
 gem 'oneview-sdk'


### PR DESCRIPTION
### Description
Adds the current Ruby version to the Gemfile so that dependencies are solved, taking into consideration the current Ruby version. Don't know why this was so hard to find, but I finally ran across [bundler PR 4651](https://github.com/bundler/bundler/pull/4651) that described this workaround.

### Issues Resolved
Fixes #85

### Check List
N/A. Just an improvement for dev

