### PR TITLE
Extends Connection Template support to FCNetwork, FCoENetwork and NetworkSet

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,3 +37,6 @@ Style/RescueModifier:
 
 Style/WordArray:
   Enabled: false
+
+Style/SingleLineBlockParams:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Adds support to API300 HPE Synergy Image Streamer resources:
   - image_streamer_os_build_plan
 
 Enhancements:
-  - connection_template now supports `EthernetNetwork`, `FCoENetwork`, `FCNetwork` and `NetworkSet`
+- [#218](https://github.com/HewlettPackard/oneview-chef/issues/218) connection_template resource does not support NetworkSet, FCoENetwork and FcNetwork
 
 
 ## 2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Adds support to API300 HPE Synergy Image Streamer resources:
   - image_streamer_os_build_plan
 
 Enhancements:
-- [#218](https://github.com/HewlettPackard/oneview-chef/issues/218) connection_template resource does not support NetworkSet, FCoENetwork and FcNetwork
+- [#218](https://github.com/HewlettPackard/oneview-chef/issues/218) connection_template resource does not support NetworkSet, FCoENetwork and FCNetwork
 
 
 ## 2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Adds support to API300 HPE Synergy Image Streamer resources:
   - image_streamer_artifact_bundle
   - image_streamer_os_build_plan
 
+Enhancements:
+  - connection_template now supports `EthernetNetwork`, `FCoENetwork`, `FCNetwork` and `NetworkSet`
+
+
 ## 2.1.0
 - [#162](https://github.com/HewlettPackard/oneview-chef/issues/162) Add server_profile_template property to oneview_server_profile
 - Add :update_from_template action to oneview_server_profile

--- a/README.md
+++ b/README.md
@@ -125,12 +125,17 @@ Connection template resource for HPE OneView.
 oneview_connection_template 'ConnectionTemplate1' do
   client <my_client>
   data <resource_data>
-  associated_ethernet_network <ethernet_name> # Optional
+  associated_ethernet_network <ethernet_network_name> # Or
+  associated_fcoe_network <fcoe_network_name> # Or
+  associated_fc_network <fc_network_name> # Or
+  associated_network_set <network_set_name>
   action [:update, :reset]
 end
 ```
 
-Although the name of the `associated_ethernet_network` being an optional parameter, it must be set if the correct URI and Connection template name are not defined.
+:memo: **Note:** This resource can be used to set connection template parameters within four OneView entities: `EthernetNetwork`, `FCoENetwork`, `FCNetwork` and `NetworkSet`. However you shall not manipulate with more that one connection template in the single resource.
+
+Although the names of the associated resources (`associated_ethernet_network`, `associated_fcoe_network`, `associated_fc_network` and `associated_network_set`) are optional parameters, they must be set if the correct URI and Connection template name are not defined.
 
 ### oneview_fabric
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ oneview_connection_template 'ConnectionTemplate1' do
 end
 ```
 
-:memo: **Note:** This resource can be used to set connection template parameters within four OneView entities: `EthernetNetwork`, `FCoENetwork`, `FCNetwork` and `NetworkSet`. However you shall not manipulate with more that one connection template in the single resource.
+:memo: **Note:** This resource can be used to set connection template parameters within four OneView entities: `EthernetNetwork`, `FCoENetwork`, `FCNetwork` and `NetworkSet`. However you cannot manipulate more than one associated resource in a single connection template.
 
 Although the names of the associated resources (`associated_ethernet_network`, `associated_fcoe_network`, `associated_fc_network` and `associated_network_set`) are optional parameters, they must be set if the correct URI and Connection template name are not defined.
 

--- a/examples/connection_template.rb
+++ b/examples/connection_template.rb
@@ -15,7 +15,7 @@ my_client = {
   password: ENV['ONEVIEWSDK_PASSWORD']
 }
 
-# Ethernet network that we'll use for the examples below
+# Ethernet network that will be used for the examples below
 oneview_ethernet_network 'ChefEthernet_3001' do
   client client
   data(
@@ -30,14 +30,14 @@ oneview_ethernet_network 'ChefEthernet_3001' do
   )
 end
 
-# Network set that we'll use for the examples below
+# Network set that will be used for the examples below
 oneview_network_set 'NetworkSet_3001' do
   client oneview_sdk_client
   ethernet_network_list ['ChefEthernet_3001']
 end
 
 
-# FC network that we'll use for the examples below
+# FC network that will be used for the examples below
 oneview_fc_network 'Fibre Channel A' do
   client client
   data(

--- a/examples/connection_template.rb
+++ b/examples/connection_template.rb
@@ -30,6 +30,22 @@ oneview_ethernet_network 'ChefEthernet_3001' do
   )
 end
 
+# Network set that we'll use for the examples below
+oneview_network_set 'NetworkSet_3001' do
+  client oneview_sdk_client
+  ethernet_network_list ['ChefEthernet_3001']
+end
+
+
+# FC network that we'll use for the examples below
+oneview_fc_network 'Fibre Channel A' do
+  client client
+  data(
+    fabricType: 'FabricAttach',
+    autoLoginRedistribution: true
+  )
+end
+
 oneview_connection_template 'Reset connection ChefEthernet_3001' do
   client client
   associated_ethernet_network 'ChefEthernet_3001'
@@ -55,4 +71,35 @@ end
 oneview_ethernet_network 'ChefEthernet_3001' do
   client client
   action :delete
+end
+
+# Reset FC Network bandwidth parameters
+oneview_connection_template 'Reset connection Fibre Channel A' do
+  client client
+  associated_fc_network 'Fibre Channel A'
+  action :reset
+end
+
+# Set FC Network bandwidth parameters
+oneview_connection_template 'Update connection Fibre Channel A' do
+  client client
+  associated_fc_network 'Fibre Channel A'
+  data(
+    bandwidth: {
+      maximumBandwidth: 1000 * 8, # 8Gb/s
+      typicalBandwidth: 1000 * 8
+    }
+  )
+end
+
+# Set Network Set bandwidth parameters
+oneview_connection_template 'Update network set NetworkSet_3001' do
+  client client
+  associated_network_set 'NetworkSet_3001'
+  data(
+    bandwidth: {
+      maximumBandwidth: 13500,
+      typicalBandwidth: 2200
+    }
+  )
 end

--- a/libraries/resource_providers/api200/connection_template_provider.rb
+++ b/libraries/resource_providers/api200/connection_template_provider.rb
@@ -23,7 +23,7 @@ module OneviewCookbook
 
       def load_connection_templates
         resources_set = [@context.associated_ethernet_network, @context.associated_fcoe_network, @context.associated_fc_network,
-                         @context.associated_network_set].reduce(0) { |sum, value| (value ? 1 : 0) + sum }
+                         @context.associated_network_set].compact.size
         raise 'A single associated resource field must be specified for this action.' if resources_set > 1
         load_template_from_resource(:EthernetNetwork, @context.associated_ethernet_network)
         load_template_from_resource(:FCoENetwork, @context.associated_fcoe_network)

--- a/libraries/resource_providers/api200/connection_template_provider.rb
+++ b/libraries/resource_providers/api200/connection_template_provider.rb
@@ -15,19 +15,34 @@ module OneviewCookbook
   module API200
     # ConnectionTemplate API200 provider
     class ConnectionTemplateProvider < ResourceProvider
-      def load_resource_from_ethernet
-        return unless @context.associated_ethernet_network
+      def load_connection_template
+        if @context.associated_ethernet_network
+          resource_class_name = :EthernetNetwork
+          resource_name = @context.associated_ethernet_network
+        elsif @context.associated_fc_network
+          resource_class_name = :FcNetwork
+          resource_name = @context.associated_fc_network
+        elsif @context.associated_network_set
+          resource_class_name = :NetworkSet
+          resource_name = @context.associated_network_set
+        elsif @context.associated_fcoe_network
+          resource_class_name = :FCoENetwork
+          resource_name = @context.associated_fcoe_network
+        else
+          return
+        end
         @item.data.delete('name')
-        @item['uri'] = load_resource(:EthernetNetwork, @context.associated_ethernet_network, 'connectionTemplateUri')
+        res = load_resource(resource_class_name, resource_name)
+        @item['uri'] = res['connectionTemplateUri']
       end
 
       def create_or_update
-        load_resource_from_ethernet
+        load_connection_template
         super
       end
 
       def reset
-        load_resource_from_ethernet
+        load_connection_template
         @item['bandwidth'] = resource_named(:ConnectionTemplate).get_default(@item.client)['bandwidth']
         create_or_update
       end

--- a/libraries/resource_providers/api200/connection_template_provider.rb
+++ b/libraries/resource_providers/api200/connection_template_provider.rb
@@ -15,17 +15,17 @@ module OneviewCookbook
   module API200
     # ConnectionTemplate API200 provider
     class ConnectionTemplateProvider < ResourceProvider
-      def load_connection_template(resource_type, resource_name)
+      def load_template_from_resource(resource_type, resource_name)
         return unless resource_name
         @item.data.delete('name')
         @item['uri'] = load_resource(resource_type, resource_name, :connectionTemplateUri)
       end
 
       def load_connection_templates
-        load_connection_template(:EthernetNetwork, @context.associated_ethernet_network)
-        load_connection_template(:FCoENetwork, @context.associated_fcoe_network)
-        load_connection_template(:FCNetwork, @context.associated_fc_network)
-        load_connection_template(:NetworkSet, @context.associated_network_set)
+        load_template_from_resource(:EthernetNetwork, @context.associated_ethernet_network)
+        load_template_from_resource(:FCoENetwork, @context.associated_fcoe_network)
+        load_template_from_resource(:FCNetwork, @context.associated_fc_network)
+        load_template_from_resource(:NetworkSet, @context.associated_network_set)
       end
 
       def create_or_update

--- a/libraries/resource_providers/api200/connection_template_provider.rb
+++ b/libraries/resource_providers/api200/connection_template_provider.rb
@@ -15,34 +15,26 @@ module OneviewCookbook
   module API200
     # ConnectionTemplate API200 provider
     class ConnectionTemplateProvider < ResourceProvider
-      def load_connection_template
-        if @context.associated_ethernet_network
-          resource_class_name = :EthernetNetwork
-          resource_name = @context.associated_ethernet_network
-        elsif @context.associated_fc_network
-          resource_class_name = :FcNetwork
-          resource_name = @context.associated_fc_network
-        elsif @context.associated_network_set
-          resource_class_name = :NetworkSet
-          resource_name = @context.associated_network_set
-        elsif @context.associated_fcoe_network
-          resource_class_name = :FCoENetwork
-          resource_name = @context.associated_fcoe_network
-        else
-          return
-        end
+      def load_connection_template(resource_type, resource_name)
+        return unless resource_name
         @item.data.delete('name')
-        res = load_resource(resource_class_name, resource_name)
-        @item['uri'] = res['connectionTemplateUri']
+        @item['uri'] = load_resource(resource_type, resource_name, :connectionTemplateUri)
+      end
+
+      def load_connection_templates
+        load_connection_template(:EthernetNetwork, @context.associated_ethernet_network)
+        load_connection_template(:FCoENetwork, @context.associated_fcoe_network)
+        load_connection_template(:FCNetwork, @context.associated_fc_network)
+        load_connection_template(:NetworkSet, @context.associated_network_set)
       end
 
       def create_or_update
-        load_connection_template
+        load_connection_templates
         super
       end
 
       def reset
-        load_connection_template
+        load_connection_templates
         @item['bandwidth'] = resource_named(:ConnectionTemplate).get_default(@item.client)['bandwidth']
         create_or_update
       end

--- a/libraries/resource_providers/api200/connection_template_provider.rb
+++ b/libraries/resource_providers/api200/connection_template_provider.rb
@@ -23,8 +23,8 @@ module OneviewCookbook
 
       def load_connection_templates
         resources_set = [@context.associated_ethernet_network, @context.associated_fcoe_network, @context.associated_fc_network,
-                         @context.associated_network_set].reduce(0) { |sum, value| (value ? 1 : 0) + sum } == 1
-        raise 'A single associated resource field must be specified for this action.' unless resources_set
+                         @context.associated_network_set].reduce(0) { |sum, value| (value ? 1 : 0) + sum }
+        raise 'A single associated resource field must be specified for this action.' if resources_set > 1
         load_template_from_resource(:EthernetNetwork, @context.associated_ethernet_network)
         load_template_from_resource(:FCoENetwork, @context.associated_fcoe_network)
         load_template_from_resource(:FCNetwork, @context.associated_fc_network)

--- a/libraries/resource_providers/api200/connection_template_provider.rb
+++ b/libraries/resource_providers/api200/connection_template_provider.rb
@@ -22,6 +22,9 @@ module OneviewCookbook
       end
 
       def load_connection_templates
+        resources_set = [@context.associated_ethernet_network, @context.associated_fcoe_network, @context.associated_fc_network,
+                         @context.associated_network_set].reduce(0) { |sum, value| (value ? 1 : 0) + sum } == 1
+        raise 'A single associated resource field must be specified for this action.' unless resources_set
         load_template_from_resource(:EthernetNetwork, @context.associated_ethernet_network)
         load_template_from_resource(:FCoENetwork, @context.associated_fcoe_network)
         load_template_from_resource(:FCNetwork, @context.associated_fc_network)

--- a/resources/connection_template.rb
+++ b/resources/connection_template.rb
@@ -14,6 +14,9 @@ OneviewCookbook::ResourceBaseProperties.load(self)
 default_action :update
 
 property :associated_ethernet_network, String
+property :associated_fc_network, String
+property :associated_network_set, String
+property :associated_fcoe_network, String
 
 action :update do
   OneviewCookbook::Helper.do_resource_action(self, :ConnectionTemplate, :create_or_update)

--- a/spec/fixtures/cookbooks/oneview_test/recipes/connection_template_update.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/connection_template_update.rb
@@ -25,3 +25,39 @@ oneview_connection_template 'ConnectionTemplate1' do
   )
   action :update
 end
+
+oneview_connection_template 'ConnectionTemplate2' do
+  client node['oneview_test']['client']
+  associated_fc_network 'FCNetwork1'
+  data(
+    bandwidth: {
+      maximumBandwidth: 9999,
+      typicalBandwidth: 1111
+    }
+  )
+  action :update
+end
+
+oneview_connection_template 'ConnectionTemplate3' do
+  client node['oneview_test']['client']
+  associated_fcoe_network 'FCoENetwork1'
+  data(
+    bandwidth: {
+      maximumBandwidth: 9999,
+      typicalBandwidth: 1111
+    }
+  )
+  action :update
+end
+
+oneview_connection_template 'ConnectionTemplate4' do
+  client node['oneview_test']['client']
+  associated_network_set 'NetworkSet1'
+  data(
+    bandwidth: {
+      maximumBandwidth: 9999,
+      typicalBandwidth: 1111
+    }
+  )
+  action :update
+end

--- a/spec/unit/resources/connection_template/update_spec.rb
+++ b/spec/unit/resources/connection_template/update_spec.rb
@@ -17,11 +17,13 @@ describe 'oneview_test::connection_template_update' do
     allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:exists?).and_return(true)
     allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:like?).and_return(false)
-    allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:update).and_return(true)
+    update_count = 0
+    allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:update) { |_i| update_count += 1 }
     expect(real_chef_run).to update_oneview_connection_template('ConnectionTemplate1')
     expect(real_chef_run).to update_oneview_connection_template('ConnectionTemplate2')
     expect(real_chef_run).to update_oneview_connection_template('ConnectionTemplate3')
     expect(real_chef_run).to update_oneview_connection_template('ConnectionTemplate4')
+    expect(update_count).to eq(4)
   end
 
   it 'leave it as is since it is up to date' do

--- a/spec/unit/resources/connection_template/update_spec.rb
+++ b/spec/unit/resources/connection_template/update_spec.rb
@@ -18,7 +18,7 @@ describe 'oneview_test::connection_template_update' do
     allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:like?).and_return(false)
     update_count = 0
-    allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:update) { |_i| update_count += 1 }
+    allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:update) { update_count += 1 }
     expect(real_chef_run).to update_oneview_connection_template('ConnectionTemplate1')
     expect(real_chef_run).to update_oneview_connection_template('ConnectionTemplate2')
     expect(real_chef_run).to update_oneview_connection_template('ConnectionTemplate3')

--- a/spec/unit/resources/connection_template/update_spec.rb
+++ b/spec/unit/resources/connection_template/update_spec.rb
@@ -7,21 +7,39 @@ describe 'oneview_test::connection_template_update' do
 
   it 'updates it searching by the Ethernet Network' do
     fake_ethernet = OneviewSDK::EthernetNetwork.new(@client, connectionTemplateUri: 'fake/connection-template')
+    fake_fc = OneviewSDK::FCNetwork.new(@client, connectionTemplateUri: 'fake/connection-template')
+    fake_fcoe = OneviewSDK::FCoENetwork.new(@client, connectionTemplateUri: 'fake/connection-template')
+    fake_net = OneviewSDK::NetworkSet.new(@client, connectionTemplateUri: 'fake/connection-template')
     allow(OneviewSDK::EthernetNetwork).to receive(:find_by).and_return([fake_ethernet])
+    allow(OneviewSDK::FCNetwork).to receive(:find_by).and_return([fake_fc])
+    allow(OneviewSDK::FCoENetwork).to receive(:find_by).and_return([fake_fcoe])
+    allow(OneviewSDK::NetworkSet).to receive(:find_by).and_return([fake_net])
     allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:exists?).and_return(true)
     allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:like?).and_return(false)
-    expect_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:update).and_return(true)
+    allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:update).and_return(true)
     expect(real_chef_run).to update_oneview_connection_template('ConnectionTemplate1')
+    expect(real_chef_run).to update_oneview_connection_template('ConnectionTemplate2')
+    expect(real_chef_run).to update_oneview_connection_template('ConnectionTemplate3')
+    expect(real_chef_run).to update_oneview_connection_template('ConnectionTemplate4')
   end
 
   it 'leave it as is since it is up to date' do
     fake_ethernet = OneviewSDK::EthernetNetwork.new(@client, connectionTemplateUri: 'fake/connection-template')
+    fake_fc = OneviewSDK::FCNetwork.new(@client, connectionTemplateUri: 'fake/connection-template')
+    fake_fcoe = OneviewSDK::FCoENetwork.new(@client, connectionTemplateUri: 'fake/connection-template')
+    fake_net = OneviewSDK::NetworkSet.new(@client, connectionTemplateUri: 'fake/connection-template')
     allow(OneviewSDK::EthernetNetwork).to receive(:find_by).and_return([fake_ethernet])
+    allow(OneviewSDK::FCNetwork).to receive(:find_by).and_return([fake_fc])
+    allow(OneviewSDK::FCoENetwork).to receive(:find_by).and_return([fake_fcoe])
+    allow(OneviewSDK::NetworkSet).to receive(:find_by).and_return([fake_net])
     allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:exists?).and_return(true)
     allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:like?).and_return(true)
     expect_any_instance_of(OneviewSDK::ConnectionTemplate).to_not receive(:update)
     expect(real_chef_run).to update_oneview_connection_template('ConnectionTemplate1')
+    expect(real_chef_run).to update_oneview_connection_template('ConnectionTemplate2')
+    expect(real_chef_run).to update_oneview_connection_template('ConnectionTemplate3')
+    expect(real_chef_run).to update_oneview_connection_template('ConnectionTemplate4')
   end
 end


### PR DESCRIPTION
### Description
As described in the issue #218 , `ConnectionTemplateProvider` now supports `EthernetNetwork`, `FcNetwork`, `NetworkSet` and `FCoENetwork` 
Rubocop seems to be happy, manipulation with resources works fine - tested with OneView Synergy edition.

Fixes #218

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).

