### PR TITLE
API300 Logical Switch Group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - firmware support for API300
   - storage_system support for API300
   - storage_pool support for API300
+  - logical_switch_group support for API300
 
 ### 1.1.0
   - Add support for client ENV variables

--- a/libraries/resource_providers/api200/logical_switch_group_provider.rb
+++ b/libraries/resource_providers/api200/logical_switch_group_provider.rb
@@ -1,0 +1,37 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../resource_provider'
+
+module OneviewCookbook
+  module API200
+    # LogicalSwitchGroup API200 provider
+    class LogicalSwitchGroupProvider < ResourceProvider
+      def load_logical_switch_group
+        # This will avoid overriding the 'switchMapTemplate' if already specified in data
+        return unless @item['switchMapTemplate'].empty?
+        raise "Unspecified property: 'switch_number'. Please set it before attempting this action." unless @context.switch_number
+        raise "Unspecified property: 'switch_type'. Please set it before attempting this action." unless @context.switch_type
+        @item.set_grouping_parameters(@context.switch_number, @context.switch_type)
+      end
+
+      def create_or_update
+        load_logical_switch_group
+        super
+      end
+
+      def create_if_missing
+        load_logical_switch_group
+        super
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api300/c7000/logical_switch_group_provider.rb
+++ b/libraries/resource_providers/api300/c7000/logical_switch_group_provider.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../api200/logical_switch_group_provider'
+
+module OneviewCookbook
+  module API300
+    module C7000
+      # LogicalSwitchGroup API300 C7000 provider
+      class LogicalSwitchGroupProvider < API200::LogicalSwitchGroupProvider
+      end
+    end
+  end
+end

--- a/resources/logical_switch_group.rb
+++ b/resources/logical_switch_group.rb
@@ -1,4 +1,4 @@
-# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,33 +11,19 @@
 
 OneviewCookbook::ResourceBaseProperties.load(self)
 
-property :switch_number, Fixnum
+property :switch_number, Integer
 property :switch_type, String
 
 default_action :create
 
-action_class do
-  include OneviewCookbook::Helper
-  include OneviewCookbook::ResourceBase
-  def load_logical_switch_group
-    item = load_resource
-    # This will avoid overriding the 'switchMapTemplate' if already specified in data
-    return item unless item['switchMapTemplate'].empty?
-    raise "Unspecified property: 'switch_number'. Please set it before attempting this action." unless switch_number
-    raise "Unspecified property: 'switch_type'. Please set it before attempting this action." unless switch_type
-    item.set_grouping_parameters(switch_number, switch_type)
-    item
-  end
-end
-
 action :create do
-  create_or_update(load_logical_switch_group)
+  OneviewCookbook::Helper.do_resource_action(self, :LogicalSwitchGroup, :create_or_update)
 end
 
 action :create_if_missing do
-  create_if_missing(load_logical_switch_group)
+  OneviewCookbook::Helper.do_resource_action(self, :LogicalSwitchGroup, :create_if_missing)
 end
 
 action :delete do
-  delete
+  OneviewCookbook::Helper.do_resource_action(self, :LogicalSwitchGroup, :delete)
 end


### PR DESCRIPTION
### Description
Adds support to API300 Logical Switch Group.

Resource does not exists for API300::Synergy.

### Issues Resolved
#130 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [ ] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
