### PR TITLE
Image Streamer API300 OS Build Plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+- Adds support to API300 HPE Synergy Image Streamer resources:
+  - image_streamer_os_build_plan
+
 ## 2.1.0
 - [#162](https://github.com/HewlettPackard/oneview-chef/issues/162) Add server_profile_template property to oneview_server_profile
 - Add :update_from_template action to oneview_server_profile

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then use any of the resources provided by this cookbook.
 ```ruby
 # my_cookbook/metadata.rb
 ...
-depends 'oneview', '~> 2.1'
+depends 'oneview', '~> 2.2'
 ```
 
 ### Credentials
@@ -904,6 +904,17 @@ image_streamer_golden_image 'GoldenImage1' do
   file_path <local_file_path> # String - Path to file to perform any download or upload like actions (Required in these actions)
   timeout <time_in_seconds>   # Integer - Optional - Time to timeout the request in the :download and :upload_if_missing actions. Defaults to the default resource value (Usualy 300 seconds)
   action [:create, :create_if_missing, :delete, :download, :download_details_archive, :upload_if_missing]
+end
+```
+### image_streamer_os_build_plan
+
+HPE Synergy Image Streamer resource for OS Build plan.
+
+```ruby
+image_streamer_os_build_plan 'OSBuildPlan1' do
+  client <my_client>   # Hash or OneviewSDK::ImageStreamer::Client
+  data <resource_data> # Hash
+  action [:create, :create_if_missing, :delete]
 end
 ```
 

--- a/examples/image_streamer/os_build_plan.rb
+++ b/examples/image_streamer/os_build_plan.rb
@@ -26,7 +26,6 @@ i3s_client = {
 # Creates or updates a simple OS Build Plan named 'Chef-BuildPlan1'
 image_streamer_os_build_plan 'Chef-OSBuildPlan1' do
   client i3s_client
-  api_version 300
   data(
     description: 'Chef created OS Build Plan',
     oeBuildPlanType: 'Deploy'
@@ -38,7 +37,6 @@ end
 # The second uses the plan 'PlanScript2' with the parameter 'deploy'
 image_streamer_os_build_plan 'Chef-OSBuildPlan1' do
   client i3s_client
-  api_version 300
   data(
     description: 'Chef created OS Build Plan',
     oeBuildPlanType: 'Deploy',
@@ -52,7 +50,6 @@ end
 # Creates a simple OS Build Plan named 'Chef-BuildPlan2' only if it does not exist
 image_streamer_os_build_plan 'Chef-OSBuildPlan2' do
   client i3s_client
-  api_version 300
   data(
     description: 'Chef created OS Build Plan',
     oeBuildPlanType: 'Deploy'

--- a/examples/image_streamer/os_build_plan.rb
+++ b/examples/image_streamer/os_build_plan.rb
@@ -1,0 +1,72 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# Defaults API version to 300
+node.default['oneview']['api_version'] = 300
+
+oneview_client = {
+  url: ENV['ONEVIEWSDK_URL'],
+  user: ENV['ONEVIEWSDK_USER'],
+  password: ENV['ONEVIEWSDK_PASSWORD']
+}
+
+i3s_client = {
+  url: ENV['I3S_URL'],
+  oneview_client: oneview_client
+}
+
+# Creates or updates a simple OS Build Plan named 'Chef-BuildPlan1'
+image_streamer_os_build_plan 'Chef-OSBuildPlan1' do
+  client i3s_client
+  api_version 300
+  data(
+    description: 'Chef created OS Build Plan',
+    oeBuildPlanType: 'Deploy'
+  )
+end
+
+# Creates or updates an OS Build Plan named 'Chef-BuildPlan1' with two build steps
+# The first uses the plan script 'PlanScript1'
+# The second uses the plan 'PlanScript2' with the parameter 'deploy'
+image_streamer_os_build_plan 'Chef-OSBuildPlan1' do
+  client i3s_client
+  api_version 300
+  data(
+    description: 'Chef created OS Build Plan',
+    oeBuildPlanType: 'Deploy',
+    buildStep: [
+      { serialNumber: 1, planScriptName: 'PlanScript1' },
+      { serialNumber: 2, planScriptName: 'PlanScript2', parameters: 'deploy' }
+    ]
+  )
+end
+
+# Creates a simple OS Build Plan named 'Chef-BuildPlan2' only if it does not exist
+image_streamer_os_build_plan 'Chef-OSBuildPlan2' do
+  client i3s_client
+  api_version 300
+  data(
+    description: 'Chef created OS Build Plan',
+    oeBuildPlanType: 'Deploy'
+  )
+  action :create_if_missing
+end
+
+# Deletes the OS Build Plans created
+image_streamer_os_build_plan 'Chef-OSBuildPlan1' do
+  client i3s_client
+  action :delete
+end
+
+image_streamer_os_build_plan 'Chef-OSBuildPlan2' do
+  client i3s_client
+  action :delete
+end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -65,6 +65,7 @@ if defined?(ChefSpec)
   image_streamer_resources = {
     image_streamer_deployment_plan: standard_actions,
     image_streamer_golden_image:    standard_actions + [:upload_if_missing, :download, :download_details_archive],
+    image_streamer_os_build_plan:   standard_actions,
     image_streamer_plan_script:     standard_actions
   }
 

--- a/libraries/resource_provider.rb
+++ b/libraries/resource_provider.rb
@@ -232,7 +232,7 @@ module OneviewCookbook
     # @param [String] resource_id Name for this resource. 'Resource1'
     # @param [NilClass, String, Symbol] ret_attribute Attribute of resource to be returned by this method. Use nil to return the complete resource
     # @return [OneviewSDK::Resource] if the `ret_attribute` is nil
-    # @return [String, Array, Hash] that is the value of the atributed defined by the `ret_attribute` for the requested resource
+    # @return [String, Array, Hash] that is the value of the attribute defined by the `ret_attribute` for the requested resource
     def load_resource(resource_class_type, resource_id, ret_attribute = nil)
       return unless resource_id
       r = resource_named(resource_class_type).new(@item.client, name: resource_id)

--- a/libraries/resource_provider.rb
+++ b/libraries/resource_provider.rb
@@ -227,13 +227,16 @@ module OneviewCookbook
     end
 
     # Generic method to retrieve and return a resource from different resources using the type and name of the resource
+    # Note: The resource class base API module is the one used by the current provider
     # @param [String, Symbol] resource_class_type Type of resource to be retrieved. e.g., :GoldenImage, :FCNetwork
     # @param [String] resource_id Name for this resource. 'Resource1'
     # @param [NilClass, String, Symbol] ret_attribute Attribute of resource to be returned by this method. Use nil to return the complete resource
+    # @return [OneviewSDK::Resource] if the `ret_attribute` is nil
+    # @return [String, Array, Hash] that is the value of the atributed defined by the `ret_attribute` for the requested resource
     def load_resource(resource_class_type, resource_id, ret_attribute = nil)
       return unless resource_id
       r = resource_named(resource_class_type).new(@item.client, name: resource_id)
-      raise "#{resource_class_type} '#{resource_id}' was not found in the appliance." unless r.retrieve!
+      raise "ResourceNotFound: #{resource_class_type} '#{resource_id}' was not found in the appliance." unless r.retrieve!
       return r unless ret_attribute
       r[ret_attribute]
     end

--- a/libraries/resource_providers/image_streamer/api300/os_build_plan_provider.rb
+++ b/libraries/resource_providers/image_streamer/api300/os_build_plan_provider.rb
@@ -1,0 +1,44 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../../resource_provider'
+
+module OneviewCookbook
+  module ImageStreamer
+    module API300
+      # OS Build Plan Provider resource methods
+      class BuildPlanProvider < ResourceProvider
+        def load_build_step
+          return unless @item['buildStep']
+          @item['buildStep'].collect! do |build_step|
+            step = convert_keys(build_step, :to_s)
+            next step if step['planScriptUri']
+            raise "InvalidResourceData: Must specify the 'planScriptName' or 'planScriptUri' for each build step" unless step['planScriptName']
+            plan = resource_named(:PlanScript).new(@item.client, name: step['planScriptName'])
+            raise "ResourceNotFound: The '#{resource_named(:PlanScript).class}' '#{plan['name']}' could not be found." unless plan.retrieve!
+            step['planScriptUri'] = plan['uri']
+            step
+          end
+        end
+
+        def create_or_update
+          load_build_step
+          super
+        end
+
+        def create_if_missing
+          load_build_step
+          super
+        end
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/image_streamer/api300/os_build_plan_provider.rb
+++ b/libraries/resource_providers/image_streamer/api300/os_build_plan_provider.rb
@@ -22,9 +22,7 @@ module OneviewCookbook
             step = convert_keys(build_step, :to_s)
             next step if step['planScriptUri']
             raise "InvalidResourceData: Must specify the 'planScriptName' or 'planScriptUri' for each build step" unless step['planScriptName']
-            plan = resource_named(:PlanScript).new(@item.client, name: step['planScriptName'])
-            raise "ResourceNotFound: The '#{resource_named(:PlanScript).class}' '#{plan['name']}' could not be found." unless plan.retrieve!
-            step['planScriptUri'] = plan['uri']
+            step['planScriptUri'] = load_resource(:PlanScript, step['planScriptName'], 'uri')
             step
           end
         end

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ license          'Apache v2.0'
 description      'Provides HPE OneView & Image Streamer resources'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version          '2.1.0'
+version          '2.2.0'
 
 source_url       'https://github.com/HewlettPackard/oneview-chef' if respond_to?(:source_url)
 issues_url       'https://github.com/HewlettPackard/oneview-chef/issues' if respond_to?(:issues_url)

--- a/resources/image_streamer/os_build_plan.rb
+++ b/resources/image_streamer/os_build_plan.rb
@@ -1,0 +1,28 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+OneviewCookbook::ResourceBaseProperties.load(self)
+
+resource_name :image_streamer_os_build_plan
+
+default_action :create
+
+action :create do
+  OneviewCookbook::Helper.do_resource_action(self, :BuildPlan, :create_or_update, OneviewCookbook::ImageStreamer)
+end
+
+action :create_if_missing do
+  OneviewCookbook::Helper.do_resource_action(self, :BuildPlan, :create_if_missing, OneviewCookbook::ImageStreamer)
+end
+
+action :delete do
+  OneviewCookbook::Helper.do_resource_action(self, :BuildPlan, :delete, OneviewCookbook::ImageStreamer)
+end

--- a/spec/fixtures/cookbooks/image_streamer_test_api300/recipes/os_build_plan_create.rb
+++ b/spec/fixtures/cookbooks/image_streamer_test_api300/recipes/os_build_plan_create.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: image_streamer_test_api300
+# Recipe:: os_build_plan_create
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+image_streamer_os_build_plan 'OSBuildPlan1' do
+  client node['image_streamer_test']['client']
+  data(
+    description: 'Chef created OS Build Plan',
+    oeBuildPlanType: 'Deploy'
+  )
+  action :create
+end

--- a/spec/fixtures/cookbooks/image_streamer_test_api300/recipes/os_build_plan_create_if_missing.rb
+++ b/spec/fixtures/cookbooks/image_streamer_test_api300/recipes/os_build_plan_create_if_missing.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: image_streamer_test_api300
+# Recipe:: os_build_plan_create_if_missing
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+image_streamer_os_build_plan 'OSBuildPlan1' do
+  client node['image_streamer_test']['client']
+  data(
+    description: 'Chef created OS Build Plan',
+    oeBuildPlanType: 'Deploy'
+  )
+  action :create_if_missing
+end

--- a/spec/fixtures/cookbooks/image_streamer_test_api300/recipes/os_build_plan_delete.rb
+++ b/spec/fixtures/cookbooks/image_streamer_test_api300/recipes/os_build_plan_delete.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: image_streamer_test_api300
+# Recipe:: os_build_plan_delete
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+image_streamer_os_build_plan 'OSBuildPlan1' do
+  client node['image_streamer_test']['client']
+  action :delete
+end

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -248,6 +248,11 @@ describe 'oneview_test::default' do
     expect(chef_run).to_not download_image_streamer_golden_image('')
     expect(chef_run).to_not download_image_streamer_golden_image_details_archive('')
 
+    # image_streamer_os_build_plan
+    expect(chef_run).to_not create_image_streamer_os_build_plan('')
+    expect(chef_run).to_not delete_image_streamer_os_build_plan('')
+    expect(chef_run).to_not create_image_streamer_os_build_plan_if_missing('')
+
     # image_streamer_plan_script
     expect(chef_run).to_not create_image_streamer_plan_script('')
     expect(chef_run).to_not delete_image_streamer_plan_script('')

--- a/spec/unit/resources_image_streamer/os_build_plan/create_if_missing_spec.rb
+++ b/spec/unit/resources_image_streamer/os_build_plan/create_if_missing_spec.rb
@@ -1,0 +1,21 @@
+require_relative './../../../spec_helper'
+
+describe 'image_streamer_test_api300::os_build_plan_create_if_missing' do
+  let(:complete_resource_name) { 'image_streamer_os_build_plan' }
+  include_context 'chef context'
+
+  let(:base_sdk) { OneviewSDK::ImageStreamer::API300 }
+
+  it 'creates it when it does not exist' do
+    expect_any_instance_of(base_sdk::BuildPlan).to receive(:exists?).and_return(false)
+    expect_any_instance_of(base_sdk::BuildPlan).to receive(:create).and_return(true)
+    expect(real_chef_run).to create_image_streamer_os_build_plan_if_missing('OSBuildPlan1')
+  end
+
+  it 'does nothing when it exists' do
+    expect_any_instance_of(base_sdk::BuildPlan).to receive(:exists?).and_return(true)
+    expect_any_instance_of(base_sdk::BuildPlan).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(base_sdk::BuildPlan).to_not receive(:create)
+    expect(real_chef_run).to create_image_streamer_os_build_plan_if_missing('OSBuildPlan1')
+  end
+end

--- a/spec/unit/resources_image_streamer/os_build_plan/create_spec.rb
+++ b/spec/unit/resources_image_streamer/os_build_plan/create_spec.rb
@@ -1,0 +1,94 @@
+require_relative './../../../spec_helper'
+
+describe 'image_streamer_test_api300::os_build_plan_create' do
+  let(:complete_resource_name) { 'image_streamer_os_build_plan' }
+  include_context 'chef context'
+
+  let(:base_sdk) { OneviewSDK::ImageStreamer::API300 }
+
+  it 'creates it when it does not exist' do
+    expect_any_instance_of(base_sdk::BuildPlan).to receive(:exists?).and_return(false)
+    expect_any_instance_of(base_sdk::BuildPlan).to receive(:create).and_return(true)
+    expect(real_chef_run).to create_image_streamer_os_build_plan('OSBuildPlan1')
+  end
+
+  it 'updates it when it exists but not alike' do
+    expect_any_instance_of(base_sdk::BuildPlan).to receive(:exists?).and_return(true)
+    expect_any_instance_of(base_sdk::BuildPlan).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(base_sdk::BuildPlan).to receive(:like?).and_return(false)
+    expect_any_instance_of(base_sdk::BuildPlan).to receive(:update).and_return(true)
+    expect(real_chef_run).to create_image_streamer_os_build_plan('OSBuildPlan1')
+  end
+
+  it 'does nothing when it exists and is alike' do
+    expect_any_instance_of(base_sdk::BuildPlan).to receive(:exists?).and_return(true)
+    expect_any_instance_of(base_sdk::BuildPlan).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(base_sdk::BuildPlan).to receive(:like?).and_return(true)
+    expect_any_instance_of(base_sdk::BuildPlan).to_not receive(:update)
+    expect_any_instance_of(base_sdk::BuildPlan).to_not receive(:create)
+    expect(real_chef_run).to create_image_streamer_os_build_plan('OSBuildPlan1')
+  end
+
+  context '#load_build_step' do
+    before(:each) do
+      allow_any_instance_of(base_sdk::BuildPlan).to receive(:[]).and_call_original
+      allow_any_instance_of(base_sdk::PlanScript).to receive(:[]).and_call_original
+    end
+
+    let(:build_step_name) do
+      [
+        { planScriptName: 'PlanScript1', serialNumber: 1 }
+      ]
+    end
+
+    let(:build_step_uri) do
+      [
+        { planScriptUri: 'rest/fake/plan-script/', serialNumber: 1 }
+      ]
+    end
+
+    let(:build_step_wrong) do
+      [
+        { serialNumber: 1 }
+      ]
+    end
+
+    it 'loads the specified plan scripts by name and works' do
+      allow_any_instance_of(base_sdk::BuildPlan).to receive(:[]).with('buildStep').and_return(build_step_name)
+      allow_any_instance_of(base_sdk::PlanScript).to receive(:retrieve!).and_return(true)
+      allow_any_instance_of(base_sdk::PlanScript).to receive(:[]).with('uri').and_return('rest/fake-uri')
+
+      # Happy path creation
+      expect_any_instance_of(base_sdk::BuildPlan).to receive(:exists?).and_return(false)
+      expect_any_instance_of(base_sdk::BuildPlan).to receive(:create).and_return(true)
+      expect(real_chef_run).to create_image_streamer_os_build_plan('OSBuildPlan1')
+
+      expect(build_step_name.first).to have_key('planScriptUri')
+      expect(build_step_name.first['planScriptUri']).to eq('rest/fake-uri')
+    end
+
+    it 'raise error when the plan script does not exist' do
+      allow_any_instance_of(base_sdk::BuildPlan).to receive(:[]).with('buildStep').and_return(build_step_name)
+      allow_any_instance_of(base_sdk::PlanScript).to receive(:retrieve!).and_return(false)
+      expect { real_chef_run }.to raise_error(RuntimeError, /ResourceNotFound/)
+    end
+
+    it 'does nothing when the url is specified' do
+      allow_any_instance_of(base_sdk::BuildPlan).to receive(:[]).with('buildStep').and_return(build_step_uri)
+      expect_any_instance_of(base_sdk::PlanScript).to_not receive(:retrieve!)
+
+      # Happy path creation
+      expect_any_instance_of(base_sdk::BuildPlan).to receive(:exists?).and_return(false)
+      expect_any_instance_of(base_sdk::BuildPlan).to receive(:create).and_return(true)
+      expect(real_chef_run).to create_image_streamer_os_build_plan('OSBuildPlan1')
+
+      expect(build_step_uri.first).to have_key('planScriptUri')
+      expect(build_step_uri.first['planScriptUri']).to eq('rest/fake/plan-script/')
+    end
+
+    it 'raise error when the plan script is not specified' do
+      allow_any_instance_of(base_sdk::BuildPlan).to receive(:[]).with('buildStep').and_return(build_step_wrong)
+      expect { real_chef_run }.to raise_error(RuntimeError, /InvalidResourceData/)
+    end
+  end
+end

--- a/spec/unit/resources_image_streamer/os_build_plan/delete_spec.rb
+++ b/spec/unit/resources_image_streamer/os_build_plan/delete_spec.rb
@@ -1,0 +1,20 @@
+require_relative './../../../spec_helper'
+
+describe 'image_streamer_test_api300::os_build_plan_delete' do
+  let(:complete_resource_name) { 'image_streamer_os_build_plan' }
+  include_context 'chef context'
+
+  let(:base_sdk) { OneviewSDK::ImageStreamer::API300 }
+
+  it 'deletes it when it exists' do
+    expect_any_instance_of(base_sdk::BuildPlan).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(base_sdk::BuildPlan).to receive(:delete).and_return(true)
+    expect(real_chef_run).to delete_image_streamer_os_build_plan('OSBuildPlan1')
+  end
+
+  it 'does nothing when it does not exist' do
+    expect_any_instance_of(base_sdk::BuildPlan).to receive(:retrieve!).and_return(false)
+    expect_any_instance_of(base_sdk::BuildPlan).to_not receive(:delete)
+    expect(real_chef_run).to delete_image_streamer_os_build_plan('OSBuildPlan1')
+  end
+end


### PR DESCRIPTION
### Description
Adds support to Image Streamer API300 OS Build Plan.
  - adds the resource `image_streamer_os_build_plan`
  - bumps up the version of the cookbook

### Issues Resolved
#209 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
