### PR TITLE
Added SAS_LIG resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
   - volume support for API300
   - volume_template support for API300
   - enclosure support for API300. Also added `:patch` action
+  - Added support to SAS Logical Interconnects for API300::Synergy
 
 ### 1.1.0
   - Add support for client ENV variables

--- a/README.md
+++ b/README.md
@@ -233,12 +233,11 @@ The `:create` action will always update the Logical Interconnect Group if you us
 oneview_logical_interconnect_group 'LogicalInterconnectGroup_1' do
   client <my_client>
   data <resource_data>
-  interconnects <interconnect_map> # Array specifying the interconnects in the bays
-  uplink_sets <uplink_set_map>     # Array containing information
+  interconnects <interconnect_data> # Array specifying the interconnects in the bays
+  uplink_sets <uplink_set_map>      # Array containing information
   action [:create, :create_if_missing, :delete]
 end
 ```
-
 
 **interconnects:** Array containing a list of Hashes indicating whether the interconnects are and which type they correspond to. Each hash should contain the keys:
   - `:bay` - It specifies the location (bay) where this interconnect is attached to. The value should range from 1 to 8.
@@ -288,6 +287,30 @@ interconnects_data = [
     { data: uplink_data_2,  connections: connections_2, networks: ['FC_1']}
   ]
   ```
+
+### oneview_sas_logical_interconnect_group
+
+SAS Logical Interconnect Group resource for HPE OneView (API300::Synergy only)
+
+```ruby
+oneview_sas_logical_interconnect_group 'SAS_LIG_1' do
+  client <my_client>
+  data <resource_data>
+  interconnects <interconnect_data> # Array specifying the interconnects in the bays
+  action [:create, :create_if_missing, :delete]
+end
+```
+
+**interconnects:** Array containing a list of Hashes indicating whether the interconnects are and which type they correspond to. Each hash should contain the keys:
+  - `:bay` - It specifies the location (bay) where this interconnect is attached to. The value should range from 1 to 8.
+  - `:type` - The interconnect type name that is currently attached to your enclosure.
+
+```ruby
+interconnects_data = [
+  { bay: 1, type: 'Synergy 12Gb SAS Connection Module' },
+  { bay: 2, type: 'Synergy 12Gb SAS Connection Module' }
+]
+```
 
 ### oneview_logical_switch_group
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ The `:create` action will always update the Logical Interconnect Group if you us
 oneview_logical_interconnect_group 'LogicalInterconnectGroup_1' do
   client <my_client>
   data <resource_data>
-  interconnects <interconnect_data> # Array specifying the interconnects in the bays
+  interconnects <interconnects_data> # Array specifying the interconnects in the bays
   uplink_sets <uplink_set_map>      # Array containing information
   action [:create, :create_if_missing, :delete]
 end
@@ -296,7 +296,7 @@ SAS Logical Interconnect Group resource for HPE OneView (API300::Synergy only)
 oneview_sas_logical_interconnect_group 'SAS_LIG_1' do
   client <my_client>
   data <resource_data>
-  interconnects <interconnect_data> # Array specifying the interconnects in the bays
+  interconnects <interconnects_data> # Array specifying the interconnects in the bays
   action [:create, :create_if_missing, :delete]
 end
 ```

--- a/examples/sas_logical_interconnect_group.rb
+++ b/examples/sas_logical_interconnect_group.rb
@@ -15,6 +15,12 @@ my_client = {
   password: ENV['ONEVIEWSDK_PASSWORD']
 }
 
+# This resource is only available for API300::Synergy, so we need to set these attributes
+# to ensure it loads the correct resource_provider module. You can also set the api_version
+# and api_variant properties on each resource definition below (see the README).
+node.default['oneview']['api_version'] = 300
+node.default['oneview']['api_variant'] = 'Synergy'
+
 # Example: Create a SAS LIG with interconnects
 oneview_sas_logical_interconnect_group 'SAS LIG' do
   my_client

--- a/examples/sas_logical_interconnect_group.rb
+++ b/examples/sas_logical_interconnect_group.rb
@@ -1,0 +1,31 @@
+# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+my_client = {
+  url: ENV['ONEVIEWSDK_URL'],
+  user: ENV['ONEVIEWSDK_USER'],
+  password: ENV['ONEVIEWSDK_PASSWORD']
+}
+
+# Example: Create a SAS LIG with interconnects
+oneview_sas_logical_interconnect_group 'SAS LIG' do
+  my_client
+  interconnects([
+    { bay: 4, type: 'Synergy 12Gb SAS Connection Module' },
+    { bay: 1, type: 'Synergy 12Gb SAS Connection Module' }
+  ])
+end
+
+# Example: Delete a SAS LIG
+oneview_logical_interconnect_group 'SAS LIG' do
+  client my_client
+  action :delete
+end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -41,6 +41,7 @@ if defined?(ChefSpec)
     oneview_power_device:               [:add, :add_if_missing, :discover, :remove],
     oneview_rack:                       [:add, :remove, :add_if_missing, :add_to_rack, :remove_from_rack],
     oneview_san_manager:                [:add, :add_if_missing, :remove],
+    oneview_sas_logical_interconnect_group: standard_actions,
     oneview_server_hardware:            [:add_if_missing, :remove, :refresh, :set_power_state, :update_ilo_firmware],
     oneview_server_hardware_type:       [:edit, :remove],
     oneview_server_profile_template:    standard_actions + [:new_profile],

--- a/libraries/resource_providers/api300/synergy/sas_logical_interconnect_group_provider.rb
+++ b/libraries/resource_providers/api300/synergy/sas_logical_interconnect_group_provider.rb
@@ -1,0 +1,25 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../api200/logical_interconnect_group_provider'
+
+module OneviewCookbook
+  module API300
+    module Synergy
+      # SASLogicalInterconnectGroup API300 Synergy resource provider methods
+      class SASLogicalInterconnectGroupProvider < API200::LogicalInterconnectGroupProvider
+        def load_uplink_sets
+          true # Uplink sets not supported by this resource
+        end
+      end
+    end
+  end
+end

--- a/resources/sas_logical_interconnect_group.rb
+++ b/resources/sas_logical_interconnect_group.rb
@@ -1,0 +1,28 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+OneviewCookbook::ResourceBaseProperties.load(self)
+
+property :interconnects, Array, default: []
+
+default_action :create
+
+action :create do
+  OneviewCookbook::Helper.do_resource_action(self, :SASLogicalInterconnectGroup, :create_or_update)
+end
+
+action :create_if_missing do
+  OneviewCookbook::Helper.do_resource_action(self, :SASLogicalInterconnectGroup, :create_if_missing)
+end
+
+action :delete do
+  OneviewCookbook::Helper.do_resource_action(self, :SASLogicalInterconnectGroup, :delete)
+end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/sas_logical_interconnect_group_create.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/sas_logical_interconnect_group_create.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: sas_logical_interconnect_group_create
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_sas_logical_interconnect_group 'SAS LIG 1' do
+  client node['oneview_test']['client']
+  interconnects []
+end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/sas_logical_interconnect_group_create_if_missing.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/sas_logical_interconnect_group_create_if_missing.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: sas_logical_interconnect_group_create_if_missing
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_sas_logical_interconnect_group 'SAS LIG 2' do
+  client node['oneview_test']['client']
+  interconnects [
+    { bay: 1, type: 'Synergy 12Gb SAS Connection Module' }
+  ]
+  action :create_if_missing
+end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/sas_logical_interconnect_group_delete.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/sas_logical_interconnect_group_delete.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: sas_logical_interconnect_group_delete
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_sas_logical_interconnect_group 'SAS LIG 3' do
+  client node['oneview_test']['client']
+  action :delete
+end

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -133,6 +133,11 @@ describe 'oneview_test::default' do
     expect(chef_run).to_not add_oneview_san_manager_if_missing('')
     expect(chef_run).to_not remove_oneview_san_manager('')
 
+    # oneview_sas_logical_interconnect_group
+    expect(chef_run).to_not create_oneview_sas_logical_interconnect_group('')
+    expect(chef_run).to_not create_oneview_sas_logical_interconnect_group_if_missing('')
+    expect(chef_run).to_not delete_oneview_sas_logical_interconnect_group('')
+
     # oneview_server_hardware
     expect(chef_run).to_not add_oneview_server_hardware_if_missing('')
     expect(chef_run).to_not remove_oneview_server_hardware('')

--- a/spec/unit/resources/sas_logical_interconnect_group/create_if_missing_spec.rb
+++ b/spec/unit/resources/sas_logical_interconnect_group/create_if_missing_spec.rb
@@ -1,0 +1,25 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::sas_logical_interconnect_group_create_if_missing' do
+  let(:resource_name) { 'sas_logical_interconnect_group' }
+  include_context 'chef context'
+  let(:klass) { OneviewSDK::API300::Synergy::SASLogicalInterconnectGroup }
+
+  before :each do
+    expect_any_instance_of(klass).to receive(:add_interconnect)
+      .with(1, 'Synergy 12Gb SAS Connection Module').and_return(true)
+  end
+
+  it 'creates it when it does not exist' do
+    expect_any_instance_of(klass).to receive(:exists?).and_return(false)
+    expect_any_instance_of(klass).to receive(:create).and_return(true)
+    expect(real_chef_run).to create_oneview_sas_logical_interconnect_group_if_missing('SAS LIG 2')
+  end
+
+  it 'does nothing when it exists' do
+    expect_any_instance_of(klass).to receive(:exists?).and_return(true)
+    expect_any_instance_of(klass).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(klass).to_not receive(:create)
+    expect(real_chef_run).to create_oneview_sas_logical_interconnect_group_if_missing('SAS LIG 2')
+  end
+end

--- a/spec/unit/resources/sas_logical_interconnect_group/create_spec.rb
+++ b/spec/unit/resources/sas_logical_interconnect_group/create_spec.rb
@@ -1,0 +1,30 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::sas_logical_interconnect_group_create' do
+  let(:resource_name) { 'sas_logical_interconnect_group' }
+  include_context 'chef context'
+  let(:klass) { OneviewSDK::API300::Synergy::SASLogicalInterconnectGroup }
+
+  it 'creates it when it does not exist' do
+    expect_any_instance_of(klass).to receive(:exists?).and_return(false)
+    expect_any_instance_of(klass).to receive(:create).and_return(true)
+    expect(real_chef_run).to create_oneview_sas_logical_interconnect_group('SAS LIG 1')
+  end
+
+  it 'updates it when it exists but not alike' do
+    expect_any_instance_of(klass).to receive(:exists?).and_return(true)
+    expect_any_instance_of(klass).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(klass).to receive(:like?).and_return(false)
+    expect_any_instance_of(klass).to receive(:update).and_return(true)
+    expect(real_chef_run).to create_oneview_sas_logical_interconnect_group('SAS LIG 1')
+  end
+
+  it 'does nothing when it exists and is alike' do
+    expect_any_instance_of(klass).to receive(:exists?).and_return(true)
+    expect_any_instance_of(klass).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(klass).to receive(:like?).and_return(true)
+    expect_any_instance_of(klass).to_not receive(:update)
+    expect_any_instance_of(klass).to_not receive(:create)
+    expect(real_chef_run).to create_oneview_sas_logical_interconnect_group('SAS LIG 1')
+  end
+end

--- a/spec/unit/resources/sas_logical_interconnect_group/delete_spec.rb
+++ b/spec/unit/resources/sas_logical_interconnect_group/delete_spec.rb
@@ -1,0 +1,19 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::sas_logical_interconnect_group_delete' do
+  let(:resource_name) { 'sas_logical_interconnect_group' }
+  include_context 'chef context'
+  let(:klass) { OneviewSDK::API300::Synergy::SASLogicalInterconnectGroup }
+
+  it 'deletes it when it exists' do
+    expect_any_instance_of(klass).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(klass).to receive(:delete).and_return(true)
+    expect(real_chef_run).to delete_oneview_sas_logical_interconnect_group('SAS LIG 3')
+  end
+
+  it 'does nothing when it does not exist' do
+    expect_any_instance_of(klass).to receive(:retrieve!).and_return(false)
+    expect_any_instance_of(klass).to_not receive(:delete)
+    expect(real_chef_run).to delete_oneview_sas_logical_interconnect_group('SAS LIG 3')
+  end
+end


### PR DESCRIPTION
### Description
Adds the `oneview_sas_logical_interconnect_group` resource to API300::Synergy.

### Issues Resolved
Fixes #144

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
