### PR TITLE
Improves load_resource to receive any Unique ID

### DIFF
--- a/libraries/resource_provider.rb
+++ b/libraries/resource_provider.rb
@@ -239,11 +239,7 @@ module OneviewCookbook
     # @raise [OneviewSDK::IncompleteResource] If you don't specify any unique identifiers in resource_id
     def load_resource(resource_class_type, resource_id, ret_attribute = nil)
       return unless resource_id
-      data = if resource_id.is_a?(Hash)
-               resource_id
-             else
-               { name: resource_id }
-             end
+      data = resource_id.is_a?(Hash) ? resource_id : { name: resource_id }
       r = resource_named(resource_class_type).new(@item.client, data)
       raise "ResourceNotFound: #{resource_class_type} with data '#{data}' was not found in the appliance." unless r.retrieve!
       return r unless ret_attribute

--- a/libraries/resource_provider.rb
+++ b/libraries/resource_provider.rb
@@ -229,14 +229,23 @@ module OneviewCookbook
     # Generic method to retrieve and return a resource from different resources using the type and name of the resource
     # Note: The resource class base API module is the one used by the current provider
     # @param [String, Symbol] resource_class_type Type of resource to be retrieved. e.g., :GoldenImage, :FCNetwork
-    # @param [String] resource_id Name for this resource. 'Resource1'
+    # @param [Hash, String, NilClass] resource_id data containing unique IDs for this resource. e.g. uri: 'rest/fake/123456ABCDEF'
+    #   If a String is passed, it assumes the attribute is the `name` for this resource. e.g. 'Resource1' is interpreted as `name: 'Resource1'`.
+    #   If nothing or nil is passed, the method returns nil since there is nothing to be retrieved.
     # @param [NilClass, String, Symbol] ret_attribute Attribute of resource to be returned by this method. Use nil to return the complete resource
     # @return [OneviewSDK::Resource] if the `ret_attribute` is nil
     # @return [String, Array, Hash] that is the value of the attribute defined by the `ret_attribute` for the requested resource
+    # @raise [RuntimeError] ResourceNotFound if the resource cannot be found
+    # @raise [OneviewSDK::IncompleteResource] If you don't specify any unique identifiers in resource_id
     def load_resource(resource_class_type, resource_id, ret_attribute = nil)
       return unless resource_id
-      r = resource_named(resource_class_type).new(@item.client, name: resource_id)
-      raise "ResourceNotFound: #{resource_class_type} '#{resource_id}' was not found in the appliance." unless r.retrieve!
+      data = if resource_id.is_a?(Hash)
+               resource_id
+             else
+               { name: resource_id }
+             end
+      r = resource_named(resource_class_type).new(@item.client, data)
+      raise "ResourceNotFound: #{resource_class_type} with data '#{data}' was not found in the appliance." unless r.retrieve!
       return r unless ret_attribute
       r[ret_attribute]
     end

--- a/spec/unit/libraries/resource_provider_spec.rb
+++ b/spec/unit/libraries/resource_provider_spec.rb
@@ -342,9 +342,16 @@ RSpec.describe OneviewCookbook::ResourceProvider do
       @other_res = sdk_klass.new(@client, name: 'T1', description: 'Blah', uri: '/fake')
     end
 
-    it 'retrieves a resource successfully when it exists' do
+    it 'retrieves a resource successfully when it exists (default by name)' do
       expect(sdk_klass).to receive(:find_by).and_return([@other_res])
       r = @res.load_resource(:VolumeTemplate, 'T1')
+      expect(r).to be_a(sdk_klass)
+      expect(r.data).to eq(@other_res.data)
+    end
+
+    it 'retrieves a resource successfully when it exists (by data Hash)' do
+      expect(sdk_klass).to receive(:find_by).and_return([@other_res])
+      r = @res.load_resource(:VolumeTemplate, uri: '/fake')
       expect(r).to be_a(sdk_klass)
       expect(r.data).to eq(@other_res.data)
     end
@@ -360,7 +367,7 @@ RSpec.describe OneviewCookbook::ResourceProvider do
 
     it 'fails when the resource does not exist' do
       expect_any_instance_of(sdk_klass).to receive(:retrieve!).and_return(false)
-      expect { @res.load_resource(:VolumeTemplate, 'T2') }.to raise_error(RuntimeError, /not found/)
+      expect { @res.load_resource(:VolumeTemplate, 'T2') }.to raise_error(RuntimeError, /ResourceNotFound/)
     end
 
     it 'returns a resource attribute when called with the ret_attribute' do

--- a/spec/unit/resources_image_streamer/deployment_plan/create_spec.rb
+++ b/spec/unit/resources_image_streamer/deployment_plan/create_spec.rb
@@ -40,6 +40,6 @@ describe 'image_streamer_test_api300::deployment_plan_create' do
 
   it 'raises an error when a resource passed in does not exist' do
     expect_any_instance_of(base_sdk::GoldenImage).to receive(:retrieve!).and_return(false)
-    expect { real_chef_run }.to raise_error(RuntimeError, /'ChefGI01' was not found in the appliance./)
+    expect { real_chef_run }.to raise_error(RuntimeError, /ResourceNotFound/)
   end
 end


### PR DESCRIPTION
### Description
Adds the capability to receive any data with unique IDs in the load_resource method.

### Issues Resolved
#211

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
