### PR TITLE
API300 Connection Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
   - logical_switch support for API300
   - interconnect support for API300
   - server_hardware support for API300. Also added `:patch` action
+  - connection_template support for API300
 
 ### 1.1.0
   - Add support for client ENV variables

--- a/README.md
+++ b/README.md
@@ -85,13 +85,30 @@ See the [example](examples/oneview_resource.rb) for more details.
 
 Ethernet network resource for HPE OneView.
 
+The `:bandwidth` can be defined inside `data` attribute. However, it will internally call the **oneview_connection_template** resource.
+
 ```Ruby
 oneview_ethernet_network 'Eth1' do
   client <my_client>
   data <resource_data>
-  action [:create, :create_if_missing, :delete]
+  action [:create, :create_if_missing, :delete, :reset_connection_template]
 end
 ```
+
+### oneview_connection_template
+
+Connection template resource for HPE OneView.
+
+```Ruby
+oneview_connection_template 'ConnectionTemplate1' do
+  client <my_client>
+  data <resource_data>
+  associated_ethernet_network <ethernet_name> # Optional
+  action [:update, :reset]
+end
+```
+
+Although the name of the `associated_ethernet_network` being an optional parameter, it must be set if the correct URI and Connection template name are not defined.
 
 ### oneview_fabric
 

--- a/libraries/resource_providers/api200/connection_template_provider.rb
+++ b/libraries/resource_providers/api200/connection_template_provider.rb
@@ -1,0 +1,37 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../resource_provider'
+
+module OneviewCookbook
+  module API200
+    # ConnectionTemplate API200 provider
+    class ConnectionTemplateProvider < ResourceProvider
+      def load_resource_from_ethernet
+        return unless @context.associated_ethernet_network
+        @item.data.delete('name')
+        ethernet = resource_named(:EthernetNetwork).find_by(@item.client, name: @context.associated_ethernet_network).first
+        @item['uri'] = ethernet['connectionTemplateUri']
+      end
+
+      def create_or_update
+        load_resource_from_ethernet
+        super
+      end
+
+      def reset
+        load_resource_from_ethernet
+        @item['bandwidth'] = resource_named(:ConnectionTemplate).get_default(@item.client)['bandwidth']
+        create_or_update
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api300/c7000/connection_template_provider.rb
+++ b/libraries/resource_providers/api300/c7000/connection_template_provider.rb
@@ -1,4 +1,4 @@
-# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -9,16 +9,14 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-OneviewCookbook::ResourceBaseProperties.load(self)
+require_relative '../../api200/connection_template_provider'
 
-default_action :update
-
-property :associated_ethernet_network, String
-
-action :update do
-  OneviewCookbook::Helper.do_resource_action(self, :ConnectionTemplate, :create_or_update)
-end
-
-action :reset do
-  OneviewCookbook::Helper.do_resource_action(self, :ConnectionTemplate, :reset)
+module OneviewCookbook
+  module API300
+    module C7000
+      # ConnectionTemplate API300 C7000 provider
+      class ConnectionTemplateProvider < API200::ConnectionTemplateProvider
+      end
+    end
+  end
 end

--- a/libraries/resource_providers/api300/synergy/connection_template_provider.rb
+++ b/libraries/resource_providers/api300/synergy/connection_template_provider.rb
@@ -1,4 +1,4 @@
-# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -9,16 +9,14 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-OneviewCookbook::ResourceBaseProperties.load(self)
+require_relative '../../api200/connection_template_provider'
 
-default_action :update
-
-property :associated_ethernet_network, String
-
-action :update do
-  OneviewCookbook::Helper.do_resource_action(self, :ConnectionTemplate, :create_or_update)
-end
-
-action :reset do
-  OneviewCookbook::Helper.do_resource_action(self, :ConnectionTemplate, :reset)
+module OneviewCookbook
+  module API300
+    module Synergy
+      # ConnectionTemplate API300 Synergy provider
+      class ConnectionTemplateProvider < API200::ConnectionTemplateProvider
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description
Adds missing Connection Template Provider

### Issues Resolved
#166

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [ ] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
