### PR TITLE
API300::Synergy LIG updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,11 +243,13 @@ end
 **interconnects:** Array containing a list of Hashes indicating whether the interconnects are and which type they correspond to. Each hash should contain the keys:
   - `:bay` - It specifies the location (bay) where this interconnect is attached to. The value should range from 1 to 8.
   - `:type` - The interconnect type name that is currently attached to your enclosure.
+  - `:enclosure_index` - enclosureIndex value for the interconnect. API300::Synergy only.
+  - `:logical_downlink` - Name of the LogicalDownlink for the interconnect. API300::Synergy only.
 
 ```ruby
 interconnects_data = [
-  {bay: 1, type: 'HP VC FlexFabric 10Gb/24-Port Module'},
-  {bay: 2, type: 'HP VC FlexFabric 10Gb/24-Port Module'}
+  { bay: 1, type: 'HP VC FlexFabric 10Gb/24-Port Module' },
+  { bay: 2, type: 'HP VC FlexFabric 10Gb/24-Port Module' }
 ]
 ```
 
@@ -271,8 +273,8 @@ interconnects_data = [
 
     ```ruby
     uplink_connections = [
-      {bay: 1, port: 'X5'},
-      {bay: 2, port: 'X7'}
+      { bay: 1, port: 'X5' },
+      { bay: 2, port: 'X7' }
     ]
     ```
 

--- a/libraries/resource_providers/api200/logical_interconnect_group_provider.rb
+++ b/libraries/resource_providers/api200/logical_interconnect_group_provider.rb
@@ -15,16 +15,19 @@ module OneviewCookbook
   module API200
     # LogicalInterconnectGroup API200 provider
     class LogicalInterconnectGroupProvider < ResourceProvider
-      def load_lig
+      def load_interconnects
         @context.interconnects.each do |location|
           parsed_location = convert_keys(location, :to_sym)
           @item.add_interconnect(parsed_location[:bay], parsed_location[:type])
         end
+      end
+
+      def load_uplink_sets
         @context.uplink_sets.each do |uplink_info|
           parsed_uplink_info = convert_keys(uplink_info, :to_sym)
           up = OneviewSDK.resource_named(:LIGUplinkSet, @sdk_api_version, @sdk_api_variant).new(@item.client, parsed_uplink_info[:data])
           parsed_uplink_info[:networks].each do |network_name|
-            net = case up[:networkType]
+            net = case up[:networkType].to_s
                   when 'Ethernet'
                     OneviewSDK.resource_named(:EthernetNetwork, @sdk_api_version, @sdk_api_variant).new(item.client, name: network_name)
                   when 'FibreChannel'
@@ -41,12 +44,14 @@ module OneviewCookbook
       end
 
       def create_or_update
-        load_lig
+        load_interconnects
+        load_uplink_sets
         super
       end
 
       def create_if_missing
-        load_lig
+        load_interconnects
+        load_uplink_sets
         super
       end
     end

--- a/libraries/resource_providers/api300/c7000/logical_interconnect_group_provider.rb
+++ b/libraries/resource_providers/api300/c7000/logical_interconnect_group_provider.rb
@@ -16,6 +16,9 @@ module OneviewCookbook
     module C7000
       # LogicalInterconnectGroup API300 C7000 provider
       class LogicalInterconnectGroupProvider < API200::LogicalInterconnectGroupProvider
+        # TODO: Inherit from API300::Synergy::LogicalInterconnectGroupProvider once the SDK
+        # API::C7000::LogicalInterconnectGroup #add_interconnect method accepts the
+        # logical_downlink & enclosure_index parameters. Update README when it does too.
       end
     end
   end

--- a/libraries/resource_providers/api300/synergy/logical_interconnect_group_provider.rb
+++ b/libraries/resource_providers/api300/synergy/logical_interconnect_group_provider.rb
@@ -16,6 +16,17 @@ module OneviewCookbook
     module Synergy
       # LogicalInterconnectGroup API300 Synergy resource provider methods
       class LogicalInterconnectGroupProvider < API200::LogicalInterconnectGroupProvider
+        def load_interconnects
+          @context.interconnects.each do |location|
+            parsed_location = convert_keys(location, :to_sym)
+            @item.add_interconnect(
+              parsed_location[:bay],
+              parsed_location[:type],
+              parsed_location[:logical_downlink] || nil,
+              parsed_location[:enclosure_index] || 1
+            )
+          end
+        end
       end
     end
   end

--- a/spec/unit/resources/storage_system/edit_credentials_spec.rb
+++ b/spec/unit/resources/storage_system/edit_credentials_spec.rb
@@ -6,6 +6,7 @@ describe 'oneview_test::storage_system_edit_credentials' do
 
   it 'does nothing when storage system does not exists' do
     allow_any_instance_of(OneviewSDK::StorageSystem).to receive(:retrieve!).and_return(false)
+    expect(Chef::Log).to receive(:error).with(/Credentials not edited/).and_return(true)
     expect_any_instance_of(OneviewSDK::StorageSystem).to_not receive(:update).and_return(true)
     expect(real_chef_run).to edit_oneview_storage_system_credentials('StorageSystem1')
   end


### PR DESCRIPTION
### Description
- Allow passing the `enclosure_index` & `logical_downlink` attributes to the SDK add_interconnect method (only for Synergy right now, but SDK [#141](https://github.com/HewlettPackard/oneview-sdk-ruby/issues/141) proposes that it be made available for all API versions & variants.
- Removes log output from a spec test

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
