### PR TITLE
Fabrics resource API300 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - fc_network support for API300
   - fcoe_network support for API300
   - network_set support for API300
+  - fabric new resource support for API300 Synergy
 
 ### 1.1.0
   - Add support for client ENV variables

--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ oneview_ethernet_network 'Eth1' do
 end
 ```
 
+### oneview_fabric
+
+Fabric resource for HPE OneView.
+
+Support only in API300 onwards with variant Synergy.
+
+Action defaults to `:none`, also performs updates on the reserved vlan range.
+
+```Ruby
+oneview_fabric 'Fabric1' do
+  client <my_client>
+  data <resource_data>
+  reserved_vlan_range <vlan_options> # Hash: Usually the 'start' and 'length' of the range
+  action [:none, :set_reserved_vlan_range]
+end
+```
+
 ### oneview_fc_network
 
 FC network resource for HPE OneView.
@@ -106,7 +123,7 @@ end
 ```
 
 
-### oneview_fc_network
+### oneview_fcoe_network
 
 FCoE network resource for HPE OneView.
 

--- a/README.md
+++ b/README.md
@@ -99,14 +99,14 @@ Fabric resource for HPE OneView.
 
 Support only in API300 onwards with variant Synergy.
 
-Action defaults to `:none`, also performs updates on the reserved vlan range.
+Performs updates on the reserved vlan range.
 
 ```Ruby
 oneview_fabric 'Fabric1' do
   client <my_client>
   data <resource_data>
   reserved_vlan_range <vlan_options> # Hash: Usually the 'start' and 'length' of the range
-  action [:none, :set_reserved_vlan_range]
+  action [:set_reserved_vlan_range]
 end
 ```
 

--- a/examples/fabric.rb
+++ b/examples/fabric.rb
@@ -15,17 +15,13 @@ my_client = {
   password: ENV['ONEVIEWSDK_PASSWORD']
 }
 
-# Does nothing (default :none)
-oneview_fabric 'DefaultFabric' do
-  client my_client
-end
-
 # Updates the DefaultFabric fabric reserved vlan range if the values do not match
 oneview_fabric 'DefaultFabric' do
   client my_client
+  api_version 300
+  api_variant 'Synergy'
   reserved_vlan_range(
     'start' => 3000,
     'length' => 120
   )
-  action :set_reserved_vlan_range
 end

--- a/examples/fabric.rb
+++ b/examples/fabric.rb
@@ -16,6 +16,7 @@ my_client = {
 }
 
 # Updates the DefaultFabric fabric reserved vlan range if the values do not match
+# Only available for API300 with Synergy
 oneview_fabric 'DefaultFabric' do
   client my_client
   api_version 300

--- a/examples/fabric.rb
+++ b/examples/fabric.rb
@@ -1,0 +1,31 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+my_client = {
+  url: ENV['ONEVIEWSDK_URL'],
+  user: ENV['ONEVIEWSDK_USER'],
+  password: ENV['ONEVIEWSDK_PASSWORD']
+}
+
+# Does nothing (default :none)
+oneview_fabric 'DefaultFabric' do
+  client my_client
+end
+
+# Updates the DefaultFabric fabric reserved vlan range if the values do not match
+oneview_fabric 'DefaultFabric' do
+  client my_client
+  reserved_vlan_range(
+    'start' => 3000,
+    'length' => 120
+  )
+  action :set_reserved_vlan_range
+end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -23,6 +23,7 @@ if defined?(ChefSpec)
     oneview_enclosure:                  [:add, :remove, :refresh, :reconfigure],
     oneview_enclosure_group:            standard_actions + [:set_script],
     oneview_ethernet_network:           standard_actions + [:reset_connection_template],
+    oneview_fabric:                     [:none, :set_reserved_vlan_range],
     oneview_fc_network:                 standard_actions,
     oneview_fcoe_network:               standard_actions,
     oneview_firmware:                   [:add, :remove, :create_custom_spp],

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -23,7 +23,7 @@ if defined?(ChefSpec)
     oneview_enclosure:                  [:add, :remove, :refresh, :reconfigure],
     oneview_enclosure_group:            standard_actions + [:set_script],
     oneview_ethernet_network:           standard_actions + [:reset_connection_template],
-    oneview_fabric:                     [:none, :set_reserved_vlan_range],
+    oneview_fabric:                     [:set_reserved_vlan_range],
     oneview_fc_network:                 standard_actions,
     oneview_fcoe_network:               standard_actions,
     oneview_firmware:                   [:add, :remove, :create_custom_spp],

--- a/libraries/resource_providers/api300/synergy/fabric_provider.rb
+++ b/libraries/resource_providers/api300/synergy/fabric_provider.rb
@@ -1,0 +1,39 @@
+# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../../resource_provider'
+
+module OneviewCookbook
+  module API300
+    module Synergy
+      # Fabric API300 Synergy provider
+      class FabricProvider < ResourceProvider
+        def set_reserved_vlan_range
+          @item.retrieve!
+          options = { 'reservedVlanRange' => convert_keys(@context.reserved_vlan_range, :to_s) }
+          options['reservedVlanRange']['type'] ||= 'vlan-pool'
+          if @item.like? options
+            Chef::Log.info("#{resource_name} '#{name}' reserved Vlan range is up to date")
+          else
+            Chef::Log.info "Set #{resource_name} '#{name}' reserved Vlan range"
+            Chef::Log.debug "#{resource_name} '#{name}' Chef resource differs from OneView resource."
+            Chef::Log.debug "Current state: #{JSON.pretty_generate(@item['reservedVlanRange'])}"
+            Chef::Log.debug "Desired state: #{JSON.pretty_generate(options['reservedVlanRange'])}"
+            diff = get_diff(@item, options)
+            @context.converge_by "Set reserved Vlan range for #{resource_name} '#{name}'#{diff}" do
+              @item.set_reserved_vlan_range(options['reservedVlanRange'])
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/resources/fabric.rb
+++ b/resources/fabric.rb
@@ -1,0 +1,24 @@
+# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+OneviewCookbook::ResourceBaseProperties.load(self)
+
+# Vlan range containing the 'start' and the 'length' of the range
+property :reserved_vlan_range, Hash
+
+default_action :none
+
+action :none do
+end
+
+action :set_reserved_vlan_range do
+  OneviewCookbook::Helper.do_resource_action(self, :Fabric, :set_reserved_vlan_range)
+end

--- a/resources/fabric.rb
+++ b/resources/fabric.rb
@@ -14,10 +14,7 @@ OneviewCookbook::ResourceBaseProperties.load(self)
 # Vlan range containing the 'start' and the 'length' of the range
 property :reserved_vlan_range, Hash
 
-default_action :none
-
-action :none do
-end
+default_action :set_reserved_vlan_range
 
 action :set_reserved_vlan_range do
   OneviewCookbook::Helper.do_resource_action(self, :Fabric, :set_reserved_vlan_range)

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/fabric_set_reserved_vlan_range.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/fabric_set_reserved_vlan_range.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: ethernet_network_create
+#
+# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_fabric 'Fabric1' do
+  client node['oneview_test']['client']
+  reserved_vlan_range(
+    'start' => 1200,
+    'length' => 120
+  )
+  action :set_reserved_vlan_range
+end

--- a/spec/unit/resources/fabric/fabric_set_reserved_vlan_range_spec.rb
+++ b/spec/unit/resources/fabric/fabric_set_reserved_vlan_range_spec.rb
@@ -1,0 +1,22 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::fabric_set_reserved_vlan_range' do
+  let(:resource_name) { 'fabric' }
+  include_context 'chef context'
+
+  let(:range) do
+    {
+      'start' => 1200,
+      'length' => 120,
+      'type' => 'vlan-pool'
+    }
+  end
+
+  it 'updates it when it does not matches' do
+    expect_any_instance_of(OneviewSDK::API300::Synergy::Fabric).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(OneviewSDK::API300::Synergy::Fabric).to receive(:like?).and_return(false)
+    expect_any_instance_of(OneviewSDK::API300::Synergy::Fabric).to receive(:set_reserved_vlan_range)
+      .with(range).and_return(range)
+    expect(real_chef_run).to set_oneview_fabric_reserved_vlan_range('Fabric1')
+  end
+end

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -42,7 +42,6 @@ describe 'oneview_test::default' do
 
     # oneview_fabric
     expect(chef_run).to_not set_oneview_fabric_reserved_vlan_range('')
-    expect(chef_run).to_not none_oneview_fabric('')
 
     # oneview_fc_network
     expect(chef_run).to_not create_oneview_fc_network('')

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -40,6 +40,10 @@ describe 'oneview_test::default' do
     expect(chef_run).to_not reset_oneview_ethernet_network_connection_template('')
     expect(chef_run).to_not delete_oneview_ethernet_network('')
 
+    # oneview_fabric
+    expect(chef_run).to_not set_oneview_fabric_reserved_vlan_range('')
+    expect(chef_run).to_not none_oneview_fabric('')
+
     # oneview_fc_network
     expect(chef_run).to_not create_oneview_fc_network('')
     expect(chef_run).to_not create_oneview_fc_network_if_missing('')


### PR DESCRIPTION
### Description
Adds new resource, tests and support to Fabrics.

Compatible only with API300::Synergy.

### Issues Resolved
#103 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
