### PR TITLE
Changes for Synergy support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ pkg/
 .vagrant
 /cookbooks
 Berksfile.lock
+.berkshelf/
 
 # Bundler
 Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,14 @@
 source 'https://rubygems.org'
 
  # Needed to consider & solve for Ruby version requirements
-ruby '2.3.0'
+ruby RuBY_VERSION
 
 gem 'chef', '~> 12.0'
 gem 'berkshelf'
 gem 'foodcritic'
 gem 'chefspec'
 gem 'rubocop', '= 0.40.0'
-gem 'oneview-sdk', '= 3.0.0'
+gem 'oneview-sdk', '~> 3.0'
 gem 'pry'
 gem 'simplecov'
 gem 'stove'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
- # Needed to consider & solve for Ruby version requirements
+# Needed to consider & solve for Ruby version requirements
 ruby RUBY_VERSION
 
 gem 'chef', '~> 12.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,14 @@
 source 'https://rubygems.org'
 
-ruby RUBY_VERSION # Needed to consider & solve for Ruby version requirements
+ # Needed to consider & solve for Ruby version requirements
+ruby '2.3.0'
 
 gem 'chef', '~> 12.0'
 gem 'berkshelf'
 gem 'foodcritic'
 gem 'chefspec'
 gem 'rubocop', '= 0.40.0'
-gem 'oneview-sdk'
+gem 'oneview-sdk', '= 3.0.0'
 gem 'pry'
 gem 'simplecov'
 gem 'stove'

--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,8 @@ end
 desc 'Run cookbook lint tool'
 FoodCritic::Rake::LintTask.new(:foodcritic) do |t|
   t.options = {
-    fail_tags: ['any']
+    fail_tags: ['any'],
+    exclude_paths: ['libraries']
   }
 end
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@ default['oneview']['ruby_sdk_version'] = '= 3.0.0'
 # Only used for Ruby SDK 3.0 or greater
 # Default API version and hardware variant are ONLY USED if they are not defined in the Client
 default['oneview']['api_version'] = 300
-default['oneview']['hardware_variant'] = 'C7000'
+default['oneview']['hardware_variant'] = 'Synergy'
 
 # Save resource info to a node attribute? Possible values/types:
 #  - true  : Save all info (Merged hash of OneView info and Chef resource properties)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,7 +12,12 @@
 # Set which version of the SDK to install and use:
 # Warning: Changing the SDK version may cause issues within the Cookbook
 # Edit only if you know exactly what are you doing
-default['oneview']['ruby_sdk_version'] = '~> 2.1'
+default['oneview']['ruby_sdk_version'] = '= 3.0.0'
+
+# Only used for Ruby SDK 3.0 or greater
+# Default API version and hardware variant are ONLY USED if they are not defined in the Client
+default['oneview']['api_version'] = 300
+default['oneview']['hardware_variant'] = 'C7000'
 
 # Save resource info to a node attribute? Possible values/types:
 #  - true  : Save all info (Merged hash of OneView info and Chef resource properties)

--- a/libraries/oneview_helper.rb
+++ b/libraries/oneview_helper.rb
@@ -76,7 +76,7 @@ module OneviewCookbook
     # @return [Class] OneViewSDK resource class
     def get_resource_named(type)
       klass = Helper.oneview_api.resource_named(type)
-      raise "Invalid OneView Resource type '#{type}'" unless klass
+      raise "Invalid OneView Resource type '#{type}' in #{Helper.oneview_api}" unless klass
       klass
     end
 

--- a/libraries/oneview_helper.rb
+++ b/libraries/oneview_helper.rb
@@ -178,7 +178,7 @@ module OneviewCookbook
 
     # Module that adds auto casting for some ResourceBase methods
     module MissingResource
-      def method_missing(method, *args, &block)
+      def method_missing(method, *_args, &_block)
         # Gets resource name and removes the oneview slice
         res_part = resource_name.to_s
         res_part.slice!('oneview') # It is intended to the resource part start with `_`
@@ -188,11 +188,8 @@ module OneviewCookbook
         # Aliases for some methods
         maybe_method = 'create_or_update' if maybe_method == 'create'
         maybe_method = 'add_or_edit' if maybe_method == 'add'
-        if respond_to?(maybe_method)
-          public_send(maybe_method)
-        else
-          raise ArgumentError.new("Method `#{method}` doesn't exist.")
-        end
+        return public_send(maybe_method) if respond_to?(maybe_method)
+        raise ArgumentError, "Method `#{method}` does not exists."
       end
     end
   end

--- a/libraries/oneview_helper.rb
+++ b/libraries/oneview_helper.rb
@@ -52,7 +52,6 @@ module OneviewCookbook
         @oneview_api = @oneview_api.const_get(variant)
         @provider_api = @provider_api.const_get(variant)
       end
-      puts "\n\nRUBY API IS   #{@oneview_api}\nPROVIDER API IS   #{@provider_api}"
     end
 
     # Builds client and resource instance

--- a/libraries/resources/api200.rb
+++ b/libraries/resources/api200.rb
@@ -1,0 +1,8 @@
+module OneviewCookbook
+  # Module for Oneview API 200 Resources
+  module API200
+  end
+end
+
+# Load all API-specific resources:
+Dir[File.dirname(__FILE__) + '/api200/*.rb'].each { |file| require file }

--- a/libraries/resources/api200/ethernet_network_provider.rb
+++ b/libraries/resources/api200/ethernet_network_provider.rb
@@ -1,5 +1,6 @@
 module OneviewCookbook
   module API200
+    # Ethernet Network Provider resource methods
     module EthernetNetworkProvider
       include OneviewCookbook::Helper
       include OneviewCookbook::Helper::MissingResource

--- a/libraries/resources/api200/ethernet_network_provider.rb
+++ b/libraries/resources/api200/ethernet_network_provider.rb
@@ -1,0 +1,42 @@
+module OneviewCookbook
+  module API200
+    module EthernetNetworkProvider
+      include OneviewCookbook::Helper
+      include OneviewCookbook::Helper::MissingResource
+      include OneviewCookbook::ResourceBase
+
+      def update_connection_template(item, bandwidth)
+        bandwidth = convert_keys(bandwidth, :to_s)
+        connection_template = Helper.oneview_api::ConnectionTemplate.new(item.client, uri: item['connectionTemplateUri'])
+        connection_template.retrieve!
+        if connection_template.like? bandwidth
+          Chef::Log.info("#{resource_name} '#{name}' connection template is up to date")
+        else
+          converge_by "Update #{resource_name} '#{name}' connection template settings" do
+            connection_template.update(bandwidth)
+          end
+        end
+      end
+
+      def create_ethernet_network
+        item = load_resource
+        bandwidth = item.data.delete('bandwidth')
+        create_or_update(item)
+        update_connection_template(item, bandwidth: bandwidth) if bandwidth
+      end
+
+      def create_ethernet_network_if_missing
+        item = load_resource
+        bandwidth = item.data.delete('bandwidth')
+        created = create_if_missing(item)
+        update_connection_template(item, bandwidth: bandwidth) if bandwidth && created
+      end
+
+      def reset_ethernet_network_connection_template
+        item = load_resource
+        item.retrieve!
+        update_connection_template(item, bandwidth: Helper.oneview_api::ConnectionTemplate.get_default(item.client)['bandwidth'])
+      end
+    end
+  end
+end

--- a/libraries/resources/api300.rb
+++ b/libraries/resources/api300.rb
@@ -1,0 +1,8 @@
+module OneviewCookbook
+  # Module for Oneview API 300 Resources
+  module API300
+  end
+end
+
+# Load all API-specific resources:
+Dir[File.dirname(__FILE__) + '/api300/*.rb'].each { |file| require file }

--- a/libraries/resources/api300/c7000.rb
+++ b/libraries/resources/api300/c7000.rb
@@ -1,0 +1,21 @@
+# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API300
+    # Module for API300 C7000
+    module C7000
+    end
+  end
+end
+
+# Load all API-specific resources:
+Dir[File.dirname(__FILE__) + '/c7000/*.rb'].each { |file| require file }

--- a/libraries/resources/api300/c7000/ethernet_network_provider.rb
+++ b/libraries/resources/api300/c7000/ethernet_network_provider.rb
@@ -1,0 +1,9 @@
+module OneviewCookbook
+  module API300
+    module C7000
+      module EthernetNetworkProvider
+        include OneviewCookbook::API200::EthernetNetworkProvider
+      end
+    end
+  end
+end

--- a/libraries/resources/api300/c7000/ethernet_network_provider.rb
+++ b/libraries/resources/api300/c7000/ethernet_network_provider.rb
@@ -1,6 +1,7 @@
 module OneviewCookbook
   module API300
     module C7000
+      # Ethernet Network Provider resource methods
       module EthernetNetworkProvider
         include OneviewCookbook::API200::EthernetNetworkProvider
       end

--- a/libraries/resources/api300/synergy.rb
+++ b/libraries/resources/api300/synergy.rb
@@ -11,11 +11,11 @@
 
 module OneviewCookbook
   module API300
-    # Module for API300 Thunderbird
-    module Thunderbird
+    # Module for API300 Synergy
+    module Synergy
     end
   end
 end
 
 # Load all API-specific resources:
-Dir[File.dirname(__FILE__) + '/thunderbird/*.rb'].each { |file| require file }
+Dir[File.dirname(__FILE__) + '/synergy/*.rb'].each { |file| require file }

--- a/libraries/resources/api300/synergy/ethernet_network_provider.rb
+++ b/libraries/resources/api300/synergy/ethernet_network_provider.rb
@@ -1,6 +1,6 @@
 module OneviewCookbook
   module API300
-    module Thunderbird
+    module Synergy
       module EthernetNetworkProvider
         include OneviewCookbook::API200::EthernetNetworkProvider
       end

--- a/libraries/resources/api300/synergy/ethernet_network_provider.rb
+++ b/libraries/resources/api300/synergy/ethernet_network_provider.rb
@@ -1,6 +1,7 @@
 module OneviewCookbook
   module API300
     module Synergy
+      # Ethernet Network Provider resource methods
       module EthernetNetworkProvider
         include OneviewCookbook::API200::EthernetNetworkProvider
       end

--- a/libraries/resources/api300/thunderbird.rb
+++ b/libraries/resources/api300/thunderbird.rb
@@ -1,0 +1,21 @@
+# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API300
+    # Module for API300 Thunderbird
+    module Thunderbird
+    end
+  end
+end
+
+# Load all API-specific resources:
+Dir[File.dirname(__FILE__) + '/thunderbird/*.rb'].each { |file| require file }

--- a/libraries/resources/api300/thunderbird/ethernet_network_provider.rb
+++ b/libraries/resources/api300/thunderbird/ethernet_network_provider.rb
@@ -1,0 +1,9 @@
+module OneviewCookbook
+  module API300
+    module Thunderbird
+      module EthernetNetworkProvider
+        include OneviewCookbook::API200::EthernetNetworkProvider
+      end
+    end
+  end
+end

--- a/resources/ethernet_network.rb
+++ b/resources/ethernet_network.rb
@@ -16,7 +16,7 @@ OneviewCookbook::Helper.load_attributes(self)
 default_action :create
 
 action_class do
-  include OneviewCookbook::Helper::provider_api::EthernetNetworkProvider
+  include OneviewCookbook::Helper.provider_api::EthernetNetworkProvider
 end
 
 action :create do

--- a/resources/ethernet_network.rb
+++ b/resources/ethernet_network.rb
@@ -10,47 +10,27 @@
 # specific language governing permissions and limitations under the License.
 
 OneviewCookbook::ResourceBaseProperties.load(self)
+OneviewCookbook::Helper.load_sdk(self)
+OneviewCookbook::Helper.load_attributes(self)
 
 default_action :create
 
 action_class do
-  include OneviewCookbook::Helper
-  include OneviewCookbook::ResourceBase
-
-  def update_connection_template(item, bandwidth)
-    bandwidth = convert_keys(bandwidth, :to_s)
-    connection_template = OneviewSDK::ConnectionTemplate.new(item.client, uri: item['connectionTemplateUri'])
-    connection_template.retrieve!
-    if connection_template.like? bandwidth
-      Chef::Log.info("#{resource_name} '#{name}' connection template is up to date")
-    else
-      converge_by "Update #{resource_name} '#{name}' connection template settings" do
-        connection_template.update(bandwidth)
-      end
-    end
-  end
+  include OneviewCookbook::Helper::provider_api::EthernetNetworkProvider
 end
 
 action :create do
-  item = load_resource
-  bandwidth = item.data.delete('bandwidth')
-  create_or_update(item)
-  update_connection_template(item, bandwidth: bandwidth) if bandwidth
+  create_ethernet_network
 end
 
 action :create_if_missing do
-  item = load_resource
-  bandwidth = item.data.delete('bandwidth')
-  created = create_if_missing(item)
-  update_connection_template(item, bandwidth: bandwidth) if bandwidth && created
+  create_ethernet_network_if_missing
 end
 
 action :reset_connection_template do
-  item = load_resource
-  item.retrieve!
-  update_connection_template(item, bandwidth: OneviewSDK::ConnectionTemplate.get_default(item.client)['bandwidth'])
+  reset_ethernet_network_connection_template
 end
 
 action :delete do
-  delete
+  delete_ethernet_network
 end

--- a/resources/firmware.rb
+++ b/resources/firmware.rb
@@ -11,6 +11,9 @@
 
 OneviewCookbook::ResourceBaseProperties.load(self)
 
+OneviewCookbook::Helper.load_sdk(self)
+OneviewCookbook::Helper.load_attributes(self)
+
 property :spp_name, String
 property :spp_file, String
 property :hotfixes_names, Array
@@ -23,7 +26,6 @@ action_class do
   include OneviewCookbook::ResourceBase
 
   def load_firmware(filename = nil)
-    load_sdk
     c = build_client(client)
     item = OneviewSDK::FirmwareDriver.new(c, name: name)
     if item.exists?
@@ -54,7 +56,6 @@ action :create_custom_spp do
   unless hotfixes_names || hotfixes_files
     raise "Unspecified property: 'hotfixes_names' or 'hotfixes_files'. Please set it before attempting this action."
   end
-  load_sdk
   c = build_client(client)
   item = OneviewSDK::FirmwareDriver.new(c, name: name)
   if item.exists?

--- a/resources/power_device.rb
+++ b/resources/power_device.rb
@@ -10,6 +10,8 @@
 # specific language governing permissions and limitations under the License.
 
 OneviewCookbook::ResourceBaseProperties.load(self)
+OneviewCookbook::Helper.load_sdk(self)
+OneviewCookbook::Helper.load_attributes(self)
 
 property :username, String
 property :password, String
@@ -30,7 +32,6 @@ action :add_if_missing do
 end
 
 action :discover do
-  load_sdk
   c = build_client(client)
   power_devices_list = OneviewSDK::PowerDevice.get_ipdu_devices(c, name)
   if power_devices_list.empty?

--- a/spec/fixtures/cookbooks/oneview_test/attributes/default.rb
+++ b/spec/fixtures/cookbooks/oneview_test/attributes/default.rb
@@ -13,5 +13,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 #
-default['oneview']['ruby_sdk_version'] = '~> 2.0'
+default['oneview']['ruby_sdk_version'] = '~> 3.0'
+default['oneview']['api_version'] = 300
+default['oneview']['hardware_variant'] = 'C7000'
 default['oneview_test']['client'] = { url: 'https://oneview.example.com', user: 'Administrator', password: 'secret123' }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,9 +23,14 @@ RSpec.configure do |config|
   config.platform = 'redhat'
   config.version = '7.2'
 
+  config.color = true
+  config.tty = true
+  config.failure_color = :magenta
+  config.fixed_color = :yellow
+
   config.before(:each) do
     # Mock appliance version and login api requests, as well as loading trusted certs
-    allow_any_instance_of(OneviewSDK::Client).to receive(:appliance_api_version).and_return(200)
+    allow_any_instance_of(OneviewSDK::Client).to receive(:appliance_api_version).and_return(300)
     allow_any_instance_of(OneviewSDK::Client).to receive(:login).and_return('secretToken')
     allow(OneviewSDK::SSLHelper).to receive(:load_trusted_certs).and_return(nil)
 

--- a/spec/unit/libraries/oneview_helper_spec.rb
+++ b/spec/unit/libraries/oneview_helper_spec.rb
@@ -14,29 +14,30 @@ RSpec.describe OneviewCookbook::Helper do
 
   describe '#load_sdk' do
     before :each do
-      allow(helper).to receive(:node).and_return('oneview' => { 'ruby_sdk_version' => sdk_version })
+      @context = {}
+      allow(@context).to receive(:node).and_return('oneview' => { 'ruby_sdk_version' => sdk_version })
     end
 
     it 'loads the specified version of the gem' do
-      expect(helper).to receive(:gem).with('oneview-sdk', sdk_version)
-      helper.load_sdk
+      expect(OneviewCookbook::Helper).to receive(:gem).with('oneview-sdk', sdk_version)
+      OneviewCookbook::Helper.load_sdk(@context)
     end
 
     it 'attempts to install the gem if it is not found' do
-      expect(helper).to receive(:gem).once.and_raise LoadError
-      expect(helper).to receive(:gem).once.and_return true
-      expect(helper).to receive(:chef_gem).with('oneview-sdk').and_return true
-      expect(helper).to receive(:require).with('oneview-sdk').and_return true
-      helper.load_sdk
+      expect(OneviewCookbook::Helper).to receive(:gem).once.and_raise LoadError
+      expect(OneviewCookbook::Helper).to receive(:gem).once.and_return true
+      expect(OneviewCookbook::Helper).to receive(:chef_gem).with('oneview-sdk').and_return true
+      expect(OneviewCookbook::Helper).to receive(:require).with('oneview-sdk').and_return true
+      OneviewCookbook::Helper.load_sdk(@context)
     end
 
     it 'prints an error message if the gem cannot be loaded either time' do
-      expect(helper).to receive(:gem).twice.and_raise LoadError, 'Blah'
+      expect(OneviewCookbook::Helper).to receive(:gem).twice.and_raise LoadError, 'Blah'
       expect(Chef::Log).to receive(:error).with(/cannot be loaded. Message: Blah/)
       expect(Chef::Log).to receive(:error).with(/Loaded version .* instead/)
-      expect(helper).to receive(:chef_gem).with('oneview-sdk').and_return true
-      expect(helper).to receive(:require).with('oneview-sdk').and_return true
-      helper.load_sdk
+      expect(OneviewCookbook::Helper).to receive(:chef_gem).with('oneview-sdk').and_return true
+      expect(OneviewCookbook::Helper).to receive(:require).with('oneview-sdk').and_return true
+      OneviewCookbook::Helper.load_sdk(@context)
     end
   end
 
@@ -46,9 +47,11 @@ RSpec.describe OneviewCookbook::Helper do
       allow(helper).to receive(:resource_name).and_return 'oneview_ethernet_network'
       allow(helper).to receive(:data).and_return(name: 'net')
       allow(helper).to receive(:load_sdk).and_return true
+      allow(OneviewCookbook::Helper).to receive(:oneview_api).and_return OneviewSDK::API200
     end
 
-    it 'loads the sdk' do
+    # It won't load the sdk in this version
+    xit 'loads the sdk' do
       expect(helper).to receive(:load_sdk).and_raise 'Called load_sdk'
       expect { helper.load_resource }.to raise_error 'Called load_sdk'
     end
@@ -79,6 +82,10 @@ RSpec.describe OneviewCookbook::Helper do
   end
 
   describe '#get_resource_named' do
+    before(:each) do
+      allow(OneviewCookbook::Helper).to receive(:oneview_api).and_return OneviewSDK::API200
+    end
+
     it 'returns a class from a valid snake_case name' do
       r = helper.get_resource_named('server_profile')
       expect(r).to be OneviewSDK::ServerProfile

--- a/spec/unit/resources/logical_enclosure/reconfigure_spec.rb
+++ b/spec/unit/resources/logical_enclosure/reconfigure_spec.rb
@@ -28,9 +28,9 @@ describe 'oneview_test::logical_enclosure_reconfigure' do
     allow_any_instance_of(OneviewSDK::LogicalEnclosure).to receive(:[]).with('enclosureUris')
       .and_return(['/rest/enclosures/encl1', '/rest/enclosures/encl2'])
     allow_any_instance_of(OneviewSDK::LogicalEnclosure).to receive(:[]).with('name').and_call_original
-    allow(OneviewSDK::Enclosure).to receive(:find_by).with(instance_of(OneviewSDK::Client), uri: '/rest/enclosures/encl1')
+    allow(OneviewSDK::Enclosure).to receive(:find_by).with(instance_of(OneviewSDK::Client), 'uri' => '/rest/enclosures/encl1')
       .and_return([encl1])
-    allow(OneviewSDK::Enclosure).to receive(:find_by).with(instance_of(OneviewSDK::Client), uri: '/rest/enclosures/encl2')
+    allow(OneviewSDK::Enclosure).to receive(:find_by).with(instance_of(OneviewSDK::Client), 'uri' => '/rest/enclosures/encl2')
       .and_return([encl2])
   end
 

--- a/spec/unit/resources/volume/create_if_missing_spec.rb
+++ b/spec/unit/resources/volume/create_if_missing_spec.rb
@@ -12,7 +12,7 @@ describe 'oneview_test::volume_create_if_missing' do
       ]
     )
     allow_any_instance_of(OneviewSDK::StorageSystem).to receive(:exists?).and_return(false)
-    allow(OneviewSDK::StorageSystem).to receive(:find_by).with(kind_of(OneviewSDK::Client), name: 'StorageSystem1')
+    allow(OneviewSDK::StorageSystem).to receive(:find_by).with(kind_of(OneviewSDK::Client), 'name' => 'StorageSystem1')
       .and_return([OneviewSDK::StorageSystem.new(client, name: 'StorageSystem1', uri: '/rest/storage-systems/1')])
   end
 

--- a/spec/unit/resources/volume/create_spec.rb
+++ b/spec/unit/resources/volume/create_spec.rb
@@ -12,7 +12,7 @@ describe 'oneview_test::volume_create' do
       ]
     )
     allow_any_instance_of(OneviewSDK::StorageSystem).to receive(:exists?).and_return(false)
-    allow(OneviewSDK::StorageSystem).to receive(:find_by).with(kind_of(OneviewSDK::Client), name: 'StorageSystem1')
+    allow(OneviewSDK::StorageSystem).to receive(:find_by).with(kind_of(OneviewSDK::Client), 'name' => 'StorageSystem1')
       .and_return([OneviewSDK::StorageSystem.new(client, name: 'StorageSystem1', uri: '/rest/storage-systems/1')])
     allow_any_instance_of(OneviewSDK::Volume).to receive(:exists?).and_return(false)
   end


### PR DESCRIPTION
### Description
Adds architectural support to Synergy and API300 resources

:warning: There is 1 expected failure: (See oneview-sdk-ruby's [#124 Missing argument in API300 C7000 Managed SAN method](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/124) for more information).

Regarding *dynamic version load*:
It won't load SDK version and variants at converge time by now. It would be better to open an issue/another PR until we have any good idea on how to kick it in, since it won't be a big deal to refactor and the implementation may be delayed if we stop the development to think about it right now.

### Main changes ###
- Added berkshelf exception to ignore
- Excluded libraries folder from foodcritic
- Addded load_attributes method
- Converted load_sdk to static method
- Added structure in libraries to receive providers
- Implemented EthernetNetwork resource as example
- Edited specs and resources to accept the new standard