### PR TITLE
Image Streamer API300 Deployment Plan enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -884,7 +884,7 @@ HPE Synergy Image Streamer resource for Deployment plans.
 image_streamer_deployment_plan 'DeploymentPlan1' do
   client <my_client>   # Hash or OneviewSDK::ImageStreamer::Client
   data <resource_data> # Hash
-  build_plan <os_build_plan_name> # String containing the name of the OS Build Plan to be associated to this deployment plan - Optional
+  os_build_plan <os_build_plan_name> # String containing the name of the OS Build Plan to be associated to this deployment plan - Optional
   golden_image <golden_image_name> # String containing the name of the Golden Image to be associated to this deployment plan - Optional
   action [:create, :create_if_missing, :delete]
 end

--- a/examples/image_streamer/deployment_plan.rb
+++ b/examples/image_streamer/deployment_plan.rb
@@ -28,7 +28,7 @@ image_streamer_deployment_plan 'DeploymentPlan1' do
     description: 'AnyDescription',
     hpProvided: false
   )
-  build_plan 'ChefBP01'
+  os_build_plan 'ChefBP01'
   golden_image 'ChefGI01'
 end
 
@@ -49,7 +49,7 @@ image_streamer_deployment_plan 'DeploymentPlan2' do
     description: 'example of create_if_missing action',
     hpProvided: false
   )
-  build_plan 'ChefBP01'
+  os_build_plan 'ChefBP01'
   golden_image 'ChefGI01'
   action :create_if_missing
 end

--- a/libraries/resource_providers/image_streamer/api300/deployment_plan.rb
+++ b/libraries/resource_providers/image_streamer/api300/deployment_plan.rb
@@ -18,13 +18,13 @@ module OneviewCookbook
       class DeploymentPlanProvider < ResourceProvider
         def create_or_update
           @item['goldenImageURI'] ||= load_resource(:GoldenImage, @context.golden_image)
-          @item['oeBuildPlanURI'] ||= load_resource(:BuildPlan, @context.build_plan)
+          @item['oeBuildPlanURI'] ||= load_resource(:BuildPlan, @context.os_build_plan)
           super
         end
 
         def create_if_missing
           @item['goldenImageURI'] ||= load_resource(:GoldenImage, @context.golden_image)
-          @item['oeBuildPlanURI'] ||= load_resource(:BuildPlan, @context.build_plan)
+          @item['oeBuildPlanURI'] ||= load_resource(:BuildPlan, @context.os_build_plan)
           super
         end
       end

--- a/resources/image_streamer/deployment_plan.rb
+++ b/resources/image_streamer/deployment_plan.rb
@@ -12,7 +12,7 @@
 OneviewCookbook::ResourceBaseProperties.load(self)
 
 property :golden_image, String
-property :build_plan, String
+property :os_build_plan, String
 
 resource_name :image_streamer_deployment_plan
 

--- a/spec/fixtures/cookbooks/image_streamer_test_api300/recipes/deployment_plan_create.rb
+++ b/spec/fixtures/cookbooks/image_streamer_test_api300/recipes/deployment_plan_create.rb
@@ -20,7 +20,7 @@ image_streamer_deployment_plan 'DeploymentPlan1' do
     description: 'AnyDescription',
     hpProvided: false
   )
-  build_plan 'ChefBP01'
+  os_build_plan 'ChefBP01'
   golden_image 'ChefGI01'
   action :create
 end

--- a/spec/fixtures/cookbooks/image_streamer_test_api300/recipes/deployment_plan_create_if_missing.rb
+++ b/spec/fixtures/cookbooks/image_streamer_test_api300/recipes/deployment_plan_create_if_missing.rb
@@ -20,7 +20,7 @@ image_streamer_deployment_plan 'DeploymentPlan1' do
     description: 'AnyDescription',
     hpProvided: false
   )
-  build_plan 'ChefBP01'
+  os_build_plan 'ChefBP01'
   golden_image 'ChefGI01'
   action :create_if_missing
 end

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -234,6 +234,11 @@ describe 'oneview_test::default' do
   end
 
   it 'supports all image streamer matchers' do
+    # image_streamer_deployment_plan
+    expect(chef_run).to_not create_image_streamer_deployment_plan('')
+    expect(chef_run).to_not delete_image_streamer_deployment_plan('')
+    expect(chef_run).to_not create_image_streamer_deployment_plan_if_missing('')
+
     # image_streamer_plan_script
     expect(chef_run).to_not create_image_streamer_plan_script('')
     expect(chef_run).to_not delete_image_streamer_plan_script('')


### PR DESCRIPTION
### Description
 - Adds missing specs for deployment plan
 - Changes deployment plan property `build_plan` to `os_build_plan`

### Issues Resolved
#202 
#203 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [ ] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
