### PR TITLE
Raise error after failed retrieve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-## 2.2.0
+## Unreleased (proposed: 2.2.0)
 Adds support to API300 HPE Synergy Image Streamer resources:
   - image_streamer_artifact_bundle
   - image_streamer_os_build_plan
+
+Bug Fixes:
+- [#220](https://github.com/HewlettPackard/oneview-chef/issues/220) Raise error after failed retrieve
 
 ## 2.1.0
 - [#162](https://github.com/HewlettPackard/oneview-chef/issues/162) Add server_profile_template property to oneview_server_profile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Adds support to API300 HPE Synergy Image Streamer resources:
   - image_streamer_os_build_plan
 
 Bug Fixes:
-- [#220](https://github.com/HewlettPackard/oneview-chef/issues/220) Raise error after failed retrieve
+- [#220](https://github.com/HewlettPackard/oneview-chef/issues/220) Raise "not found" error after failed retrieval of resource
 
 ## 2.1.0
 - [#162](https://github.com/HewlettPackard/oneview-chef/issues/162) Add server_profile_template property to oneview_server_profile

--- a/libraries/resource_providers/api200/enclosure_group_provider.rb
+++ b/libraries/resource_providers/api200/enclosure_group_provider.rb
@@ -44,7 +44,7 @@ module OneviewCookbook
       end
 
       def set_script
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         return Chef::Log.info("#{@resource_name} '#{@name}' script is up to date") if @item.get_script.eql?(@context.script)
         Chef::Log.debug "#{@resource_name} '#{@name}' Chef resource differs from OneView resource."
         @context.converge_by "Updated script for #{@resource_name} '#{@name}'" do

--- a/libraries/resource_providers/api200/enclosure_provider.rb
+++ b/libraries/resource_providers/api200/enclosure_provider.rb
@@ -24,7 +24,7 @@ module OneviewCookbook
       end
 
       def reconfigure
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         if ['NotReapplyingConfiguration', 'ReapplyingConfigurationFailed', ''].include? @item['reconfigurationState']
           @context.converge_by "#{@resource_name} '#{@name}' was reconfigured." do
             @item.configuration
@@ -35,7 +35,7 @@ module OneviewCookbook
       end
 
       def refresh
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         refresh_ready = ['RefreshFailed', 'NotRefreshing', ''].include? @item['refreshState']
         return Chef::Log.info("#{@resource_name} '#{@name}' refresh is already running. State: #{@item['refreshState']}") unless refresh_ready
         @context.converge_by "#{@resource_name} '#{@name}' was refreshed." do

--- a/libraries/resource_providers/api200/ethernet_network_provider.rb
+++ b/libraries/resource_providers/api200/ethernet_network_provider.rb
@@ -41,7 +41,7 @@ module OneviewCookbook
       end
 
       def reset_connection_template
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         klass = resource_named(:ConnectionTemplate)
         update_connection_template(bandwidth: klass.get_default(@item.client)['bandwidth'])
       end

--- a/libraries/resource_providers/api200/interconnect_provider.rb
+++ b/libraries/resource_providers/api200/interconnect_provider.rb
@@ -17,7 +17,7 @@ module OneviewCookbook
     class InterconnectProvider < ResourceProvider
       def set_uid_light
         raise "Unspecified property: 'uid_light_state'. Please set it before attempting this action." unless @context.uid_light_state
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         # Impossible to verify this value programatically
         @context.converge_by "Set #{@resource_name} '#{@name}' UID light to #{@context.uid_light_state.upcase}" do
           @item.patch('replace', '/uidState', @context.uid_light_state.capitalize)
@@ -26,7 +26,7 @@ module OneviewCookbook
 
       def set_power_state
         raise "Unspecified property: 'power_state'. Please set it before attempting this action." unless @context.power_state
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         if @item['powerState'] != @context.power_state
           @context.converge_by "Power #{@resource_name} '#{@name}' #{@context.power_state.upcase}" do
             @item.patch('replace', '/powerState', @context.power_state.capitalize)
@@ -37,7 +37,7 @@ module OneviewCookbook
       end
 
       def reset
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         # Nothing to verify
         @context.converge_by "Reset #{@resource_name} '#{@name}'" do
           @item.patch('replace', '/deviceResetState', 'Reset')
@@ -45,7 +45,7 @@ module OneviewCookbook
       end
 
       def reset_port_protection
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         # Nothing to verify
         @context.converge_by "Reset #{@resource_name} '#{@name}' port protection" do
           @item.reset_port_protection
@@ -56,7 +56,7 @@ module OneviewCookbook
         raise "Unspecified property: 'port_options'. Please set it before attempting this action." unless @context.port_options
         parsed_port_options = convert_keys(@context.port_options, :to_s)
         raise "Required value \"name\" for 'port_options' not specified" unless parsed_port_options['name']
-        raise "#{@resource_name} '#{@item['name']}' not found!" unless @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         target_port = (@item['ports'].select { |port| port['name'] == parsed_port_options['name'] }).first
         raise "Could not find port: #{parsed_port_options['name']}" unless target_port
         # Update only if there are options that differ from the current ones

--- a/libraries/resource_providers/api200/logical_enclosure_provider.rb
+++ b/libraries/resource_providers/api200/logical_enclosure_provider.rb
@@ -37,7 +37,7 @@ module OneviewCookbook
       end
 
       def update_from_group
-        raise "LogicalEnclosure '#{@name}' not found!" unless @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         return if @item['state'] == 'Consistent'
         @context.converge_by "Update LogicalEnclosure '#{@name}' from group" do
           @item.update_from_group
@@ -45,7 +45,7 @@ module OneviewCookbook
       end
 
       def reconfigure
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         @item['enclosureUris'].each do |enclosure_uri|
           enc_state = load_resource(:Enclosure, { uri: enclosure_uri }, 'reconfigurationState')
           next unless ['NotReapplyingConfiguration', 'ReapplyingConfigurationFailed', ''].include?(enc_state)
@@ -59,7 +59,7 @@ module OneviewCookbook
       end
 
       def set_script
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         if @item.get_script.eql? @context.script
           Chef::Log.info("#{@resource_name} '#{@name}' script is up to date")
         else

--- a/libraries/resource_providers/api200/logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api200/logical_interconnect_provider.rb
@@ -51,7 +51,7 @@ module OneviewCookbook
       # Handle the most types of updates
       def update_handler(action, key = nil)
         temp = key ? { key.to_s => Marshal.load(Marshal.dump(@item[key])) } : Marshal.load(Marshal.dump(@item.data))
-        raise "Resource not found: Action '#{action}' cannot be performed since #{@resource_name} '#{@name}' was not found." unless @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         return Chef::Log.info("#{@resource_name} '#{@name}' is up to date") if @item.like?(temp)
         Chef::Log.info "#{action.to_s.capitalize.tr('_', ' ')} #{@resource_name} '#{@name}'"
         Chef::Log.debug "#{@resource_name} '#{@name}' Chef resource differs from OneView resource."
@@ -65,7 +65,7 @@ module OneviewCookbook
       end
 
       def firmware_handler(action)
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         current_firmware = @item.get_firmware
         @context.firmware_data['command'] = action
         dif_values = @context.firmware_data.select { |k, v| current_firmware[k] != v }
@@ -109,7 +109,7 @@ module OneviewCookbook
       end
 
       def update_internal_networks
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         @context.internal_networks.collect! { |n| load_resource(:EthernetNetwork, n) }
         if @item['internalNetworkUris'].sort == @context.internal_networks.collect { |x| x['uri'] }.sort
           Chef::Log.info("Internal networks for #{@resource_name} #{@name} are up to date")
@@ -166,7 +166,7 @@ module OneviewCookbook
       end
 
       def update_from_group
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         # Nothing to verify
         @context.converge_by "Update #{@resource_name} '#{@name}' from group" do
           @item.compliance
@@ -174,7 +174,7 @@ module OneviewCookbook
       end
 
       def reapply_configuration
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         # Nothing to verify
         @context.converge_by "Reapply configuration in #{@resource_name} '#{@name}'" do
           @item.configuration

--- a/libraries/resource_providers/api200/logical_switch_provider.rb
+++ b/libraries/resource_providers/api200/logical_switch_provider.rb
@@ -61,7 +61,7 @@ module OneviewCookbook
       end
 
       def refresh
-        raise "ResourceNotFound: #{@resource_name} '#{@name}' could not be found" unless @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         @context.converge_by "Refreshed #{@resource_name} '#{@name}'" do
           @item.refresh_state
         end

--- a/libraries/resource_providers/api200/managed_san_provider.rb
+++ b/libraries/resource_providers/api200/managed_san_provider.rb
@@ -16,7 +16,7 @@ module OneviewCookbook
     # ManagedSAN API200 provider
     class ManagedSANProvider < ResourceProvider
       def refresh
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         refresh_ready = ['RefreshFailed', 'NotRefreshing', ''].include? @item['refreshState']
         return Chef::Log.info("#{@resource_name} '#{@name}' refresh is already running. State: #{@item['refreshState']}") unless refresh_ready
         @context.converge_by "#{@resource_name} '#{@name}' was refreshed." do
@@ -26,7 +26,7 @@ module OneviewCookbook
 
       def set_policy
         temp = Marshal.load(Marshal.dump(@item['sanPolicy']))
-        raise "ResourceNotFound: #{@resource_name} '#{@name}' could not be found" unless @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         return Chef::Log.info "#{@resource_name} '#{@name}' san policy is up to date" if temp.all? { |k, v| v == @item['sanPolicy'][k] }
         Chef::Log.info "Updating #{@resource_name} '#{@name}' san policy"
         @context.converge_by "#{@resource_name} '#{@name}' san policy updated" do
@@ -36,7 +36,7 @@ module OneviewCookbook
 
       def set_public_attributes
         temp = Marshal.load(Marshal.dump(@item['publicAttributes']))
-        raise "ResourceNotFound: #{@resource_name} '#{@name}' could not be found" unless @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         # compares two hashes
         results = []
         temp_attributes = temp.sort_by { |element| element['name'] }

--- a/libraries/resource_providers/api200/network_set_provider.rb
+++ b/libraries/resource_providers/api200/network_set_provider.rb
@@ -30,7 +30,7 @@ module OneviewCookbook
         if @item.exists?
           create_if_exists(temp)
         else
-          Chef::Log.info "Create #{resource_name} '#{name}'"
+          Chef::Log.info "Creating #{resource_name} '#{name}'"
           @context.converge_by "Create #{resource_name} '#{name}'" do
             @item.create
           end

--- a/libraries/resource_providers/api200/rack_provider.rb
+++ b/libraries/resource_providers/api200/rack_provider.rb
@@ -28,7 +28,7 @@ module OneviewCookbook
 
       def add_to_rack
         raise "Unspecified property: 'mount_options'. Please set it before attempting this action." unless @context.mount_options
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         mount_item = load_mount_item
         rack_uris = @item['rackMounts'].collect { |i| i['mountUri'] }
         options = convert_keys(@context.mount_options, :to_s).reject! { |i| ['type', 'name'].include?(i) }
@@ -50,7 +50,7 @@ module OneviewCookbook
 
       def remove_from_rack
         raise "Unspecified property: 'mount_options'. Please set it before attempting this action." unless @context.mount_options
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         mount_item = load_mount_item
         rack_uris = @item['rackMounts'].collect { |i| i['mountUri'] }
         return Chef::Log.info("Item '#{mount_item['name']}' in '#{@name}' is up to date") unless rack_uris.include? mount_item['uri']

--- a/libraries/resource_providers/api200/server_hardware_provider.rb
+++ b/libraries/resource_providers/api200/server_hardware_provider.rb
@@ -16,7 +16,7 @@ module OneviewCookbook
     # ServerHardware API200 provider
     class ServerHardwareProvider < ResourceProvider
       def update_ilo_firmware
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         @context.converge_by "Updated iLO firmware on #{@resource_name} '#{@name}'" do
           @item.update_ilo_firmware
         end
@@ -25,7 +25,7 @@ module OneviewCookbook
       def set_power_state
         raise "Unspecified property: 'power_state'. Please set it before attempting this action." unless @context.power_state
         ps = @context.power_state.to_s.downcase
-        raise "#{@resource_name} '#{@name}' not found!" unless @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         if @item['powerState'].casecmp(ps).zero?
           Chef::Log.info("#{@resource_name} '#{@name}' is already powered #{ps}")
         else
@@ -36,7 +36,7 @@ module OneviewCookbook
       end
 
       def refresh
-        raise "#{@resource_name} '#{@name}' not found!" unless @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         refresh_ready = ['RefreshFailed', 'NotRefreshing', ''].include? @item['refreshState']
         return Chef::Log.info("#{@resource_name} '#{@name}' refresh is already running.") unless refresh_ready
         @context.converge_by "Refresh #{@resource_name} '#{@name}'." do

--- a/libraries/resource_providers/api200/server_profile_provider.rb
+++ b/libraries/resource_providers/api200/server_profile_provider.rb
@@ -65,7 +65,7 @@ module OneviewCookbook
       end
 
       def update_from_template
-        raise "#{@resource_name} '#{@item['name']}' was not found!" unless @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         if @item['templateCompliance'] == 'Compliant'
           Chef::Log.info("#{@resource_name} '#{@item['name']}' is up to date")
         else

--- a/libraries/resource_providers/api200/server_profile_template_provider.rb
+++ b/libraries/resource_providers/api200/server_profile_template_provider.rb
@@ -38,8 +38,7 @@ module OneviewCookbook
 
       def new_profile
         raise "Unspecified property: 'profile_name'. Please set it before attempting this action." unless @context.profile_name
-        raise "Resource not found: '#{@name}' could not be found." unless @item.exists?
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         @item = @item.new_profile(@context.profile_name)
         create_if_missing
       end

--- a/libraries/resource_providers/api200/storage_system_provider.rb
+++ b/libraries/resource_providers/api200/storage_system_provider.rb
@@ -48,7 +48,7 @@ module OneviewCookbook
       def edit_credentials
         temp = {}
         temp['credentials'] = Marshal.load(Marshal.dump(@item.data))
-        return Chef::Log.error("\nCredentials not edited. #{@resource_name} '#{@name}' could not be found.\n") unless @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         temp['credentials']['ip_hostname'] ||= @item['credentials']['ip_hostname']
         Chef::Log.info "Updating #{@resource_name} '#{@name}' credentials"
         @context.converge_by "Update #{@resource_name} '#{@name}' credentials" do

--- a/libraries/resource_providers/api200/switch_provider.rb
+++ b/libraries/resource_providers/api200/switch_provider.rb
@@ -17,7 +17,7 @@ module OneviewCookbook
     class SwitchProvider < ResourceProvider
       def remove
         # Checks if the switch was already removed from oneview
-        return Chef::Log.info "#{@resource_name} '#{@name}' is already in the inventory." unless @item.retrieve! && 'Inventory' != @item['state']
+        return Chef::Log.info "#{@resource_name} '#{@name}' is already in the inventory." unless @item.retrieve! && @item['state'] != 'Inventory'
         @context.converge_by "Removed #{@resource_name} '#{@name}'" do
           @item.remove
         end

--- a/libraries/resource_providers/api200/volume_provider.rb
+++ b/libraries/resource_providers/api200/volume_provider.rb
@@ -79,9 +79,8 @@ module OneviewCookbook
 
       def create_snapshot
         raise "UnspecifiedProperty: 'snapshot_data'. Please set it before attempting this action." unless @context.snapshot_data
-        raise "ResourceNotFound: #{@resource_name} '#{@item['name']}'" unless @item.exists?
         temp = convert_keys(Marshal.load(Marshal.dump(@context.snapshot_data)), :to_s)
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         snapshot = @item.get_snapshot(temp['name'])
         return Chef::Log.info "Volume snapshot '#{temp['name']}' already exists" unless snapshot.empty?
         Chef::Log.info "Creating oneview_volume '#{@name}' snapshot"
@@ -92,9 +91,8 @@ module OneviewCookbook
 
       def delete_snapshot
         raise "UnspecifiedProperty: 'snapshot_data'. Please set it before attempting this action." unless @context.snapshot_data
-        raise "ResourceNotFound: #{@resource_name} '#{@item['name']}'" unless @item.exists?
         temp = convert_keys(Marshal.load(Marshal.dump(@context.snapshot_data)), :to_s)
-        @item.retrieve!
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         snapshot = @item.get_snapshot(temp['name'])
         return Chef::Log.info "Volume snapshot '#{temp['name']}' already exists" if snapshot.empty?
         Chef::Log.info "Deleting oneview_volume_snapshot '#{@name}'"

--- a/libraries/resource_providers/api300/c7000/scope_provider.rb
+++ b/libraries/resource_providers/api300/c7000/scope_provider.rb
@@ -21,7 +21,7 @@ module OneviewCookbook
         def change_resource_assignments
           add_or_remove = @context.add.any? || @context.remove.any?
           raise "Unspecified properties: 'add' and 'remove'. Please set at least one before attempting this action." unless add_or_remove
-          @item.retrieve!
+          @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
           values_to_add = build_resource_list
           values_to_remove = build_resource_list(:remove)
           return Chef::Log.info("#{@resource_name} '#{@name}' is up to date") if values_to_add.empty? && values_to_remove.empty?

--- a/libraries/resource_providers/api300/c7000/switch_provider.rb
+++ b/libraries/resource_providers/api300/c7000/switch_provider.rb
@@ -24,7 +24,7 @@ module OneviewCookbook
           invalid_param = @context.operation.nil? || @context.path.nil?
           raise "InvalidParameters: Parameters 'operation' and 'path' must be set for patch" if invalid_param
           # TODO: Add support to Scopes (Currently not supported by oneview-sdk gem 3.1.0)
-          @item.retrieve!
+          @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
           @context.converge_by "Performing '#{@context.operation}' at #{@context.path} with #{@context.value} in #{@resource_name} '#{@name}'" do
             body = if @context.value
                      { op: @context.operation, path: @context.path, value: @context.value }

--- a/libraries/resource_providers/api300/synergy/fabric_provider.rb
+++ b/libraries/resource_providers/api300/synergy/fabric_provider.rb
@@ -17,7 +17,7 @@ module OneviewCookbook
       # Fabric API300 Synergy provider
       class FabricProvider < ResourceProvider
         def set_reserved_vlan_range
-          @item.retrieve!
+          @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
           options = { 'reservedVlanRange' => convert_keys(@context.reserved_vlan_range, :to_s) }
           options['reservedVlanRange']['type'] ||= 'vlan-pool'
           if @item.like? options

--- a/libraries/resource_providers/api300/synergy/sas_interconnect_provider.rb
+++ b/libraries/resource_providers/api300/synergy/sas_interconnect_provider.rb
@@ -25,7 +25,7 @@ module OneviewCookbook
         end
 
         def refresh
-          @item.retrieve!
+          @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
           refresh_ready = ['RefreshFailed', 'NotRefreshing', ''].include? @item['refreshState']
           return Chef::Log.info("#{@resource_name} '#{@name}' refresh is already running. State: #{@item['refreshState']}") unless refresh_ready
           @context.converge_by "#{@resource_name} '#{@name}' was refreshed." do
@@ -36,7 +36,7 @@ module OneviewCookbook
         protected
 
         def reset_handler(path)
-          @item.retrieve!
+          @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
           # Nothing to verify
           @context.converge_by "#{path.delete('/').gsub(/([A-Z])/, ' \1').capitalize} #{@resource_name} '#{@name}'" do
             @item.patch('replace', path, 'Reset')

--- a/libraries/resource_providers/api300/synergy/sas_logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api300/synergy/sas_logical_interconnect_provider.rb
@@ -30,7 +30,7 @@ module OneviewCookbook
           raise 'InvalidParameters: Old drive enclosure name or serial number must be set and should be valid' unless old_sn
           new_sn = @item.data.delete('newSerialNumber') || get_serial_number(@context.new_drive_enclosure)
           raise 'InvalidParameters: New drive enclosure name or serial number must be set and should be valid' unless new_sn
-          raise "ResourceNotFound: The '#{@resource_name}' '#{@name}' could not be found" unless @item.retrieve!
+          @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
           @context.converge_by "Replacing drive enclosure '#{old_sn}' by '#{new_sn}'" do
             @item.replace_drive_enclosure(old_sn, new_sn)
           end

--- a/libraries/resource_providers/image_streamer/api300/artifact_bundle_provider.rb
+++ b/libraries/resource_providers/image_streamer/api300/artifact_bundle_provider.rb
@@ -39,7 +39,7 @@ module OneviewCookbook
 
         def update_name
           raise 'This action requires the new_name field to be specified.' unless @context.new_name
-          raise "#{@resource_name} #{@name} does not exist in the appliance. Cannot run update_name action." unless @item.retrieve!
+          @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
           return Chef::Log.info("#{@resource_name} '#{@name}' is up to date") if @item['name'] == @context.new_name
           new_name_in_use = resource_named(:ArtifactBundle).new(@item.client, name: @context.new_name).exists?
           raise "ArtifactBundle name '#{@context.new_name}' is already in use." if new_name_in_use
@@ -51,7 +51,7 @@ module OneviewCookbook
 
         def download
           raise "#{@resource_name} #{@context.file_path} must be specified for this action" unless @context.file_path
-          raise "#{@resource_name} #{@name} does not exist in the appliance. Cannot run download action." unless @item.retrieve!
+          @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
           return Chef::Log.info("#{@resource_name} '#{@name}' file already exists in specified location.") if File.file?(@context.file_path)
           @context.converge_by "Download #{@resource_name}'s '#{@name}' to #{@context.file_path} completed successfully" do
             @item.download(@context.file_path)

--- a/libraries/resource_providers/image_streamer/api300/golden_image_provider.rb
+++ b/libraries/resource_providers/image_streamer/api300/golden_image_provider.rb
@@ -45,7 +45,7 @@ module OneviewCookbook
         def download_validation
           raise 'InvalidFilePath: The file_path was not specified. Please set it and try again' unless @context.file_path
           return Chef::Log.info("#{@resource_type} '#{@name}' file '#{@context.file_path}' already exist") if File.exist?(@context.file_path)
-          raise "ResourceNotFound: #{@resource_type} '#{@name}' could not be found" unless @item.retrieve!
+          @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         end
 
         def download

--- a/spec/unit/resources/enclosure/reconfigure_spec.rb
+++ b/spec/unit/resources/enclosure/reconfigure_spec.rb
@@ -23,4 +23,9 @@ describe 'oneview_test::enclosure_reconfigure' do
     expect_any_instance_of(OneviewSDK::Enclosure).to receive(:configuration).and_return(true)
     expect(real_chef_run).to reconfigure_oneview_enclosure('Enclosure1')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::Enclosure).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/enclosure/refresh_spec.rb
+++ b/spec/unit/resources/enclosure/refresh_spec.rb
@@ -23,4 +23,9 @@ describe 'oneview_test::enclosure_refresh' do
     expect_any_instance_of(OneviewSDK::Enclosure).to receive(:set_refresh_state).and_return(true)
     expect(real_chef_run).to refresh_oneview_enclosure('Enclosure1')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::Enclosure).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/enclosure_group/set_script_spec.rb
+++ b/spec/unit/resources/enclosure_group/set_script_spec.rb
@@ -17,4 +17,9 @@ describe 'oneview_test::enclosure_group_set_script' do
     expect_any_instance_of(OneviewSDK::EnclosureGroup).to receive(:set_script).with('hello, world!').and_return(true)
     expect(real_chef_run).to set_oneview_enclosure_group_script('EnclosureGroup3')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::EnclosureGroup).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/ethernet_network/reset_connection_template_spec.rb
+++ b/spec/unit/resources/ethernet_network/reset_connection_template_spec.rb
@@ -30,4 +30,9 @@ describe 'oneview_test::ethernet_network_reset_connection_template' do
     expect_any_instance_of(OneviewSDK::ConnectionTemplate).to_not receive(:update)
     expect(real_chef_run).to reset_oneview_ethernet_network_connection_template('EthernetNetwork4')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/fabric/fabric_set_reserved_vlan_range_spec.rb
+++ b/spec/unit/resources/fabric/fabric_set_reserved_vlan_range_spec.rb
@@ -12,11 +12,16 @@ describe 'oneview_test_api300_synergy::fabric_set_reserved_vlan_range' do
     }
   end
 
-  it 'updates it when it does not matches' do
+  it 'updates it when it does not match' do
     expect_any_instance_of(OneviewSDK::API300::Synergy::Fabric).to receive(:retrieve!).and_return(true)
     expect_any_instance_of(OneviewSDK::API300::Synergy::Fabric).to receive(:like?).and_return(false)
     expect_any_instance_of(OneviewSDK::API300::Synergy::Fabric).to receive(:set_reserved_vlan_range)
       .with(range).and_return(range)
     expect(real_chef_run).to set_oneview_fabric_reserved_vlan_range('Fabric1')
+  end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::API300::Synergy::Fabric).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 end

--- a/spec/unit/resources/interconnect/reset_spec.rb
+++ b/spec/unit/resources/interconnect/reset_spec.rb
@@ -9,4 +9,9 @@ describe 'oneview_test::interconnect_reset' do
     expect_any_instance_of(OneviewSDK::Interconnect).to receive(:patch).with('replace', '/deviceResetState', 'Reset')
     expect(real_chef_run).to reset_oneview_interconnect('Interconnect3')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/interconnect/set_power_state_spec.rb
+++ b/spec/unit/resources/interconnect/set_power_state_spec.rb
@@ -9,6 +9,11 @@ describe 'oneview_test::interconnect_set_power_state' do
     expect_any_instance_of(OneviewSDK::Interconnect).to receive(:patch).with('replace', '/powerState', anything)
     expect(real_chef_run).to set_oneview_interconnect_power_state('Interconnect2')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end
 
 describe 'oneview_test::interconnect_set_power_state_invalid' do

--- a/spec/unit/resources/interconnect/set_uid_light_spec.rb
+++ b/spec/unit/resources/interconnect/set_uid_light_spec.rb
@@ -9,6 +9,11 @@ describe 'oneview_test::interconnect_set_uid_light' do
     expect_any_instance_of(OneviewSDK::Interconnect).to receive(:patch).with('replace', '/uidState', anything)
     expect(real_chef_run).to set_oneview_interconnect_uid_light('Interconnect1')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end
 
 describe 'oneview_test::interconnect_set_uid_light_invalid' do

--- a/spec/unit/resources/interconnect/update_port_spec.rb
+++ b/spec/unit/resources/interconnect/update_port_spec.rb
@@ -44,6 +44,11 @@ describe 'oneview_test::interconnect_update_port' do
     allow_any_instance_of(OneviewSDK::Interconnect).to receive(:[]).with('ports').and_return(ports)
     expect { real_chef_run }.to raise_error(RuntimeError, /Could not find port/)
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end
 
 describe 'oneview_test::interconnect_update_port_invalid' do

--- a/spec/unit/resources/logical_enclosure/reconfigure_spec.rb
+++ b/spec/unit/resources/logical_enclosure/reconfigure_spec.rb
@@ -56,4 +56,9 @@ describe 'oneview_test::logical_enclosure_reconfigure' do
     expect_any_instance_of(OneviewSDK::LogicalEnclosure).to_not receive(:reconfigure)
     expect(real_chef_run).to reconfigure_oneview_logical_enclosure('LogicalEnclosure1')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::LogicalEnclosure).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/logical_enclosure/set_script_spec.rb
+++ b/spec/unit/resources/logical_enclosure/set_script_spec.rb
@@ -17,4 +17,9 @@ describe 'oneview_test::logical_enclosure_set_script' do
     expect_any_instance_of(OneviewSDK::LogicalEnclosure).to receive(:set_script).with('script commands')
     expect(real_chef_run).to set_oneview_logical_enclosure_script('LogicalEnclosure1')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::LogicalEnclosure).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/logical_interconnect/activate_firmware_spec.rb
+++ b/spec/unit/resources/logical_interconnect/activate_firmware_spec.rb
@@ -17,4 +17,9 @@ describe 'oneview_test::logical_interconnect_activate_firmware' do
       .with('Activate', instance_of(OneviewSDK::FirmwareDriver), anything).and_return(true)
     expect(real_chef_run).to activate_oneview_logical_interconnect_firmware('LogicalInterconnect-activate_firmware')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/logical_interconnect/reapply_configuration_spec.rb
+++ b/spec/unit/resources/logical_interconnect/reapply_configuration_spec.rb
@@ -9,4 +9,9 @@ describe 'oneview_test::logical_interconnect_reapply_configuration' do
     expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:configuration).and_return(true)
     expect(real_chef_run).to reapply_oneview_logical_interconnect_configuration('LogicalInterconnect-reapply_configuration')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/logical_interconnect/stage_firmware_spec.rb
+++ b/spec/unit/resources/logical_interconnect/stage_firmware_spec.rb
@@ -21,4 +21,9 @@ describe 'oneview_test::logical_interconnect_stage_firmware' do
       .with('Stage', @firmware_driver, anything).and_return(true)
     expect(real_chef_run).to stage_oneview_logical_interconnect_firmware('LogicalInterconnect-stage_firmware')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/logical_interconnect/update_firmware_spec.rb
+++ b/spec/unit/resources/logical_interconnect/update_firmware_spec.rb
@@ -21,4 +21,9 @@ describe 'oneview_test::logical_interconnect_update_firmware' do
       .with('Update', @firmware_driver, anything).and_return(true)
     expect(real_chef_run).to update_oneview_logical_interconnect_firmware('LogicalInterconnect-update_firmware')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/logical_interconnect/update_from_group_spec.rb
+++ b/spec/unit/resources/logical_interconnect/update_from_group_spec.rb
@@ -9,4 +9,9 @@ describe 'oneview_test::logical_interconnect_update_from_group' do
     expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:compliance).and_return(true)
     expect(real_chef_run).to update_oneview_logical_interconnect_from_group('LogicalInterconnect-update_from_group')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/logical_interconnect/update_internal_networks_spec.rb
+++ b/spec/unit/resources/logical_interconnect/update_internal_networks_spec.rb
@@ -11,4 +11,9 @@ describe 'oneview_test::logical_interconnect_update_internal_networks' do
     expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:update_internal_networks).and_return(true)
     expect(real_chef_run).to update_oneview_logical_interconnect_internal_networks('LogicalInterconnect-update_internal_networks')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/logical_interconnect/update_settings_spec.rb
+++ b/spec/unit/resources/logical_interconnect/update_settings_spec.rb
@@ -15,4 +15,9 @@ describe 'oneview_test::logical_interconnect_update_settings' do
     expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:update_settings).and_return(true)
     expect(real_chef_run).to update_oneview_logical_interconnect_settings('LogicalInterconnect-update_settings')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/logical_switch/refresh_spec.rb
+++ b/spec/unit/resources/logical_switch/refresh_spec.rb
@@ -13,6 +13,6 @@ describe 'oneview_test::logical_switch_refresh' do
   it 'raises error when it does not exist' do
     expect_any_instance_of(OneviewSDK::LogicalSwitch).to receive(:retrieve!).and_return(false)
     expect_any_instance_of(OneviewSDK::LogicalSwitch).to_not receive(:refresh_state)
-    expect { real_chef_run }.to raise_error(RuntimeError, /ResourceNotFound/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 end

--- a/spec/unit/resources/managed_san/refresh_spec.rb
+++ b/spec/unit/resources/managed_san/refresh_spec.rb
@@ -23,4 +23,9 @@ describe 'oneview_test::managed_san_refresh' do
     expect_any_instance_of(OneviewSDK::ManagedSAN).to receive(:set_refresh_state).and_return(true)
     expect(real_chef_run).to refresh_oneview_managed_san('ManagedSAN1')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::ManagedSAN).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/managed_san/set_policy_spec.rb
+++ b/spec/unit/resources/managed_san/set_policy_spec.rb
@@ -6,7 +6,7 @@ describe 'oneview_test::managed_san_set_policy' do
 
   it 'fails whe it does not exist' do
     allow_any_instance_of(OneviewSDK::ManagedSAN).to receive(:retrieve!).and_return(false)
-    expect { real_chef_run }.to raise_error(RuntimeError, /ResourceNotFound/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 
   it 'sets the policy if it is not alike' do

--- a/spec/unit/resources/managed_san/set_public_attributes_spec.rb
+++ b/spec/unit/resources/managed_san/set_public_attributes_spec.rb
@@ -6,7 +6,7 @@ describe 'oneview_test::managed_san_set_public_attributes' do
 
   it 'fails whe it does not exist' do
     allow_any_instance_of(OneviewSDK::ManagedSAN).to receive(:retrieve!).and_return(false)
-    expect { real_chef_run }.to raise_error(RuntimeError, /ResourceNotFound/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 
   it 'sets public attributes if it is no alike' do

--- a/spec/unit/resources/rack/add_to_rack_spec.rb
+++ b/spec/unit/resources/rack/add_to_rack_spec.rb
@@ -44,4 +44,9 @@ describe 'oneview_test::rack_add_to_rack' do
     expect_any_instance_of(OneviewSDK::Rack).to_not receive(:update)
     expect(real_chef_run).to add_oneview_rack_to_rack('Rack1')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::Rack).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/rack/remove_from_rack_spec.rb
+++ b/spec/unit/resources/rack/remove_from_rack_spec.rb
@@ -47,4 +47,9 @@ describe 'oneview_test::rack_remove_from_rack' do
     expect_any_instance_of(OneviewSDK::Rack).to_not receive(:update)
     expect(real_chef_run).to remove_oneview_rack_from_rack('Rack1')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::Rack).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/sas_interconnect/refresh_spec.rb
+++ b/spec/unit/resources/sas_interconnect/refresh_spec.rb
@@ -20,4 +20,9 @@ describe 'oneview_test_api300_synergy::sas_interconnect_refresh' do
     expect_any_instance_of(klass).to receive(:set_refresh_state).and_return(true)
     expect(real_chef_run).to refresh_oneview_sas_interconnect('SASInterconnect1')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(klass).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/sas_interconnect/reset_spec.rb
+++ b/spec/unit/resources/sas_interconnect/reset_spec.rb
@@ -10,6 +10,11 @@ describe 'oneview_test_api300_synergy::sas_interconnect_reset' do
     expect_any_instance_of(klass).to receive(:patch).with('replace', '/softResetState', 'Reset')
     expect(real_chef_run).to reset_oneview_sas_interconnect('SASInterconnect1')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(klass).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end
 
 describe 'oneview_test_api300_synergy::sas_interconnect_hard_reset' do

--- a/spec/unit/resources/sas_interconnect/set_power_state_spec.rb
+++ b/spec/unit/resources/sas_interconnect/set_power_state_spec.rb
@@ -10,6 +10,11 @@ describe 'oneview_test_api300_synergy::sas_interconnect_set_power_state' do
     expect_any_instance_of(klass).to receive(:patch).with('replace', '/powerState', anything)
     expect(real_chef_run).to set_oneview_sas_interconnect_power_state('SASInterconnect1')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(klass).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end
 
 describe 'oneview_test_api300_synergy::sas_interconnect_set_power_state_invalid' do

--- a/spec/unit/resources/sas_interconnect/set_uid_light_spec.rb
+++ b/spec/unit/resources/sas_interconnect/set_uid_light_spec.rb
@@ -10,6 +10,11 @@ describe 'oneview_test_api300_synergy::sas_interconnect_set_uid_light' do
     expect_any_instance_of(klass).to receive(:patch).with('replace', '/uidState', anything)
     expect(real_chef_run).to set_oneview_sas_interconnect_uid_light('SASInterconnect1')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(klass).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end
 
 describe 'oneview_test_api300_synergy::sas_interconnect_set_uid_light_invalid' do

--- a/spec/unit/resources/sas_logical_interconnect/replace_drive_enclosure_spec.rb
+++ b/spec/unit/resources/sas_logical_interconnect/replace_drive_enclosure_spec.rb
@@ -79,8 +79,7 @@ describe 'oneview_test_api300_synergy::sas_logical_interconnect_replace_drive_en
     allow_any_instance_of(provider).to receive(:load_resource).with(:DriveEnclosure, 'NEW_DRIVE', 'serialNumber')
       .and_return('SNFAKE2')
     expect_any_instance_of(klass).to receive(:retrieve!).and_return(false)
-
     expect_any_instance_of(klass).to_not receive(:replace_drive_enclosure)
-    expect { real_chef_run }.to raise_error(RuntimeError, /ResourceNotFound/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 end

--- a/spec/unit/resources/scope/change_resource_assignments_spec.rb
+++ b/spec/unit/resources/scope/change_resource_assignments_spec.rb
@@ -19,7 +19,12 @@ describe 'oneview_test_api300_synergy::scope_change_resource_assignments' do
     expect(real_chef_run).to change_oneview_scope_resource_assignments('Scope-change_resource_assignments')
   end
 
-  it 'Fails if one of the resources listed does not exist' do
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(klass).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
+
+  it 'fails if one of the resources listed does not exist' do
     expect_any_instance_of(klass).to receive(:retrieve!).and_return(true)
     expect_any_instance_of(en_klass).to receive(:retrieve!).and_return(false)
     expect { real_chef_run }.to raise_error(RuntimeError, /ResourceNotFound:.+Encl1/)

--- a/spec/unit/resources/server_hardware/update_ilo_firmware_spec.rb
+++ b/spec/unit/resources/server_hardware/update_ilo_firmware_spec.rb
@@ -9,4 +9,9 @@ describe 'oneview_test::server_hardware_update_ilo_firmware' do
     expect_any_instance_of(OneviewSDK::ServerHardware).to receive(:update_ilo_firmware)
     expect(real_chef_run).to update_oneview_server_hardware_ilo_firmware('ServerHardware1')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::ServerHardware).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/server_profile/update_from_template_spec.rb
+++ b/spec/unit/resources/server_profile/update_from_template_spec.rb
@@ -28,8 +28,8 @@ describe 'oneview_test::server_profile_update_from_template' do
     expect(Chef::Log).to have_received(:info).with(/Updating.*from template.*Preview:[\s\S]*stuff/)
   end
 
-  it 'fails if the profile cannot be found' do
-    expect(klass).to receive(:find_by).and_return([])
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(klass).to receive(:retrieve!).and_return(false)
     expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 end

--- a/spec/unit/resources/server_profile_template/new_profile_spec.rb
+++ b/spec/unit/resources/server_profile_template/new_profile_spec.rb
@@ -5,7 +5,6 @@ describe 'oneview_test::server_profile_template_new_profile' do
   include_context 'chef context'
 
   it 'creates it when it does not exist' do
-    expect_any_instance_of(OneviewSDK::ServerProfileTemplate).to receive(:exists?).and_return(true)
     expect_any_instance_of(OneviewSDK::ServerProfileTemplate).to receive(:retrieve!).and_return(true)
     expect_any_instance_of(OneviewSDK::ServerProfileTemplate).to receive(:new_profile).and_return(OneviewSDK::ServerProfile.new(client))
     expect_any_instance_of(OneviewSDK::ServerProfile).to receive(:exists?).and_return(false)

--- a/spec/unit/resources/storage_system/edit_credentials_spec.rb
+++ b/spec/unit/resources/storage_system/edit_credentials_spec.rb
@@ -4,11 +4,9 @@ describe 'oneview_test::storage_system_edit_credentials' do
   let(:resource_name) { 'storage_system' }
   include_context 'chef context'
 
-  it 'does nothing when storage system does not exists' do
-    allow_any_instance_of(OneviewSDK::StorageSystem).to receive(:retrieve!).and_return(false)
-    expect(Chef::Log).to receive(:error).with(/Credentials not edited/).and_return(true)
-    expect_any_instance_of(OneviewSDK::StorageSystem).to_not receive(:update).and_return(true)
-    expect(real_chef_run).to edit_oneview_storage_system_credentials('StorageSystem1')
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::StorageSystem).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 
   it 'edits storage system credentials when it exists' do

--- a/spec/unit/resources/switch/patch_spec.rb
+++ b/spec/unit/resources/switch/patch_spec.rb
@@ -17,4 +17,9 @@ describe 'oneview_test_api300_synergy::switch_patch' do
 
     expect(real_chef_run).to patch_oneview_switch('Switch1')
   end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(api::Switch).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
 end

--- a/spec/unit/resources/volume/create_snapshot_spec.rb
+++ b/spec/unit/resources/volume/create_snapshot_spec.rb
@@ -5,8 +5,8 @@ describe 'oneview_test::volume_create_snapshot' do
   include_context 'chef context'
 
   it 'raises error when resource does not exists' do
-    expect_any_instance_of(OneviewSDK::Volume).to receive(:exists?).and_return(false)
-    expect { real_chef_run }.to raise_error(RuntimeError, /ResourceNotFound: oneview_volume 'Volume1'/)
+    expect_any_instance_of(OneviewSDK::Volume).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 
   it 'does nothing when a snapshot already exists with the same name' do

--- a/spec/unit/resources/volume/delete_snapshot_spec.rb
+++ b/spec/unit/resources/volume/delete_snapshot_spec.rb
@@ -5,8 +5,8 @@ describe 'oneview_test::volume_delete_snapshot' do
   include_context 'chef context'
 
   it 'raises error when resource does not exists' do
-    expect_any_instance_of(OneviewSDK::Volume).to receive(:exists?).and_return(false)
-    expect { real_chef_run }.to raise_error(RuntimeError, /ResourceNotFound: oneview_volume 'Volume1'/)
+    expect_any_instance_of(OneviewSDK::Volume).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 
   it 'does nothin when it does not exists' do

--- a/spec/unit/resources_image_streamer/artifact_bundle/download_spec.rb
+++ b/spec/unit/resources_image_streamer/artifact_bundle/download_spec.rb
@@ -24,6 +24,6 @@ describe 'image_streamer_test_api300::artifact_bundle_download' do
 
   it 'not download when resource does not exist' do
     expect_any_instance_of(base_sdk::ArtifactBundle).to receive(:retrieve!).and_return(false)
-    expect { real_chef_run }.to raise_error(RuntimeError, /ArtifactBundle1 does not exist in the appliance. Cannot run download action./)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 end

--- a/spec/unit/resources_image_streamer/artifact_bundle/update_name_spec.rb
+++ b/spec/unit/resources_image_streamer/artifact_bundle/update_name_spec.rb
@@ -22,7 +22,7 @@ describe 'image_streamer_test_api300::artifact_bundle_update_name' do
 
   it 'raises an error when a resource passed in does not exist' do
     expect_any_instance_of(base_sdk::ArtifactBundle).to receive(:retrieve!).and_return(false)
-    expect { real_chef_run }.to raise_error(RuntimeError, /ArtifactBundle1 does not exist in the appliance. Cannot run update_name action./)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 
   it 'raises an error when the new name is already in use' do


### PR DESCRIPTION
### Description
Fail immediately after a necessary retrieve fails. Also standardized the message across the board.

The 1 weird resource that I found (but didn't update) is in the [storage_system_provider](https://github.com/HewlettPackard/oneview-chef/blob/v2.1.0/libraries/resource_providers/api200/storage_system_provider.rb#L51). It returns after putting a log statement instead of failing, which seems very strange to me. @tmiotto or @fgbulsoni , do you know why it has this behavior? Should we fail like the other resources instead?

### Issues Resolved
Fixes #220

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
