### PR TITLE
oneview_storage_system should not try to update the name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-## 2.2.0
+## Unreleased (proposed: 2.2.0)
 Adds support to API300 HPE Synergy Image Streamer resources:
   - image_streamer_artifact_bundle
   - image_streamer_os_build_plan
 
+Bug Fixes:
+- [#93](https://github.com/HewlettPackard/oneview-chef/issues/93) oneview_storage_system should not try to update the name
+ 
 ## 2.1.0
 - [#162](https://github.com/HewlettPackard/oneview-chef/issues/162) Add server_profile_template property to oneview_server_profile
 - Add :update_from_template action to oneview_server_profile

--- a/libraries/resource_providers/api200/storage_system_provider.rb
+++ b/libraries/resource_providers/api200/storage_system_provider.rb
@@ -19,6 +19,7 @@ module OneviewCookbook
         temp = Marshal.load(Marshal.dump(@item.data))
         if @item.exists?
           @item.retrieve!
+          temp.delete('name') # Don't compare the name, since it can't be updated
           return Chef::Log.info("#{@resource_name} '#{@name}' is up to date") if @item.like?(temp)
           Chef::Log.info "Updating #{@resource_name} '#{@name}'"
           Chef::Log.debug "#{@resource_name} '#{@name}' Chef resource differs from OneView resource."

--- a/spec/unit/resources/storage_system/add_spec.rb
+++ b/spec/unit/resources/storage_system/add_spec.rb
@@ -26,4 +26,16 @@ describe 'oneview_test::storage_system_add' do
     expect_any_instance_of(OneviewSDK::StorageSystem).to_not receive(:add)
     expect(real_chef_run).to add_oneview_storage_system('StorageSystem1')
   end
+
+  it 'does not try to update the name or password' do
+    r = OneviewSDK::StorageSystem.new(client, name: 'other', managedDomain: 'TestDomain', credentials: {
+                                        'ip_hostname' => '127.0.0.1',
+                                        'username' => 'username',
+                                        'password' => 'different_password'
+                                      })
+    allow(OneviewSDK::StorageSystem).to receive(:find_by).and_return([r])
+    expect_any_instance_of(OneviewSDK::StorageSystem).to_not receive(:update)
+    expect_any_instance_of(OneviewSDK::StorageSystem).to_not receive(:add)
+    expect(real_chef_run).to add_oneview_storage_system('StorageSystem1')
+  end
 end


### PR DESCRIPTION
### Description
Disables the comparison of the storage_system's name since it can't be updated. Previously, it would try to update it every time the recipe was ran after the creation.

### Issues Resolved
Fixes #93

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
