### PR TITLE
Added CodeClimate quality and coverage badges

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,18 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+  fixme:
+    enabled: true
+  rubocop:
+    enabled: true
+ratings:
+  paths:
+  - "**.rb"
+exclude_paths:
+- spec/
+- examples/
+- attributes/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ before_install: gem update bundler
 
 script:
   - rake test
+  - codeclimate-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install: gem update bundler
 
 script:
   - rake test
-  - codeclimate-test-reporter
+  - bundle exec codeclimate-test-reporter

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby RUBY_VERSION # Needed to consider & solve for Ruby version requirements
 gem 'berkshelf'
 gem 'chef', '~> 12.0'
 gem 'chefspec'
+gem 'codeclimate-test-reporter', '~> 1.0.0'
 gem 'foodcritic'
 gem 'oneview-sdk', '~> 4.0'
 gem 'pry'

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Cookbook Version](https://img.shields.io/cookbook/v/oneview.svg)](https://supermarket.chef.io/cookbooks/oneview)
 [![Travis Build Status](https://travis-ci.org/HewlettPackard/oneview-chef.svg?branch=master)](https://travis-ci.org/HewlettPackard/oneview-chef)
 [![Chef Build Status](https://jenkins-01.eastus.cloudapp.azure.com/job/oneview-cookbook/badge/icon)](https://jenkins-01.eastus.cloudapp.azure.com/job/oneview-cookbook/)
+[![Code Climate](https://codeclimate.com/github/HewlettPackard/oneview-chef/badges/gpa.svg)](https://codeclimate.com/github/HewlettPackard/oneview-chef)
+[![Test Coverage](https://codeclimate.com/github/HewlettPackard/oneview-chef/badges/coverage.svg)](https://codeclimate.com/github/HewlettPackard/oneview-chef/coverage)
 
 Chef cookbook that provides resources for managing HPE OneView.
 


### PR DESCRIPTION
### Description
Adds CodeClimate quality and coverage badges for the repo.

:warning:  Coverage only shows the coverage for the master branch, also it will only show the report generated by the simplecov (So no ChefSpec coverage)

### Issues Resolved
#178 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [ ] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
