### PR TITLE
Server Profile OS Deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Bug Fixes:
 - [#220](https://github.com/HewlettPackard/oneview-chef/issues/220) Raise "not found" error after failed retrieval of resource
 
 Enhancements:
+- [#217](https://github.com/HewlettPackard/oneview-chef/issues/217) Create full server deploy example recipe using Image Streamer and OneView resources
 - [#218](https://github.com/HewlettPackard/oneview-chef/issues/218) connection_template resource does not support NetworkSet, FCoENetwork and FCNetwork
 
 ## 2.1.0

--- a/README.md
+++ b/README.md
@@ -259,9 +259,9 @@ oneview_logical_interconnect 'LogicalInterconnect1' do
   trap_destinations <trap_options>   # Hash: Optional for :update_snmp_configuration
   enclosure <enclosure_name>         # String: Required for :add_interconnect and :remove_interconnect
   bay_number <bay>                   # Fixnum: Required for :add_interconnect and :remove_interconnect
-  action [:none, :add_interconnect, :remove_interconnect, :update_internal_networks, 
-          :update_settings,:update_ethernet_settings, :update_port_monitor, :update_qos_configuration, 
-          :update_telemetry_configuration, :update_snmp_configuration, :update_firmware, :stage_firmware, 
+  action [:none, :add_interconnect, :remove_interconnect, :update_internal_networks,
+          :update_settings,:update_ethernet_settings, :update_port_monitor, :update_qos_configuration,
+          :update_telemetry_configuration, :update_snmp_configuration, :update_firmware, :stage_firmware,
           :activate_firmware, :update_from_group, :reapply_configuration]
 end
 ```
@@ -277,7 +277,7 @@ oneview_sas_logical_interconnect 'SASLogicalInterconnect1' do
   firmware_data <firmware_data>                 # Hash: Optional for actions like :<action>_firwmare
   old_drive_enclosure <old_drive_enclosure_id>  # String (Optional): Old Drive enclosure name or serial number. It is used with the action :replace_drive_enclosure.
   new_drive_enclosure <new_drive_enclosure_id>  # String (Optional): New Drive enclosure name or serial number. It is used with the action :replace_drive_enclosure.
-  action [:none, :update_firmware, :stage_firmware, :activate_firmware, :update_from_group, 
+  action [:none, :update_firmware, :stage_firmware, :activate_firmware, :update_from_group,
           :reapply_configuration, :replace_drive_enclosure]
 end
 ```
@@ -671,14 +671,14 @@ end
 ```
 
 - **add** and **remove** (Hash) Optional - Used in the `:change_resource_assignments` action only. Specify resources to be added or removed. The Hash should have `<resource_type> => [<resource_names>]` associations. The `resource_type` can be a `String` or `Symbol`, and should be in upper CamelCase (i.e., ServerHardware, Enclosure):
-  
+
   ```ruby
   resource_list = {
     Enclosure: ['Encl1'],
     ServerHardware: ['Server1']
   }
   ```
-  
+
   See the [example](examples/scope.rb) for more information.
 
 ### [oneview_server_hardware](examples/server_hardware.rb)
@@ -745,6 +745,7 @@ oneview_server_profile 'ServerProfile1' do
   ethernet_network_connections <ethernet_network_connections_data>
   fc_network_connections <fc_network_connections_data>
   network_set_connections <network_set_connections_data>
+  deployment_plan <image_streamer_deployment_plan_name>
   action [:create, :create_if_missing, :delete]
 end
 ```
@@ -752,6 +753,7 @@ end
 You can specify the association of the server profile with each of the resources using the resource properties. Also it is easy to add connections using the connection properties:
 
 - **\<network_type\>_connections** (Hash) Optional - Specify connections with the desired resource type. The Hash should have `<network_name> => <connection_data>` associations. See the [examples](examples/server_profile.rb) for more information.
+- **deployment_plan** (String) Optional - Specify the Deployment Plan to be applied with the Server Profile. The OS Deployment Plan need to be created in Image Streamer appliance. See the [examples](examples/image_streamer/server_profile_deploy.rb) for more information.
 
 
 ### [oneview_switch](examples/switch.rb)

--- a/README.md
+++ b/README.md
@@ -745,7 +745,7 @@ oneview_server_profile 'ServerProfile1' do
   ethernet_network_connections <ethernet_network_connections_data>
   fc_network_connections <fc_network_connections_data>
   network_set_connections <network_set_connections_data>
-  deployment_plan <image_streamer_deployment_plan_name>
+  os_deployment_plan <os_deployment_plan_name>
   action [:create, :create_if_missing, :delete]
 end
 ```
@@ -753,7 +753,7 @@ end
 You can specify the association of the server profile with each of the resources using the resource properties. Also it is easy to add connections using the connection properties:
 
 - **\<network_type\>_connections** (Hash) Optional - Specify connections with the desired resource type. The Hash should have `<network_name> => <connection_data>` associations. See the [examples](examples/server_profile.rb) for more information.
-- **deployment_plan** (String) Optional - Specify the Deployment Plan to be applied with the Server Profile. The OS Deployment Plan need to be created in Image Streamer appliance. See the [examples](examples/image_streamer/server_profile_deploy.rb) for more information.
+- **os_deployment_plan** (String) Optional - Specify the OS Deployment Plan to be applied with the Server Profile. The OS Deployment Plan needs to be created in Image Streamer appliance in order to appear in OneView. See the [example](examples/image_streamer/server_profile_deploy.rb) for more information.
 
 
 ### [oneview_switch](examples/switch.rb)

--- a/examples/image_streamer/server_profile_deploy.rb
+++ b/examples/image_streamer/server_profile_deploy.rb
@@ -1,0 +1,83 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# Defaults API version to 300
+node.default['oneview']['api_version'] = 300
+
+oneview_client = {
+  url: ENV['ONEVIEWSDK_URL'],
+  user: ENV['ONEVIEWSDK_USER'],
+  password: ENV['ONEVIEWSDK_PASSWORD']
+}
+
+i3s_client = {
+  url: ENV['I3S_URL'],
+  oneview_client: oneview_client
+}
+
+# Create the Plan scripts
+image_streamer_plan_script 'ESXi - Configure environment' do
+  client i3s_client
+  data(
+    hpProvided: false,
+    planType: 'deploy',
+    content: File.open('my/script/path/configure_environment.sh', 'rb').read
+  )
+end
+
+image_streamer_plan_script 'ESXi - Set credentials' do
+  client i3s_client
+  data(
+    hpProvided: false,
+    planType: 'deploy',
+    content: File.open('my/script/path/set_credentials.sh', 'rb').read
+  )
+end
+
+image_streamer_os_build_plan 'ESXi - Build simple environment' do
+  client i3s_client
+  data(
+    oeBuildPlanType: 'Deploy',
+    buildStep: [
+      { serialNumber: 1, planScriptName: 'ESXi - Configure environment' },
+      { serialNumber: 2, planScriptName: 'ESXi - Set credentials' }
+    ]
+  )
+end
+
+image_streamer_golden_image 'GoldenImage - Deploy1' do
+  client i3s_client
+  os_volume 'OSVolume1'
+  data(
+    imageCapture: false # Deploy
+  )
+end
+
+image_streamer_deployment_plan 'DeploymentPlan1' do
+  client i3s_client
+  data(
+    hpProvided: false
+  )
+  os_build_plan 'ESXi - Build simple environment'
+  golden_image 'GoldenImage - Deploy1'
+end
+
+oneview_server_profile_template 'WebServerTemplate1' do
+  client oneview_client
+  profile_name 'ESXi - WebServer1'
+  action :new_profile
+end
+
+oneview_server_profile 'ESXi - WebServer1' do
+  client oneview_client
+  os_deployment_plan 'ESXi - Build simple environment'
+  server_hardware 'SY0000, bay 1'
+end

--- a/examples/image_streamer/server_profile_deploy.rb
+++ b/examples/image_streamer/server_profile_deploy.rb
@@ -9,6 +9,8 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+# NOTE: It assumes the server profile template 'WebServerTemplate1' was already created with all the connection information
+
 # Defaults API version to 300
 node.default['oneview']['api_version'] = 300
 
@@ -62,23 +64,18 @@ image_streamer_golden_image 'GoldenImage - Deploy1' do
 end
 
 # Create or update the Deployment Plan with the OS build plan and the golden image
-image_streamer_deployment_plan 'DeploymentPlan1' do
+image_streamer_deployment_plan 'ESXi - Deploy simple' do
   client i3s_client
   data(hpProvided: false)
   os_build_plan 'ESXi - Build simple environment'
   golden_image 'GoldenImage - Deploy1'
 end
 
-# Instantiate a new server profile from the previously created template 'WebServerTemplate1'
-oneview_server_profile_template 'WebServerTemplate1' do
-  client oneview_client
-  profile_name 'ESXi - WebServer1'
-  action :new_profile
-end
-
-# Apply the server profile to the 'SY0000, bay 1' server hardware blade with the OS deployment plan
+# Apply the server profile, based on the 'WebServerTemplate1' template to the 'SY0000, bay 1' server hardware blade
+#   with the OS deployment plan 'ESXi - Deploy simple' from the last steps
 oneview_server_profile 'ESXi - WebServer1' do
   client oneview_client
-  os_deployment_plan 'ESXi - Build simple environment'
-  server_hardware 'SY0000, bay 1'
+  server_profile_template 'WebServerTemplate1'
+  server_hardware 'Enclosure1, bay 1'
+  os_deployment_plan 'ESXi - Deploy simple'
 end

--- a/examples/image_streamer/server_profile_deploy.rb
+++ b/examples/image_streamer/server_profile_deploy.rb
@@ -23,7 +23,7 @@ i3s_client = {
   oneview_client: oneview_client
 }
 
-# Create the Plan scripts
+# Create the Plan scripts to be executed during the provisioning step
 image_streamer_plan_script 'ESXi - Configure environment' do
   client i3s_client
   data(
@@ -42,6 +42,7 @@ image_streamer_plan_script 'ESXi - Set credentials' do
   )
 end
 
+# Create an OS build plan that lists the execution of the previously created plan scripts
 image_streamer_os_build_plan 'ESXi - Build simple environment' do
   client i3s_client
   data(
@@ -53,29 +54,29 @@ image_streamer_os_build_plan 'ESXi - Build simple environment' do
   )
 end
 
+# Create the Golden Image from 'OSVolume1'
 image_streamer_golden_image 'GoldenImage - Deploy1' do
   client i3s_client
   os_volume 'OSVolume1'
-  data(
-    imageCapture: false # Deploy
-  )
+  data(imageCapture: true)
 end
 
+# Create or update the Deployment Plan with the OS build plan and the golden image
 image_streamer_deployment_plan 'DeploymentPlan1' do
   client i3s_client
-  data(
-    hpProvided: false
-  )
+  data(hpProvided: false)
   os_build_plan 'ESXi - Build simple environment'
   golden_image 'GoldenImage - Deploy1'
 end
 
+# Instantiate a new server profile from the previously created template 'WebServerTemplate1'
 oneview_server_profile_template 'WebServerTemplate1' do
   client oneview_client
   profile_name 'ESXi - WebServer1'
   action :new_profile
 end
 
+# Apply the server profile to the 'SY0000, bay 1' server hardware blade with the OS deployment plan
 oneview_server_profile 'ESXi - WebServer1' do
   client oneview_client
   os_deployment_plan 'ESXi - Build simple environment'

--- a/examples/image_streamer/server_profile_deploy.rb
+++ b/examples/image_streamer/server_profile_deploy.rb
@@ -71,7 +71,7 @@ image_streamer_deployment_plan 'ESXi - Deploy simple' do
   golden_image 'GoldenImage - Deploy1'
 end
 
-# Apply the server profile, based on the 'WebServerTemplate1' template to the 'SY0000, bay 1' server hardware blade
+# Apply the server profile, based on the 'WebServerTemplate1' template to the 'Enclosure1, bay 1' server hardware blade
 #   with the OS deployment plan 'ESXi - Deploy simple' from the last steps
 oneview_server_profile 'ESXi - WebServer1' do
   client oneview_client

--- a/libraries/resource_providers/api300/synergy/server_profile_provider.rb
+++ b/libraries/resource_providers/api300/synergy/server_profile_provider.rb
@@ -32,7 +32,7 @@ module OneviewCookbook
             return Chef::Log.warn('The OS deployment plan is already defined in `data`. ' /
                "The `os_deployment_plan` property will be ignored in favor of '#{@item['osDeploymentSettings']['osDeploymentPlanUri']}'")
           end
-          @item.set_os_deployment_setings(
+          @item.set_os_deployment_settings(
             load_resource(:OSDeploymentPlan, @context.os_deployment_plan),
             @item['osDeploymentSettings']['customAttributes']
           )

--- a/libraries/resource_providers/api300/synergy/server_profile_provider.rb
+++ b/libraries/resource_providers/api300/synergy/server_profile_provider.rb
@@ -16,6 +16,27 @@ module OneviewCookbook
     module Synergy
       # ServerProfile API300 Synergy provider
       class ServerProfileProvider < API200::ServerProfileProvider
+        def create_or_update
+          load_os_deployment_plan
+          super
+        end
+
+        protected
+
+        def load_os_deployment_plan
+          # Return if the property is not defined
+          return unless @context.os_deployment_plan
+          @item['osDeploymentSettings'] ||= {}
+          # Return if the value is already defined in data
+          if @item['osDeploymentSettings']['osDeploymentPlanUri']
+            return Chef::Log.warn('The OS deployment plan is already defined in `data`. ' /
+               "The `os_deployment_plan` property will be ignored in favor of '#{@item['osDeploymentSettings']['osDeploymentPlanUri']}'")
+          end
+          @item.set_os_deployment_setings(
+            load_resource(:OSDeploymentPlan, @context.os_deployment_plan),
+            @item['osDeploymentSettings']['customAttributes']
+          )
+        end
       end
     end
   end

--- a/resources/server_profile.rb
+++ b/resources/server_profile.rb
@@ -20,6 +20,7 @@ property :ethernet_network_connections, Hash
 property :fc_network_connections, Hash
 property :network_set_connections, Hash
 property :server_profile_template, String
+property :os_deployment_plan, String
 
 default_action :create
 

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/server_profile_properties.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/server_profile_properties.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: server_profile_properties
+#
+# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_server_profile 'ServerProfile1' do
+  client node['oneview_test']['client']
+  os_deployment_plan 'OSDeploymentPlan1'
+  data('osDeploymentSettings' => { 'customAttributes' => { 'it' => 'works' } })
+  action :create
+end

--- a/spec/unit/resources/server_profile/properties_spec.rb
+++ b/spec/unit/resources/server_profile/properties_spec.rb
@@ -24,3 +24,26 @@ describe 'oneview_test::server_profile_properties' do
     expect(real_chef_run).to create_oneview_server_profile('ServerProfile4')
   end
 end
+
+describe 'oneview_test_api300_synergy::server_profile_properties' do
+  let(:resource_name) { 'server_profile' }
+  include_context 'chef context'
+  include_context 'shared context'
+
+  let(:provider) { OneviewCookbook::API300::Synergy::ServerProfileProvider }
+  let(:base_sdk) { OneviewSDK::API300::Synergy }
+
+  it 'loads the new associated resource OS Deployment Plan' do
+    osdp = base_sdk::OSDeploymentPlan.new(@client, name: 'OSDeploymentPlan1', uri: 'rest/fake0')
+    allow_any_instance_of(provider).to receive(:load_resource).and_call_original
+    allow_any_instance_of(provider).to receive(:load_resource).with(anything, 'OSDeploymentPlan1').and_return(osdp)
+
+    expect_any_instance_of(base_sdk::ServerProfile).to receive(:set_os_deployment_settings).with(osdp, 'it' => 'works')
+
+    # Mock create
+    expect_any_instance_of(base_sdk::ServerProfile).to receive(:exists?).and_return(false)
+    expect_any_instance_of(base_sdk::ServerProfile).to receive(:create).and_return(true)
+
+    expect(real_chef_run).to create_oneview_server_profile('ServerProfile1')
+  end
+end

--- a/spec/unit/resources/server_profile/properties_spec.rb
+++ b/spec/unit/resources/server_profile/properties_spec.rb
@@ -36,7 +36,7 @@ describe 'oneview_test_api300_synergy::server_profile_properties' do
   it 'loads the new associated resource OS Deployment Plan' do
     osdp = base_sdk::OSDeploymentPlan.new(@client, name: 'OSDeploymentPlan1', uri: 'rest/fake0')
     allow_any_instance_of(provider).to receive(:load_resource).and_call_original
-    allow_any_instance_of(provider).to receive(:load_resource).with(anything, 'OSDeploymentPlan1').and_return(osdp)
+    allow_any_instance_of(provider).to receive(:load_resource).with(:OSDeploymentPlan, 'OSDeploymentPlan1').and_return(osdp)
 
     expect_any_instance_of(base_sdk::ServerProfile).to receive(:set_os_deployment_settings).with(osdp, 'it' => 'works')
 


### PR DESCRIPTION
### Description
Add support to OS Deployment Plans in the oneview_server_profile resource.

### Issues Resolved
#217

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
