### PR TITLE
Support multiple LIGS in enclosure_group resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - storage_system support for API300
   - storage_pool support for API300
   - logical_interconnect_group support for API300
+  - deprecate enclosure_group property 'logical_interconnect_group' (string) in favor of 'logical_interconnect_groups' (array)
 
 ### 1.1.0
   - Add support for client ENV variables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
   - storage_system support for API300
   - storage_pool support for API300
   - logical_interconnect_group support for API300
-  - deprecate enclosure_group property 'logical_interconnect_group' (string) in favor of 'logical_interconnect_groups' (array)
+  - Deprecate enclosure_group property 'logical_interconnect_group' (string) in favor of 'logical_interconnect_groups' (array)
+    - Also supports SAS LIGs for Synergy in this logical_interconnect_groups property
 
 ### 1.1.0
   - Add support for client ENV variables

--- a/README.md
+++ b/README.md
@@ -381,10 +381,12 @@ Enclosure Group resource for HPE OneView.
 oneview_enclosure_group 'EnclosureGroup_1' do
   client <my_client>
   data <resource_data>
-  logical_interconnect_group <LIG_name>
+  logical_interconnect_groups [<LIG_name1>, <LIG_name2>]
   action [:create, :create_if_missing, :delete]
 end
 ```
+
+**logical_interconnect_groups:** Array of LIG names used to build the interconnect bay configuration
 
 ### oneview_enclosure
 

--- a/examples/enclosure_group.rb
+++ b/examples/enclosure_group.rb
@@ -20,7 +20,7 @@ oneview_enclosure_group 'Eg2' do
     stackingMode: 'Enclosure',
     interconnectBayMappingCount: 8
   )
-  logical_interconnect_group 'lig1'
+  logical_interconnect_groups ['lig1']
   client my_client
   action :create
 end

--- a/libraries/resource_providers/api200/enclosure_group_provider.rb
+++ b/libraries/resource_providers/api200/enclosure_group_provider.rb
@@ -15,14 +15,18 @@ module OneviewCookbook
   module API200
     # EnclosureGroup API200 provider
     class EnclosureGroupProvider < ResourceProvider
-      def load_ligs
+      def load_lig # Deprecated property: logical_interconnect_group
+        return unless @context.logical_interconnect_group
         lig_klass = resource_named(:LogicalInterconnectGroup)
-        if @context.logical_interconnect_group # Deprecated property: logical_interconnect_group
-          dep_warn = "The 'logical_interconnect_group' property (string) is deprecated!"
-          Chef::Log.warn("#{dep_warn} Please use 'logical_interconnect_groups' property (array) instead")
-          @item.add_logical_interconnect_group(lig_klass.new(@item.client, name: @context.logical_interconnect_group))
-        end
+        dep_warn = "The 'logical_interconnect_group' property (string) is deprecated!"
+        Chef::Log.warn("#{dep_warn} Please use 'logical_interconnect_groups' property (array) instead")
+        @item.add_logical_interconnect_group(lig_klass.new(@item.client, name: @context.logical_interconnect_group))
+      end
+
+      def load_ligs
+        load_lig # Deprecated method
         return unless @context.logical_interconnect_groups
+        lig_klass = resource_named(:LogicalInterconnectGroup)
         @context.logical_interconnect_groups.each do |lig|
           @item.add_logical_interconnect_group(lig_klass.new(@item.client, name: lig))
         end

--- a/libraries/resource_providers/api200/enclosure_group_provider.rb
+++ b/libraries/resource_providers/api200/enclosure_group_provider.rb
@@ -15,19 +15,26 @@ module OneviewCookbook
   module API200
     # EnclosureGroup API200 provider
     class EnclosureGroupProvider < ResourceProvider
-      def load_lig
-        return unless @context.logical_interconnect_group
+      def load_ligs
         lig_klass = resource_named(:LogicalInterconnectGroup)
-        @item.add_logical_interconnect_group(lig_klass.new(@item.client, name: @context.logical_interconnect_group))
+        if @context.logical_interconnect_group # Deprecated property: logical_interconnect_group
+          dep_warn = "The 'logical_interconnect_group' property (string) is deprecated!"
+          Chef::Log.warn("#{dep_warn} Please use 'logical_interconnect_groups' property (array) instead")
+          @item.add_logical_interconnect_group(lig_klass.new(@item.client, name: @context.logical_interconnect_group))
+        end
+        return unless @context.logical_interconnect_groups
+        @context.logical_interconnect_groups.each do |lig|
+          @item.add_logical_interconnect_group(lig_klass.new(@item.client, name: lig))
+        end
       end
 
       def create_or_update
-        load_lig
+        load_ligs
         super
       end
 
       def create_if_missing
-        load_lig
+        load_ligs
         super
       end
 

--- a/libraries/resource_providers/api300/synergy/enclosure_group_provider.rb
+++ b/libraries/resource_providers/api300/synergy/enclosure_group_provider.rb
@@ -16,6 +16,17 @@ module OneviewCookbook
     module Synergy
       # EnclosureGroup API300 Synergy resource provider methods
       class EnclosureGroupProvider < API200::EnclosureGroupProvider
+        def load_ligs
+          load_lig # Deprecated method
+          return unless @context.logical_interconnect_groups
+          lig_klass = resource_named(:LogicalInterconnectGroup)
+          sas_lig_klass = resource_named(:SASLogicalInterconnectGroup)
+          @context.logical_interconnect_groups.each do |lig|
+            ret = @item.add_logical_interconnect_group(lig_klass.new(@item.client, name: lig))
+            # Look for and add the SAS LIG if no standard LIG was found
+            @item.add_logical_interconnect_group(sas_lig_klass.new(@item.client, name: lig)) unless ret && !ret.empty?
+          end
+        end
       end
     end
   end

--- a/resources/enclosure_group.rb
+++ b/resources/enclosure_group.rb
@@ -12,7 +12,8 @@
 OneviewCookbook::ResourceBaseProperties.load(self)
 
 property :script, String
-property :logical_interconnect_group, String # Name of LIG
+property :logical_interconnect_group, String # Name of LIG # DEPRECATED!
+property :logical_interconnect_groups, Array # Array of strings (names of LIGs)
 
 default_action :create
 

--- a/spec/fixtures/cookbooks/oneview_test/recipes/enclosure_group_create.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/enclosure_group_create.rb
@@ -20,5 +20,5 @@ oneview_enclosure_group 'EnclosureGroup1' do
     stackingMode: 'Enclosure',
     interconnectBayMappingCount: 8
   )
-  logical_interconnect_group 'LIG1'
+  logical_interconnect_groups ['LIG1', 'LIG2']
 end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/enclosure_group_create_if_missing.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/enclosure_group_create_if_missing.rb
@@ -20,6 +20,6 @@ oneview_enclosure_group 'EnclosureGroup2' do
     stackingMode: 'Enclosure',
     interconnectBayMappingCount: 8
   )
-  logical_interconnect_group 'LIG1'
+  logical_interconnect_groups ['LIG1']
   action :create_if_missing
 end

--- a/spec/unit/resources/enclosure_group/create_if_missing_spec.rb
+++ b/spec/unit/resources/enclosure_group/create_if_missing_spec.rb
@@ -4,7 +4,7 @@ describe 'oneview_test::enclosure_group_create_if_missing' do
   let(:resource_name) { 'enclosure_group' }
   include_context 'chef context'
 
-  it 'accepts a logical_interconnect_group parameter' do
+  it 'accepts a logical_interconnect_groups parameter' do
     expect_any_instance_of(OneviewSDK::EnclosureGroup).to receive(:add_logical_interconnect_group).and_return(true)
     expect_any_instance_of(OneviewSDK::EnclosureGroup).to receive(:exists?).and_return(false)
     expect_any_instance_of(OneviewSDK::EnclosureGroup).to receive(:create).and_return(true)

--- a/spec/unit/resources/enclosure_group/create_spec.rb
+++ b/spec/unit/resources/enclosure_group/create_spec.rb
@@ -4,8 +4,8 @@ describe 'oneview_test::enclosure_group_create' do
   let(:resource_name) { 'enclosure_group' }
   include_context 'chef context'
 
-  it 'accepts a logical_interconnect_group parameter' do
-    expect_any_instance_of(OneviewSDK::EnclosureGroup).to receive(:add_logical_interconnect_group).and_return(true)
+  it 'accepts a logical_interconnect_groups parameter' do
+    expect_any_instance_of(OneviewSDK::EnclosureGroup).to receive(:add_logical_interconnect_group).twice.and_return(true)
     expect_any_instance_of(OneviewSDK::EnclosureGroup).to receive(:exists?).and_return(false)
     expect_any_instance_of(OneviewSDK::EnclosureGroup).to receive(:create).and_return(true)
     expect(real_chef_run).to create_oneview_enclosure_group('EnclosureGroup1')


### PR DESCRIPTION
### Description
Adds a `logical_interconnect_groups` property to the oneview_enclosure_group resource and deprecates the old one (`logical_interconnect_group`). It'll still work for now, but comes with a deprecation warning.

Also, this new `logical_interconnect_groups` property is able to find SAS LIGs for Synergy EnclosureGroups.

### Issues Resolved
None

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
