### PR TITLE
Proxy method for OneviewSDK::resource_named

### DIFF
--- a/libraries/resource_provider.rb
+++ b/libraries/resource_provider.rb
@@ -133,7 +133,7 @@ module OneviewCookbook
     # Gathers the OneviewSDK correct resource class
     # @param [Symbol | String] resource Resource name/type desired
     # @param [Integer] version Version of the SDK desired
-    # @param [Integer] variant Variant of the SDK desired
+    # @param [String] variant Variant of the SDK desired
     # @return [OneviewSDK::Resource] Returns the class of the resource in the loaded API version and variant
     def resource_named(resource, version = @sdk_api_version, variant = @sdk_variant)
       OneviewSDK.resource_named(resource, version, variant)

--- a/libraries/resource_provider.rb
+++ b/libraries/resource_provider.rb
@@ -125,10 +125,18 @@ module OneviewCookbook
     end
 
     # Remove the OneView resource if it exists
-    # @param [Symbol] method Remove method
     # @return [TrueClass, FalseClass] Returns true if the resource was removed
     def remove
       delete(:remove)
+    end
+
+    # Gathers the OneviewSDK correct resource class
+    # @param [Symbol | String] resource Resource name/type desired
+    # @param [Integer] version Version of the SDK desired
+    # @param [Integer] variant Variant of the SDK desired
+    # @return [OneviewSDK::Resource] Returns the class of the resource in the loaded API version and variant
+    def resource_named(resource, version = @sdk_api_version, variant = @sdk_api_variant)
+      OneviewSDK.resource_named(resource, version, variant)
     end
 
     # Save the data from a resource to a node attribute

--- a/libraries/resource_provider.rb
+++ b/libraries/resource_provider.rb
@@ -135,7 +135,7 @@ module OneviewCookbook
     # @param [Integer] version Version of the SDK desired
     # @param [Integer] variant Variant of the SDK desired
     # @return [OneviewSDK::Resource] Returns the class of the resource in the loaded API version and variant
-    def resource_named(resource, version = @sdk_api_version, variant = @sdk_api_variant)
+    def resource_named(resource, version = @sdk_api_version, variant = @sdk_variant)
       OneviewSDK.resource_named(resource, version, variant)
     end
 

--- a/libraries/resource_providers/api200/enclosure_group_provider.rb
+++ b/libraries/resource_providers/api200/enclosure_group_provider.rb
@@ -17,7 +17,7 @@ module OneviewCookbook
     class EnclosureGroupProvider < ResourceProvider
       def load_lig
         return unless @context.logical_interconnect_group
-        lig_klass = OneviewSDK.resource_named(:LogicalInterconnectGroup, @sdk_api_version, @sdk_api_variant)
+        lig_klass = resource_named(:LogicalInterconnectGroup)
         @item.add_logical_interconnect_group(lig_klass.new(@item.client, name: @context.logical_interconnect_group))
       end
 

--- a/libraries/resource_providers/api200/ethernet_network_provider.rb
+++ b/libraries/resource_providers/api200/ethernet_network_provider.rb
@@ -29,7 +29,7 @@ module OneviewCookbook
 
       def update_connection_template(bandwidth)
         bandwidth = convert_keys(bandwidth, :to_s)
-        klass = OneviewSDK.resource_named(:ConnectionTemplate, @sdk_api_version, @sdk_variant)
+        klass = resource_named(:ConnectionTemplate)
         connection_template = klass.new(@item.client, uri: @item['connectionTemplateUri'])
         connection_template.retrieve!
         if connection_template.like? bandwidth
@@ -44,7 +44,7 @@ module OneviewCookbook
 
       def reset_connection_template
         @item.retrieve!
-        klass = OneviewSDK.resource_named(:ConnectionTemplate, @sdk_api_version, @sdk_variant)
+        klass = resource_named(:ConnectionTemplate)
         update_connection_template(bandwidth: klass.get_default(@item.client)['bandwidth'])
       end
     end

--- a/libraries/resource_providers/api200/firmware_driver_provider.rb
+++ b/libraries/resource_providers/api200/firmware_driver_provider.rb
@@ -19,7 +19,7 @@ module OneviewCookbook
         return @item if @item.retrieve!
         filename ||= @name
         filename = ::File.basename(filename, ::File.extname(filename)).tr('.', '_')
-        firmware_list = OneviewSDK.resource_named(:FirmwareDriver, @sdk_api_version, @sdk_api_variant).find_by(@item.client, {})
+        firmware_list = resource_named(:FirmwareDriver).find_by(@item.client, {})
         firmware_list.find { |fw| filename == fw['resourceId'] }
       end
 
@@ -57,7 +57,7 @@ module OneviewCookbook
       # Verifies and loads the SPP
       def load_spp
         spp = nil
-        fd_klass = OneviewSDK.resource_named(:FirmwareDriver, @sdk_api_version, @sdk_api_variant)
+        fd_klass = resource_named(:FirmwareDriver)
         if @context.spp_name
           spp = fd_klass.new(@item.client, name: @context.spp_name)
           spp.retrieve!
@@ -70,7 +70,7 @@ module OneviewCookbook
       # Verifies and loads Hotfixes
       def load_hotfixes
         @item['hotfixUris'] = []
-        fd_klass = OneviewSDK.resource_named(:FirmwareDriver, @sdk_api_version, @sdk_api_variant)
+        fd_klass = resource_named(:FirmwareDriver)
         if @context.hotfixes_names
           @context.hotfixes_names.each do |hotfix|
             temp = fd_klass.new(@item.client, name: hotfix)

--- a/libraries/resource_providers/api200/logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api200/logical_interconnect_provider.rb
@@ -18,8 +18,8 @@ module OneviewCookbook
       def interconnect_handler(present_block, absent_block)
         raise "Unspecified property: 'bay_number'. Please set it before attempting this action." unless @context.bay_number
         raise "Unspecified property: 'enclosure'. Please set it before attempting this action." unless @context.enclosure
-        interconnect_list = OneviewSDK.resource_named(:Interconnect, @sdk_api_version, @sdk_variant).find_by(@item.client, {})
-        enclosure_item = OneviewSDK.resource_named(:Enclosure, @sdk_api_version, @sdk_variant).find_by(@item.client, name: @context.enclosure).first
+        interconnect_list = resource_named(:Interconnect).find_by(@item.client, {})
+        enclosure_item = resource_named(:Enclosure).find_by(@item.client, name: @context.enclosure).first
         # Procedure to get (bay, enclosure) pairs and interconnect state
         listed_pairs = {}
         interconnect_list.each do |inter|
@@ -77,7 +77,7 @@ module OneviewCookbook
         fw_defined = @context.firmware || @context.firmware_data['sppName']
         raise "Unspecified property: 'firmware'. Please set it before attempting this action." unless fw_defined
         return Chef::Log.info("Firmware #{@context.firmware} from logical interconnect '#{@name}' is up to date") if dif_values.empty?
-        fd = OneviewSDK.resource_named(:FirmwareDriver, @sdk_api_version, @sdk_variant).find_by(@item.client, name: @context.firmware).first
+        fd = resource_named(:FirmwareDriver).find_by(@item.client, name: @context.firmware).first
         raise "Resource not found: Firmware action '#{action}' cannot be performed since the firmware '#{@context.firmware}' was not found." unless fd
         diff = get_diff(current_firmware, @context.firmware_data)
         Chef::Log.info "#{action.to_s.capitalize.tr('_', ' ')} #{@resource_name} '#{@name}'"
@@ -116,7 +116,7 @@ module OneviewCookbook
       def update_internal_networks
         @item.retrieve!
         @context.internal_networks.collect! do |n|
-          OneviewSDK.resource_named(:EthernetNetwork, @sdk_api_version, @sdk_variant).find_by(@item.client, name: n).first
+          resource_named(:EthernetNetwork).find_by(@item.client, name: n).first
         end
         if @item['internalNetworkUris'].sort == @context.internal_networks.collect { |x| x['uri'] }.sort
           Chef::Log.info("Internal networks for #{@resource_name} #{@name} are up to date")

--- a/libraries/resource_providers/api200/network_set_provider.rb
+++ b/libraries/resource_providers/api200/network_set_provider.rb
@@ -16,7 +16,7 @@ module OneviewCookbook
     # NetworkSet API200 provider
     class NetworkSetProvider < ResourceProvider
       def load_resource_with_properties
-        eth_class = OneviewSDK.resource_named(:EthernetNetwork, @sdk_api_version, @sdk_variant)
+        eth_class = resource_named(:EthernetNetwork)
         if @context.native_network
           native_net = eth_class.find_by(@item.client, name: @context.native_network).first
           raise "Native network #{@context.native_network} not found!" unless native_net

--- a/libraries/resource_providers/api200/power_device_provider.rb
+++ b/libraries/resource_providers/api200/power_device_provider.rb
@@ -16,7 +16,7 @@ module OneviewCookbook
     # PowerDevice API200 provider
     class PowerDeviceProvider < ResourceProvider
       def discover
-        pd_klass = OneviewSDK.resource_named(:PowerDevice, @sdk_api_version, @sdk_variant)
+        pd_klass = resource_named(:PowerDevice)
         power_devices_list = pd_klass.get_ipdu_devices(@item.client, @name)
         if power_devices_list.empty?
           Chef::Log.info "Discovering #{@resource_name} '#{@name}'"
@@ -31,7 +31,7 @@ module OneviewCookbook
       def remove
         # First try to remove by name, if it does not work it consider the power device is an iPDU
         return true if super
-        power_devices_list = OneviewSDK.resource_named(:PowerDevice, @sdk_api_version, @sdk_variant).get_ipdu_devices(@item.client, @name)
+        power_devices_list = resource_named(:PowerDevice).get_ipdu_devices(@item.client, @name)
         return false if power_devices_list.empty?
         @item = power_devices_list.first
         super

--- a/libraries/resource_providers/api200/storage_pool_provider.rb
+++ b/libraries/resource_providers/api200/storage_pool_provider.rb
@@ -18,7 +18,7 @@ module OneviewCookbook
       def add_if_missing
         raise "Unspecified property: 'storage_system'. Please set it before attempting this action." unless @context.storage_system
         @item['poolName'] ||= @name
-        sto_sys_klass = OneviewSDK.resource_named(:StorageSystem, @sdk_api_version, @sdk_api_variant)
+        sto_sys_klass = resource_named(:StorageSystem)
         storage_system_resource = sto_sys_klass.new(@item.client, credentials: { ip_hostname: @context.storage_system })
         storage_system_resource = sto_sys_klass.new(@item.client, name: @context.storage_system) unless storage_system_resource.exists?
         storage_system_resource.retrieve!

--- a/spec/unit/libraries/resource_provider_spec.rb
+++ b/spec/unit/libraries/resource_provider_spec.rb
@@ -165,8 +165,6 @@ RSpec.describe OneviewCookbook::ResourceProvider do
     end
   end
 
-  # Private methods:
-
   describe '#save_res_info' do
     before :each do
       res.item.data['uri'] = '/rest/fake'

--- a/spec/unit/libraries/resource_provider_spec.rb
+++ b/spec/unit/libraries/resource_provider_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe OneviewCookbook::ResourceProvider do
   end
 
   describe '#add_if_missing' do
-    it 'calls the create_or_update method with parameters' do
+    it 'calls the create_if_missing method with parameters' do
       expect(res).to receive(:create_if_missing).with(:add)
       res.add_if_missing
     end
@@ -162,6 +162,30 @@ RSpec.describe OneviewCookbook::ResourceProvider do
       expect(res.item).to receive(:retrieve!).and_return(true)
       expect(res.item).to receive(:delete).and_return(true)
       expect(res.delete).to eq(true) # And returns true
+    end
+  end
+
+  describe '#remove' do
+    it 'calls the delete method with parameters' do
+      expect(res).to receive(:delete).with(:remove)
+      res.remove
+    end
+  end
+
+  describe '#resource_named' do
+    before :each do
+      res.sdk_api_version = -1
+      res.sdk_variant = '_test_'
+    end
+
+    it 'calls the OneviewSDK::resource_named method with the default parameters' do
+      expect(OneviewSDK).to receive(:resource_named).with(:ResourceType, -1, '_test_')
+      res.resource_named(:ResourceType)
+    end
+
+    it 'calls the OneviewSDK::resource_named method with overriden parameters' do
+      expect(OneviewSDK).to receive(:resource_named).with(:ResourceType, -5, '_override_test_')
+      res.resource_named(:ResourceType, -5, '_override_test_')
     end
   end
 


### PR DESCRIPTION
### Description
 - Created a proxy method for OneviewSDK::resource_named, OneviewCookbook#resource_named.
 - Added and fixed unit tests
 - Refactored resources to use the new and more concise method 

### Issues Resolved
#138 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [ ] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
