### PR TITLE
Added create & delete actions to logical_enclosure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   - logical_interconnect_group support for API300
   - Deprecate enclosure_group property 'logical_interconnect_group' (string) in favor of 'logical_interconnect_groups' (array)
     - Also supports SAS LIGs for Synergy in this logical_interconnect_groups property
+  - logical_enclosure  support for API300
+  - Add `create`, `create_if_missing` and `delete` actions to logical_enclosure
 
 ### 1.1.0
   - Add support for client ENV variables

--- a/README.md
+++ b/README.md
@@ -516,9 +516,15 @@ Logical enclosure resource for HPE OneView.
 ```ruby
 oneview_logical_enclosure 'Encl1' do
   client <my_client>
-  action :update_from_group
+  data <data>
+  enclosures [<enclosure_names>] # Array of enclosure names (or serialNumbers or OA IPs) for :create & :create_if_missing actions only
+  enclosure_group 'EncGroup1'    # Name of enclosure group for :create & :create_if_missing actions only
+  script 'script'                # For :set_script action only
+  action [:create_if_missing, :create, :update_from_group, :reconfigure, :set_script, :delete]
 end
 ```
+
+Notes: The default action is `:create_if_missing`. Also, the creation process may take 30min or more.
 
 ### oneview_managed_san
 

--- a/README.md
+++ b/README.md
@@ -517,8 +517,8 @@ Logical enclosure resource for HPE OneView.
 oneview_logical_enclosure 'Encl1' do
   client <my_client>
   data <data>
-  enclosures [<enclosure_names>] # Array of enclosure names (or serialNumbers or OA IPs) for :create & :create_if_missing actions only
-  enclosure_group 'EncGroup1'    # Name of enclosure group for :create & :create_if_missing actions only
+  enclosures [<enclosure_names>] # Optional. Array of enclosure names (or serialNumbers or OA IPs) for :create & :create_if_missing actions only
+  enclosure_group 'EncGroup1'    # Optional. Name of enclosure group for :create & :create_if_missing actions only
   script 'script'                # For :set_script action only
   action [:create_if_missing, :create, :update_from_group, :reconfigure, :set_script, :delete]
 end

--- a/examples/logical_enclosure.rb
+++ b/examples/logical_enclosure.rb
@@ -15,7 +15,42 @@ my_client = {
   password: ENV['ONEVIEWSDK_PASSWORD']
 }
 
+# Example: Create a logical enclosure if it's missing
+oneview_logical_enclosure 'LE1' do
+  client my_client
+  data(
+    firmwareBaselineUri: nil
+  )
+  enclosures ['EN1', 'EN2', 'EN3'] # List of enclosure names, serial numbers or OA IPs
+  enclosure_group 'EG1'
+  action :create_if_missing # This is the default action, so you don't need to specify it
+end
+
+# Example: Make a logical enclosure consistent with the enclosure group
+# Note that this resource will do this action every time; it's meant to be notified to run,
+# not as a standalone resource like this.
 oneview_logical_enclosure 'Encl1' do
   client my_client
   action :update_from_group
+end
+
+# Example: Reapply the appliance's configuration on enclosures for a logical enclosure
+# Note that this resource will do this action every time; it's meant to be notified to run,
+# not as a standalone resource like this.
+oneview_logical_enclosure 'Encl1' do
+  client my_client
+  action :reconfigure
+end
+
+# Example: Set the configuration script of the logical enclosure and on all enclosures in the logical enclosure
+oneview_logical_enclosure 'Encl1' do
+  client my_client
+  script '# My script commands here'
+  action :set_script
+end
+
+# Example: Delete a logical enclosure, logical interconnects and put all attached enclosures and their components to the Monitored state
+oneview_logical_enclosure 'LE1' do
+  client my_client
+  action :delete
 end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -28,7 +28,7 @@ if defined?(ChefSpec)
     oneview_fcoe_network:               standard_actions,
     oneview_firmware:                   [:add, :remove, :create_custom_spp],
     oneview_interconnect:               [:set_uid_light, :set_power_state, :reset, :reset_port_protection, :update_port],
-    oneview_logical_enclosure:          [:update_from_group, :reconfigure, :set_script],
+    oneview_logical_enclosure:          [:create_if_missing, :create, :update_from_group, :reconfigure, :set_script, :delete],
     oneview_logical_interconnect_group: standard_actions,
     oneview_logical_interconnect:       [:none, :add_interconnect, :remove_interconnect, :update_internal_networks, :update_settings,
                                          :update_ethernet_settings, :update_port_monitor, :update_qos_configuration, :update_telemetry_configuration,

--- a/libraries/resource_providers/api200/logical_enclosure_provider.rb
+++ b/libraries/resource_providers/api200/logical_enclosure_provider.rb
@@ -1,0 +1,86 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../resource_provider'
+
+module OneviewCookbook
+  module API200
+    # LogicalEnclosure API200 provider
+    class LogicalEnclosureProvider < ResourceProvider
+      # Load the enclosure_group & enclosures properties
+      def load_logical_enclosure
+        if @context.enclosure_group
+          eg_klass = resource_named(:EnclosureGroup)
+          eg = eg_klass.find_by(@item.client, name: @context.enclosure_group).first
+          raise "EnclosureGroup '#{@context.enclosure_group}' not found!" unless eg
+          @item['enclosureGroupUri'] = eg['uri']
+        end
+
+        @item['enclosureUris'] ||= []
+        if @context.enclosures
+          enc_klass = resource_named(:Enclosure)
+          @context.enclosures.each do |e|
+            enc = enc_klass.new(@item.client, name: e, serialNumber: e, activeOaPreferredIP: e, standbyOaPreferredIP: e)
+            raise "Enclosure '#{e}' not found!" unless enc.retrieve!
+            @item['enclosureUris'].push enc['uri']
+          end
+        end
+      end
+
+      def create_or_update
+        load_logical_enclosure
+        super
+      end
+
+      def create_if_missing
+        load_logical_enclosure
+        super
+      end
+
+      def update_from_group
+        raise "LogicalEnclosure '#{@name}' not found!" unless @item.retrieve!
+        return if @item['state'] == 'Consistent'
+        @context.converge_by "Update LogicalEnclosure '#{@name}' from group" do
+          @item.update_from_group
+        end
+      end
+
+      def reconfigure
+        @item.retrieve!
+        @item['enclosureUris'].each do |enclosure_uri|
+          enclosure = resource_named(:Enclosure).new(@item.client, uri: enclosure_uri)
+          enclosure.retrieve!
+          next unless ['NotReapplyingConfiguration', 'ReapplyingConfigurationFailed', ''].include? enclosure['reconfigurationState']
+          Chef::Log.info "Reconfiguring #{@resource_name} '#{@name}'"
+          @context.converge_by "#{@resource_name} '#{@name}' was reconfigured." do
+            @item.reconfigure
+          end
+          return true
+        end
+
+        Chef::Log.info("#{@resource_name} '#{@name}' is currently being reconfigured")
+      end
+
+      def set_script
+        @item.retrieve!
+        if @item.get_script.eql? @context.script
+          Chef::Log.info("#{@resource_name} '#{@name}' script is up to date")
+        else
+          Chef::Log.info "Updating #{@resource_name} '#{@name}'"
+          Chef::Log.debug "#{@resource_name} '#{@name}' Chef resource differs from OneView resource."
+          @context.converge_by "Updated script for #{@resource_name} '#{@name}'" do
+            @item.set_script(@context.script)
+          end
+        end
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api300/c7000/logical_enclosure_provider.rb
+++ b/libraries/resource_providers/api300/c7000/logical_enclosure_provider.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../api200/logical_enclosure_provider'
+
+module OneviewCookbook
+  module API300
+    module C7000
+      # LogicalEnclosureProvider
+      class LogicalEnclosureProvider < OneviewCookbook::API200::LogicalEnclosureProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api300/synergy/logical_enclosure_provider.rb
+++ b/libraries/resource_providers/api300/synergy/logical_enclosure_provider.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../api200/logical_enclosure_provider'
+
+module OneviewCookbook
+  module API300
+    module Synergy
+      # LogicalEnclosureProvider
+      class LogicalEnclosureProvider < OneviewCookbook::API200::LogicalEnclosureProvider
+      end
+    end
+  end
+end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/logical_enclosure_create.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/logical_enclosure_create.rb
@@ -1,0 +1,25 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: logical_enclosure_create
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_logical_enclosure 'LogicalEnclosure1' do
+  client node['oneview_test']['client']
+  data(
+    firmwareBaselineUri: nil
+  )
+  enclosures ['EN1', 'EN2']
+  enclosure_group 'EG1'
+  action :create
+end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/logical_enclosure_create_if_missing.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/logical_enclosure_create_if_missing.rb
@@ -1,0 +1,25 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: logical_enclosure_create_if_missing
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_logical_enclosure 'LogicalEnclosure1' do
+  client node['oneview_test']['client']
+  data(
+    firmwareBaselineUri: nil
+  )
+  enclosures ['EN1', 'EN2']
+  enclosure_group 'EG1'
+  action :create_if_missing
+end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/logical_enclosure_delete.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/logical_enclosure_delete.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: logical_enclosure_delete
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_logical_enclosure 'LogicalEnclosure1' do
+  client node['oneview_test']['client']
+  action :delete
+end

--- a/spec/unit/resources/logical_enclosure/create_if_missing_spec.rb
+++ b/spec/unit/resources/logical_enclosure/create_if_missing_spec.rb
@@ -1,0 +1,27 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test::logical_enclosure_create_if_missing' do
+  let(:resource_name) { 'logical_enclosure' }
+  let(:klass) { OneviewSDK::LogicalEnclosure }
+  include_context 'chef context'
+
+  before :each do
+    allow(OneviewSDK::EnclosureGroup).to receive(:find_by).with(instance_of(OneviewSDK::Client), name: 'EG1')
+      .and_return([{ 'uri' => '/rest/fake' }])
+    allow(OneviewSDK::Enclosure).to receive(:find_by).at_most(2).times
+      .and_return([OneviewSDK::Enclosure.new(client, uri: '/rest/fake')])
+  end
+
+  it 'creates it when it does not exist' do
+    expect_any_instance_of(klass).to receive(:exists?).and_return(false)
+    expect_any_instance_of(klass).to receive(:create).and_return(true)
+    expect(real_chef_run).to create_oneview_logical_enclosure_if_missing('LogicalEnclosure1')
+  end
+
+  it 'does nothing when it exists' do
+    expect_any_instance_of(klass).to receive(:exists?).and_return(true)
+    expect_any_instance_of(klass).to_not receive(:create)
+    expect_any_instance_of(klass).to receive(:retrieve!).and_return(true)
+    expect(real_chef_run).to create_oneview_logical_enclosure_if_missing('LogicalEnclosure1')
+  end
+end

--- a/spec/unit/resources/logical_enclosure/create_spec.rb
+++ b/spec/unit/resources/logical_enclosure/create_spec.rb
@@ -1,0 +1,37 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test::logical_enclosure_create' do
+  let(:resource_name) { 'logical_enclosure' }
+  let(:klass) { OneviewSDK::LogicalEnclosure }
+  include_context 'chef context'
+
+  before :each do
+    allow(OneviewSDK::EnclosureGroup).to receive(:find_by).with(instance_of(OneviewSDK::Client), name: 'EG1')
+      .and_return([{ 'uri' => '/rest/fake' }])
+    allow(OneviewSDK::Enclosure).to receive(:find_by).at_most(2).times
+      .and_return([OneviewSDK::Enclosure.new(client, uri: '/rest/fake')])
+  end
+
+  it 'creates it when it does not exist' do
+    expect_any_instance_of(klass).to receive(:exists?).and_return(false)
+    expect_any_instance_of(klass).to receive(:create).and_return(true)
+    expect(real_chef_run).to create_oneview_logical_enclosure('LogicalEnclosure1')
+  end
+
+  it 'updates it when it exists but not alike' do
+    expect_any_instance_of(klass).to receive(:exists?).and_return(true)
+    expect_any_instance_of(klass).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(klass).to receive(:like?).and_return(false)
+    expect_any_instance_of(klass).to receive(:update).and_return(true)
+    expect(real_chef_run).to create_oneview_logical_enclosure('LogicalEnclosure1')
+  end
+
+  it 'does nothing when it exists and is alike' do
+    expect_any_instance_of(klass).to receive(:exists?).and_return(true)
+    expect_any_instance_of(klass).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(klass).to receive(:like?).and_return(true)
+    expect_any_instance_of(klass).to_not receive(:update).and_return(true)
+    expect_any_instance_of(klass).to_not receive(:create).and_return(true)
+    expect(real_chef_run).to create_oneview_logical_enclosure('LogicalEnclosure1')
+  end
+end

--- a/spec/unit/resources/logical_enclosure/delete_spec.rb
+++ b/spec/unit/resources/logical_enclosure/delete_spec.rb
@@ -1,0 +1,19 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test::logical_enclosure_delete' do
+  let(:resource_name) { 'logical_enclosure' }
+  let(:klass) { OneviewSDK::LogicalEnclosure }
+  include_context 'chef context'
+
+  it 'deletes it when it exists' do
+    expect_any_instance_of(klass).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(klass).to receive(:delete).and_return(true)
+    expect(real_chef_run).to delete_oneview_logical_enclosure('LogicalEnclosure1')
+  end
+
+  it 'does nothing when it does not exist' do
+    expect_any_instance_of(klass).to receive(:retrieve!).and_return(false)
+    expect_any_instance_of(klass).to_not receive(:delete)
+    expect(real_chef_run).to delete_oneview_logical_enclosure('LogicalEnclosure1')
+  end
+end

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -69,6 +69,9 @@ describe 'oneview_test::default' do
     expect(chef_run).to_not update_oneview_logical_enclosure_from_group('')
     expect(chef_run).to_not reconfigure_oneview_logical_enclosure('')
     expect(chef_run).to_not set_oneview_logical_enclosure_script('')
+    expect(chef_run).to_not create_oneview_logical_enclosure('')
+    expect(chef_run).to_not create_oneview_logical_enclosure_if_missing('')
+    expect(chef_run).to_not delete_oneview_logical_enclosure('')
 
     # oneview_logical_interconnect
     expect(chef_run).to_not add_oneview_logical_interconnect_interconnect('')


### PR DESCRIPTION
### Description
Adds the `:create`, `:create_if_missing` & `:delete` actions to the `oneview_logical_enclosure` resource. Also converts the resource to support API300.

There is only 1 thing I'd like feedback on: whether or not it was OK to switch the default action from `:update_from_group` to `:create_if_missing`? I think the `:update_from_group` action should generally only be used with a notifies statement anyways, but it would technically break backwards compatibility when no action is specified. I see the lack of those actions in the first place as a bug though, so IDK. What do you think @tmiotto ?

### Issues Resolved
Fixes #148 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
