### PR TITLE
Print diff before converge finished statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Adds support to API300 HPE Synergy Image Streamer resources:
   - image_streamer_artifact_bundle
   - image_streamer_os_build_plan
 
+Bug Fixes:
+- [#98](https://github.com/HewlettPackard/oneview-chef/issues/98) Fix get_diff for comparisons of alike data
+- [#145](https://github.com/HewlettPackard/oneview-chef/issues/145) Show diff on log statement before actual update
+
 ## 2.1.0
 - [#162](https://github.com/HewlettPackard/oneview-chef/issues/162) Add server_profile_template property to oneview_server_profile
 - Add :update_from_template action to oneview_server_profile

--- a/libraries/oneview_helper.rb
+++ b/libraries/oneview_helper.rb
@@ -158,7 +158,7 @@ module OneviewCookbook
     # @return [String] Diff string (multi-line). Returns empty string if there is no diff or an error occurred
     def self.get_diff(resource, desired_data)
       data = resource.is_a?(Hash) ? resource : resource.data
-      recursive_diff(data, desired_data, "\n", '  ')
+      recursive_diff(data, desired_data, '', '  ')
     rescue StandardError => e
       Chef::Log.error "Failed to generate resource diff for '#{resource['name']}': #{e.message}"
       '' # Return empty diff

--- a/libraries/resource_provider.rb
+++ b/libraries/resource_provider.rb
@@ -96,12 +96,13 @@ module OneviewCookbook
         if @item.like? desired_state
           Chef::Log.info("#{@resource_name} '#{@name}' is up to date")
         else
-          Chef::Log.info "#{method_2.to_s.capitalize} #{@resource_name} '#{@name}'"
+          diff = get_diff(@item, desired_state)
+          diff.insert(0, '. Diff:') unless diff.to_s.empty?
+          Chef::Log.info "#{method_2.to_s.capitalize} #{@resource_name} '#{@name}'#{diff}"
           Chef::Log.debug "#{@resource_name} '#{@name}' Chef resource differs from OneView resource."
           Chef::Log.debug "Current state: #{JSON.pretty_generate(@item.data)}"
           Chef::Log.debug "Desired state: #{JSON.pretty_generate(desired_state)}"
-          diff = get_diff(@item, desired_state)
-          @context.converge_by "#{method_2.to_s.capitalize} #{@resource_name} '#{@name}'#{diff}" do
+          @context.converge_by "#{method_2.to_s.capitalize} #{@resource_name} '#{@name}'" do
             @item.update(desired_state)
           end
         end

--- a/libraries/resource_provider.rb
+++ b/libraries/resource_provider.rb
@@ -97,7 +97,6 @@ module OneviewCookbook
           Chef::Log.info("#{@resource_name} '#{@name}' is up to date")
         else
           diff = get_diff(@item, desired_state)
-          diff.insert(0, '. Diff:') unless diff.to_s.empty?
           Chef::Log.info "#{method_2.to_s.capitalize} #{@resource_name} '#{@name}'#{diff}"
           Chef::Log.debug "#{@resource_name} '#{@name}' Chef resource differs from OneView resource."
           Chef::Log.debug "Current state: #{JSON.pretty_generate(@item.data)}"
@@ -218,7 +217,9 @@ module OneviewCookbook
     # Get the diff of the current resource state and the desired state
     # See the OneviewCookbook::Helper.get_diff method for param details
     def get_diff(resource, desired_data)
-      OneviewCookbook::Helper.get_diff(resource, desired_data)
+      diff = OneviewCookbook::Helper.get_diff(resource, desired_data)
+      return '. (no diff)' if diff.to_s.empty?
+      ". Diff: #{diff}"
     end
 
     # Get the diff of the current resource state and the desired state

--- a/libraries/resource_providers/api200/ethernet_network_provider.rb
+++ b/libraries/resource_providers/api200/ethernet_network_provider.rb
@@ -34,7 +34,9 @@ module OneviewCookbook
           Chef::Log.info("#{@resource_name} '#{@name}' connection template is up to date")
         else
           diff = get_diff(connection_template, bandwidth)
-          @context.converge_by "Update #{@resource_name} '#{@name}' connection template settings#{diff}" do
+          diff.insert(0, '. Diff:') unless diff.to_s.empty?
+          Chef::Log.info "Updating #{@resource_name} '#{@name}' connection template settings#{diff}"
+          @context.converge_by "Update #{@resource_name} '#{@name}' connection template settings" do
             connection_template.update(bandwidth)
           end
         end

--- a/libraries/resource_providers/api200/ethernet_network_provider.rb
+++ b/libraries/resource_providers/api200/ethernet_network_provider.rb
@@ -34,7 +34,6 @@ module OneviewCookbook
           Chef::Log.info("#{@resource_name} '#{@name}' connection template is up to date")
         else
           diff = get_diff(connection_template, bandwidth)
-          diff.insert(0, '. Diff:') unless diff.to_s.empty?
           Chef::Log.info "Updating #{@resource_name} '#{@name}' connection template settings#{diff}"
           @context.converge_by "Update #{@resource_name} '#{@name}' connection template settings" do
             connection_template.update(bandwidth)

--- a/libraries/resource_providers/api200/interconnect_provider.rb
+++ b/libraries/resource_providers/api200/interconnect_provider.rb
@@ -62,7 +62,9 @@ module OneviewCookbook
         # Update only if there are options that differ from the current ones
         if parsed_port_options.any? { |k, v| target_port[k] != v }
           diff = get_diff(target_port, parsed_port_options)
-          @context.converge_by "Update #{@resource_name} '#{@name}' port #{parsed_port_options['name']}.#{diff}" do
+          diff.insert(0, '. Diff:') unless diff.to_s.empty?
+          Chef::Log.info "Updating #{@resource_name} '#{@name}'#{diff}"
+          @context.converge_by "Update #{@resource_name} '#{@name}' port #{parsed_port_options['name']}" do
             @item.update_port(parsed_port_options['name'], parsed_port_options)
           end
         else

--- a/libraries/resource_providers/api200/interconnect_provider.rb
+++ b/libraries/resource_providers/api200/interconnect_provider.rb
@@ -62,7 +62,6 @@ module OneviewCookbook
         # Update only if there are options that differ from the current ones
         if parsed_port_options.any? { |k, v| target_port[k] != v }
           diff = get_diff(target_port, parsed_port_options)
-          diff.insert(0, '. Diff:') unless diff.to_s.empty?
           Chef::Log.info "Updating #{@resource_name} '#{@name}'#{diff}"
           @context.converge_by "Update #{@resource_name} '#{@name}' port #{parsed_port_options['name']}" do
             @item.update_port(parsed_port_options['name'], parsed_port_options)

--- a/libraries/resource_providers/api200/logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api200/logical_interconnect_provider.rb
@@ -54,7 +54,6 @@ module OneviewCookbook
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         return Chef::Log.info("#{@resource_name} '#{@name}' is up to date") if @item.like?(temp)
         diff = get_diff(@item, temp)
-        diff.insert(0, '. Diff:') unless diff.to_s.empty?
         Chef::Log.info "#{action.to_s.capitalize.tr('_', ' ')} #{@resource_name} '#{@name}'#{diff}"
         Chef::Log.debug "#{@resource_name} '#{@name}' Chef resource differs from OneView resource."
         Chef::Log.debug "Current state: #{JSON.pretty_generate(@item.data)}"
@@ -76,7 +75,6 @@ module OneviewCookbook
         fd = load_resource(:FirmwareDriver, @context.firmware)
         raise "Resource not found: Firmware action '#{action}' cannot be performed since the firmware '#{@context.firmware}' was not found." unless fd
         diff = get_diff(current_firmware, @context.firmware_data)
-        diff.insert(0, '. Diff:') unless diff.to_s.empty?
         Chef::Log.info "#{action.to_s.capitalize.tr('_', ' ')} #{@resource_name} '#{@name}'#{diff}"
         Chef::Log.debug "#{@resource_name} '#{@name}' Chef resource firmware options differs from OneView resource."
         Chef::Log.debug "Current state: #{JSON.pretty_generate(current_firmware)}"
@@ -117,7 +115,6 @@ module OneviewCookbook
           Chef::Log.info("Internal networks for #{@resource_name} #{@name} are up to date")
         else
           diff = get_diff(@item, 'internalNetworkUris' => @context.internal_networks)
-          diff.insert(0, '. Diff:') unless diff.to_s.empty?
           Chef::Log.info "Updating internal networks for #{@resource_name} '#{@name}'#{diff}"
           @context.converge_by("Update internal networks for #{@resource_name} '#{@name}'") do
             @item.update_internal_networks(*@context.internal_networks)

--- a/libraries/resource_providers/api200/logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api200/logical_interconnect_provider.rb
@@ -53,13 +53,14 @@ module OneviewCookbook
         temp = key ? { key.to_s => Marshal.load(Marshal.dump(@item[key])) } : Marshal.load(Marshal.dump(@item.data))
         raise "Resource not found: Action '#{action}' cannot be performed since #{@resource_name} '#{@name}' was not found." unless @item.retrieve!
         return Chef::Log.info("#{@resource_name} '#{@name}' is up to date") if @item.like?(temp)
-        Chef::Log.info "#{action.to_s.capitalize.tr('_', ' ')} #{@resource_name} '#{@name}'"
+        diff = get_diff(@item, temp)
+        diff.insert(0, '. Diff:') unless diff.to_s.empty?
+        Chef::Log.info "#{action.to_s.capitalize.tr('_', ' ')} #{@resource_name} '#{@name}'#{diff}"
         Chef::Log.debug "#{@resource_name} '#{@name}' Chef resource differs from OneView resource."
         Chef::Log.debug "Current state: #{JSON.pretty_generate(@item.data)}"
         Chef::Log.debug "Desired state: #{JSON.pretty_generate(temp)}"
-        diff = get_diff(@item, temp)
         recursive_set(@item.data, temp)
-        @context.converge_by "#{action.to_s.capitalize.tr('_', ' ')} #{@resource_name} '#{@name}'#{diff}" do
+        @context.converge_by "#{action.to_s.capitalize.tr('_', ' ')} #{@resource_name} '#{@name}'" do
           @item.send(action)
         end
       end
@@ -75,11 +76,12 @@ module OneviewCookbook
         fd = load_resource(:FirmwareDriver, @context.firmware)
         raise "Resource not found: Firmware action '#{action}' cannot be performed since the firmware '#{@context.firmware}' was not found." unless fd
         diff = get_diff(current_firmware, @context.firmware_data)
-        Chef::Log.info "#{action.to_s.capitalize.tr('_', ' ')} #{@resource_name} '#{@name}'"
+        diff.insert(0, '. Diff:') unless diff.to_s.empty?
+        Chef::Log.info "#{action.to_s.capitalize.tr('_', ' ')} #{@resource_name} '#{@name}'#{diff}"
         Chef::Log.debug "#{@resource_name} '#{@name}' Chef resource firmware options differs from OneView resource."
         Chef::Log.debug "Current state: #{JSON.pretty_generate(current_firmware)}"
         Chef::Log.debug "Desired state: #{JSON.pretty_generate(@context.firmware_data)}"
-        @context.converge_by "#{action.capitalize} firmware '#{@context.firmware}' from logical interconnect '#{@name}'#{diff}" do
+        @context.converge_by "#{action.capitalize} firmware '#{@context.firmware}' from logical interconnect '#{@name}'" do
           @item.firmware_update(action, fd, @context.firmware_data)
         end
       end
@@ -115,7 +117,9 @@ module OneviewCookbook
           Chef::Log.info("Internal networks for #{@resource_name} #{@name} are up to date")
         else
           diff = get_diff(@item, 'internalNetworkUris' => @context.internal_networks)
-          @context.converge_by("Update internal networks for #{@resource_name} '#{@name}'#{diff}") do
+          diff.insert(0, '. Diff:') unless diff.to_s.empty?
+          Chef::Log.info "Updating internal networks for #{@resource_name} '#{@name}'#{diff}"
+          @context.converge_by("Update internal networks for #{@resource_name} '#{@name}'") do
             @item.update_internal_networks(*@context.internal_networks)
           end
         end

--- a/libraries/resource_providers/api200/network_set_provider.rb
+++ b/libraries/resource_providers/api200/network_set_provider.rb
@@ -49,9 +49,9 @@ module OneviewCookbook
         if @item.like?(temp) && networks_match
           Chef::Log.info("#{resource_name} '#{name}' is up to date")
         else
-          diff = get_diff(@item, temp)
-          diff << get_diff({ networkUris: retrieved_networks }, networkUris: desired_networks)
-          Chef::Log.info "Updating #{resource_name} '#{name}'. Diff:#{diff}"
+          diff = OneviewCookbook::Helper.get_diff(@item, temp)
+          diff << OneviewCookbook::Helper.get_diff({ networkUris: retrieved_networks }, networkUris: desired_networks)
+          Chef::Log.info "Updating #{resource_name} '#{name}'. Diff: #{diff}"
           Chef::Log.debug "#{resource_name} '#{name}' Chef resource differs from OneView resource."
           Chef::Log.debug "Current state: #{JSON.pretty_generate(@item.data)}"
           Chef::Log.debug "Desired state: #{JSON.pretty_generate(temp)}"

--- a/libraries/resource_providers/api200/network_set_provider.rb
+++ b/libraries/resource_providers/api200/network_set_provider.rb
@@ -49,13 +49,13 @@ module OneviewCookbook
         if @item.like?(temp) && networks_match
           Chef::Log.info("#{resource_name} '#{name}' is up to date")
         else
-          Chef::Log.info "Update #{resource_name} '#{name}'"
+          diff = get_diff(@item, temp)
+          diff << get_diff({ networkUris: retrieved_networks }, networkUris: desired_networks)
+          Chef::Log.info "Updating #{resource_name} '#{name}'. Diff:#{diff}"
           Chef::Log.debug "#{resource_name} '#{name}' Chef resource differs from OneView resource."
           Chef::Log.debug "Current state: #{JSON.pretty_generate(@item.data)}"
           Chef::Log.debug "Desired state: #{JSON.pretty_generate(temp)}"
-          diff = get_diff(@item, temp)
-          diff << get_diff({ networkUris: retrieved_networks }, networkUris: desired_networks)
-          @context.converge_by "Update #{resource_name} '#{name}'#{diff}" do
+          @context.converge_by "Update #{resource_name} '#{name}'" do
             temp['networkUris'] = desired_networks
             @item.update(temp)
           end

--- a/libraries/resource_providers/api200/rack_provider.rb
+++ b/libraries/resource_providers/api200/rack_provider.rb
@@ -36,7 +36,6 @@ module OneviewCookbook
           mounted_resource = @item['rackMounts'].find { |i| i['mountUri'] == mount_item['uri'] }
           return Chef::Log.info("Item '#{mount_item['name']}' in '#{@name}' is up to date") unless options.any? { |k, v| v != mounted_resource[k] }
           diff = get_diff(mounted_resource, options)
-          diff.insert(0, '. Diff:') unless diff.to_s.empty?
           Chef::Log.info "Updating #{mount_item['name']} in #{resource_name} '#{name}'#{diff}"
           @context.converge_by "Update #{mount_item['name']} in #{resource_name} '#{name}'" do
             @item.add_rack_resource(mount_item, options)

--- a/libraries/resource_providers/api200/rack_provider.rb
+++ b/libraries/resource_providers/api200/rack_provider.rb
@@ -36,7 +36,9 @@ module OneviewCookbook
           mounted_resource = @item['rackMounts'].find { |i| i['mountUri'] == mount_item['uri'] }
           return Chef::Log.info("Item '#{mount_item['name']}' in '#{@name}' is up to date") unless options.any? { |k, v| v != mounted_resource[k] }
           diff = get_diff(mounted_resource, options)
-          @context.converge_by "Update #{mount_item['name']} in #{resource_name} '#{name}'#{diff}" do
+          diff.insert(0, '. Diff:') unless diff.to_s.empty?
+          Chef::Log.info "Updating #{mount_item['name']} in #{resource_name} '#{name}'#{diff}"
+          @context.converge_by "Update #{mount_item['name']} in #{resource_name} '#{name}'" do
             @item.add_rack_resource(mount_item, options)
             @item.update
           end

--- a/libraries/resource_providers/api200/storage_system_provider.rb
+++ b/libraries/resource_providers/api200/storage_system_provider.rb
@@ -22,7 +22,6 @@ module OneviewCookbook
           temp.delete('name') # Don't compare the name, since it can't be updated
           return Chef::Log.info("#{@resource_name} '#{@name}' is up to date") if @item.like?(temp)
           diff = get_diff(@item, temp)
-          diff.insert(0, '. Diff:') unless diff.to_s.empty?
           Chef::Log.info "Updating #{@resource_name} '#{@name}'#{diff}"
           Chef::Log.debug "#{@resource_name} '#{@name}' Chef resource differs from OneView resource."
           Chef::Log.debug "Current state: #{JSON.pretty_generate(@item.data)}"

--- a/libraries/resource_providers/api200/storage_system_provider.rb
+++ b/libraries/resource_providers/api200/storage_system_provider.rb
@@ -20,12 +20,13 @@ module OneviewCookbook
         if @item.exists?
           @item.retrieve!
           return Chef::Log.info("#{@resource_name} '#{@name}' is up to date") if @item.like?(temp)
-          Chef::Log.info "Updating #{@resource_name} '#{@name}'"
+          diff = get_diff(@item, temp)
+          diff.insert(0, '. Diff:') unless diff.to_s.empty?
+          Chef::Log.info "Updating #{@resource_name} '#{@name}'#{diff}"
           Chef::Log.debug "#{@resource_name} '#{@name}' Chef resource differs from OneView resource."
           Chef::Log.debug "Current state: #{JSON.pretty_generate(@item.data)}"
           Chef::Log.debug "Desired state: #{JSON.pretty_generate(temp)}"
-          diff = get_diff(@item, temp)
-          @context.converge_by "Update #{@resource_name} '#{@name}'#{diff}" do
+          @context.converge_by "Update #{@resource_name} '#{@name}'" do
             @item.update(temp)
           end
         else

--- a/libraries/resource_providers/api300/synergy/fabric_provider.rb
+++ b/libraries/resource_providers/api300/synergy/fabric_provider.rb
@@ -24,7 +24,6 @@ module OneviewCookbook
             Chef::Log.info("#{resource_name} '#{name}' reserved Vlan range is up to date")
           else
             diff = get_diff(@item, options)
-            diff.insert(0, '. Diff:') unless diff.to_s.empty?
             Chef::Log.info "Setting #{resource_name} '#{name}' reserved Vlan range#{diff}"
             Chef::Log.debug "#{resource_name} '#{name}' Chef resource differs from OneView resource."
             Chef::Log.debug "Current state: #{JSON.pretty_generate(@item['reservedVlanRange'])}"

--- a/libraries/resource_providers/api300/synergy/fabric_provider.rb
+++ b/libraries/resource_providers/api300/synergy/fabric_provider.rb
@@ -23,12 +23,13 @@ module OneviewCookbook
           if @item.like? options
             Chef::Log.info("#{resource_name} '#{name}' reserved Vlan range is up to date")
           else
-            Chef::Log.info "Set #{resource_name} '#{name}' reserved Vlan range"
+            diff = get_diff(@item, options)
+            diff.insert(0, '. Diff:') unless diff.to_s.empty?
+            Chef::Log.info "Setting #{resource_name} '#{name}' reserved Vlan range#{diff}"
             Chef::Log.debug "#{resource_name} '#{name}' Chef resource differs from OneView resource."
             Chef::Log.debug "Current state: #{JSON.pretty_generate(@item['reservedVlanRange'])}"
             Chef::Log.debug "Desired state: #{JSON.pretty_generate(options['reservedVlanRange'])}"
-            diff = get_diff(@item, options)
-            @context.converge_by "Set reserved Vlan range for #{resource_name} '#{name}'#{diff}" do
+            @context.converge_by "Set reserved Vlan range for #{resource_name} '#{name}'" do
               @item.set_reserved_vlan_range(options['reservedVlanRange'])
             end
           end

--- a/spec/unit/libraries/oneview_helper_spec.rb
+++ b/spec/unit/libraries/oneview_helper_spec.rb
@@ -285,13 +285,13 @@ RSpec.describe OneviewCookbook::Helper do
     end
 
     it 'calls #recursive_diff' do
-      expect(described_class).to receive(:recursive_diff).with(@item.data, @desired_data, "\n", '  ').and_return('diff')
+      expect(described_class).to receive(:recursive_diff).with(@item.data, @desired_data, '', '  ').and_return('diff')
       diff = described_class.get_diff(@item, @desired_data)
       expect(diff).to eq('diff')
     end
 
     it 'allows a hash values instead of a resource' do
-      expect(described_class).to receive(:recursive_diff).with(@item.data, @desired_data, "\n", '  ').and_return('diff')
+      expect(described_class).to receive(:recursive_diff).with(@item.data, @desired_data, '', '  ').and_return('diff')
       diff = described_class.get_diff(@item.data, @desired_data)
       expect(diff).to eq('diff')
     end

--- a/spec/unit/libraries/resource_provider_spec.rb
+++ b/spec/unit/libraries/resource_provider_spec.rb
@@ -107,8 +107,8 @@ RSpec.describe OneviewCookbook::ResourceProvider do
       expect(res.item).to receive(:like?).and_return(false)
       expect(res.item).to receive(:update).and_return(true)
       expect(res).to receive(:get_diff).and_return('diff')
+      expect(Chef::Log).to receive(:info).ordered.with("Update #{res.resource_name} '#{res.name}'. Diff:diff").and_return true
       expect(Chef::Log).to receive(:info).ordered.with("Update #{res.resource_name} '#{res.name}'").and_return true
-      expect(Chef::Log).to receive(:info).ordered.with("Update #{res.resource_name} '#{res.name}'diff").and_return true
       expect(Chef::Log).to receive(:debug).with(/differs from OneView resource/).and_return true
       expect(Chef::Log).to receive(:debug)
         .with(/Current state: #{JSON.pretty_generate(res.item.data)}/).and_return true

--- a/spec/unit/libraries/resource_provider_spec.rb
+++ b/spec/unit/libraries/resource_provider_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe OneviewCookbook::ResourceProvider do
       expect(res.item).to receive(:like?).and_return(false)
       expect(res.item).to receive(:update).and_return(true)
       expect(res).to receive(:get_diff).and_return('diff')
-      expect(Chef::Log).to receive(:info).ordered.with("Update #{res.resource_name} '#{res.name}'. Diff:diff").and_return true
+      expect(Chef::Log).to receive(:info).ordered.with("Update #{res.resource_name} '#{res.name}'diff").and_return true
       expect(Chef::Log).to receive(:info).ordered.with("Update #{res.resource_name} '#{res.name}'").and_return true
       expect(Chef::Log).to receive(:debug).with(/differs from OneView resource/).and_return true
       expect(Chef::Log).to receive(:debug)
@@ -315,7 +315,13 @@ RSpec.describe OneviewCookbook::ResourceProvider do
     it 'calls the Helper method' do
       expect(OneviewCookbook::Helper).to receive(:get_diff)
         .with(:resource, :desired_data).and_return(:value)
-      expect(res.send(:get_diff, :resource, :desired_data)).to eq(:value)
+      expect(res.send(:get_diff, :resource, :desired_data)).to eq('. Diff: value')
+    end
+
+    it 'converts empty diffs' do
+      expect(OneviewCookbook::Helper).to receive(:get_diff)
+        .with(:resource, :desired_data).and_return('')
+      expect(res.send(:get_diff, :resource, :desired_data)).to eq('. (no diff)')
     end
   end
 


### PR DESCRIPTION
### Description
This moves the diff statement to just before it tries to do the update of a resource, not after. This will be extremely helpful in debugging things, as often you don't know what it's trying to update if the update fails.

### Issues Resolved
Fixes #98
Fixes #145

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
