### PR TITLE
Helper Methods, Examples & Yard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ bin/*
 .bundle/*
 
 coverage
+doc/
+.yardoc/
 .kitchen/
 .kitchen.local.yml
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,8 +6,14 @@ AllCops:
     - 'examples/*'
     - 'bin/*'
 
+Metrics/AbcSize:
+  Enabled: false
+
 Metrics/ClassLength:
   Max: 200
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
 
 Metrics/LineLength:
   Max: 150
@@ -19,11 +25,8 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Max: 210
 
-Metrics/AbcSize:
-  Enabled: false
-
-Metrics/CyclomaticComplexity:
-  Enabled: false
+Metrics/ParameterLists:
+  CountKeywordArgs: false
 
 Metrics/PerceivedComplexity:
   Enabled: false
@@ -35,8 +38,8 @@ Style/EmptyLineBetweenDefs:
 Style/RescueModifier:
   Enabled: false
 
-Style/WordArray:
+Style/SingleLineBlockParams:
   Enabled: false
 
-Style/SingleLineBlockParams:
+Style/WordArray:
   Enabled: false

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,1 @@
+libraries/**/*.rb - LICENSE metadata.rb CHANGELOG.md attributes/**/*.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@ Adds new Synergy resources.
   - Fixed volume resource (#92) & examples
 
 # 1.0.0
-Now the cookbook can operate with all the supported OneView 2.0 resources. Also added some bug fixes and minor improvements.
+Now the cookbook can operate with all the supported OneView 2.0 (API200) resources. Also added some bug fixes and minor improvements.
   - Added support to Volume actions `:create_snapshot` and `:delete_snapshot`
   - Added support to SAN manager actions
   - Added support to Uplink set actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## Unreleased (proposed: 2.2.0)
+## Unreleased
+Enhancements:
+- [#228](https://github.com/HewlettPackard/oneview-chef/issues/228) Add ::load_resource method to OneviewCookbook::Helper
+
+## 2.2.0
 Adds support to API300 HPE Synergy Image Streamer resources:
   - image_streamer_artifact_bundle
   - image_streamer_os_build_plan

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Cookbook for HPE OneView
 
 [![Cookbook Version](https://img.shields.io/cookbook/v/oneview.svg)](https://supermarket.chef.io/cookbooks/oneview)
+[![Yard Docs](https://img.shields.io/badge/yard-docs-yellow.svg)](http://www.rubydoc.info/github/HewlettPackard/oneview-chef)
+
 [![Travis Build Status](https://travis-ci.org/HewlettPackard/oneview-chef.svg?branch=master)](https://travis-ci.org/HewlettPackard/oneview-chef)
 [![Chef Build Status](https://jenkins-01.eastus.cloudapp.azure.com/job/oneview-cookbook/badge/icon)](https://jenkins-01.eastus.cloudapp.azure.com/job/oneview-cookbook/)
 [![Code Climate](https://codeclimate.com/github/HewlettPackard/oneview-chef/badges/gpa.svg)](https://codeclimate.com/github/HewlettPackard/oneview-chef)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See [attributes/default.rb](attributes/default.rb) for more info.
 The following are the standard properties available for all resources. Some resources have additional properties or small differences; see their doc sections below for more details.
 
  - **client**: Hash, OneviewSDK::Client or OneviewSDK::ImageStreamer::Client object that contains information about how to connect to the HPE OneView or HPE Synergy Image Streamer instances.
-   - For HPE OneView required attributes are: `url` and, `token` or `user` and `password`.
+   - For HPE OneView required attributes are: `url` and `token` or `user` and `password`.
    - For HPE Synergy Image Streamer required attributes are: `url` and, `token` or `oneview_client`.
  See [this](https://github.com/HewlettPackard/oneview-sdk-ruby#configuration) for more options.
  - **data**: Hash specifying options for this resource. Refer to the OneView API docs for what's available and/or required. If no name attribute is given, it will use the name given to the Chef resource.

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ end
 ```ruby
 interconnects_data = [
   { bay: 1, type: 'Synergy 12Gb SAS Connection Module' },
-  { bay: 2, type: 'Synergy 12Gb SAS Connection Module' }
+  { bay: 4, type: 'Synergy 12Gb SAS Connection Module' }
 ]
 ```
 

--- a/chefignore
+++ b/chefignore
@@ -42,6 +42,8 @@ a.out
 *.dll
 *.exe
 */rdoc/
+doc/*
+.yardoc/*
 
 # Testing #
 ###########

--- a/examples/custom_ruby_resources.rb
+++ b/examples/custom_ruby_resources.rb
@@ -1,0 +1,58 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# =======================================================================================
+
+# If you find that this cookbook does not provide a resource you need, you can easily
+# extend the functionality of this cookbook using the libraries it provides. Note that
+# this is a more advanced usage and requires a deeper understanding of Chef, Ruby, and
+# the OneView SDK for Ruby.
+
+# The very first thing we need to do is make sure that the SDK is loaded, giving us access
+# to its namespace & classes:
+OneviewCookbook::Helper.load_sdk(self)
+
+# Now we can use the SDK classes, such as the Client class:
+my_client = OneviewSDK::Client.new(
+  url: ENV['ONEVIEWSDK_URL'],
+  user: ENV['ONEVIEWSDK_USER'],
+  password: ENV['ONEVIEWSDK_PASSWORD']
+)
+
+# Since Chef recipes should not just be action scripts, we still need to use the Chef
+# model of each configuration item being an idempotent resource definition. Chef provides
+# a ruby_block resource that allows us to use pure ruby to define our own Chef resource.
+
+# Example: make sure that hardware setup access is disabled
+# Note that, if possible, we should always add an only_if or not_if block to the resource
+# to make the resource idempotent. In this example, Chef will only run the main action
+# block if the only_if block returns true.
+ruby_block 'disable hardware setup access' do
+  block do
+    resp = my_client.rest_post('/rest/logindomains/global-settings/hardware-setup-access', body: false)
+    my_client.response_handler(resp)
+  end
+  only_if do
+    resp = my_client.rest_get('/rest/logindomains/global-settings/hardware-setup-access')
+    my_client.response_handler(resp)['technicianEnabled']
+  end
+end
+
+# There are also a few other helper methods that this cookbook provides to make it easier
+# to do custom things. Here are a few (use these inside a custom ruby_block resource):
+ruby_block 'compare resources' do
+  block do
+    vol1 = OneviewCookbook::Helper.load_resource(my_client, type: 'Volume', id: 'Vol1')
+    vol2 = OneviewCookbook::Helper.load_resource(my_client, type: 'Volume', id: 'Vol2')
+    diff = OneviewCookbook::Helper.get_diff(vol1.data, vol2.data)
+    puts diff
+  end
+end

--- a/examples/oneview_resource.rb
+++ b/examples/oneview_resource.rb
@@ -15,11 +15,12 @@
 # but that resource must have a defined oneview-sdk class. This will make more sense as we look
 # at some examples below, but note that there are some generic assumptions being made about how
 # these resources can be interacted with. These assumptions include the availability of the
-# :exists?, :retrieve!, :create, :update and :destroy methods
+# :exists?, :retrieve!, :create, :update and :destroy methods. For resources that don't conform
+# to those assumptions, see the custom_ruby_resources.rb example.
 
 # Note that this client is not just a hash; it's a OneviewSDK::Client object. We'll need to use
 # it in our examples below to interact with OneView and get some information we need.
-require 'oneview-sdk'
+OneviewCookbook::Helper.load_sdk(self)
 my_client = OneviewSDK::Client.new(
   url: ENV['ONEVIEWSDK_URL'],
   user: ENV['ONEVIEWSDK_USER'],

--- a/examples/server_profile.rb
+++ b/examples/server_profile.rb
@@ -19,7 +19,7 @@ my_client = {
 oneview_server_profile 'ServerProfile1' do
   client my_client
   enclosure_group 'EnclosureGroup1'
-  server_hardware_type 'DL360 Gen8 1'
+  server_hardware_type 'BL460c Gen8'
 end
 
 # Creates a server profile using a template
@@ -54,7 +54,7 @@ end
 oneview_server_profile 'ServerProfile3' do
   client my_client
   enclosure_group 'EnclosureGroup2'
-  server_hardware_type 'DL360 Gen9 1'
+  server_hardware_type 'BL460c Gen8'
   data(
     'macType' => 'Virtual',
     'wwnType' => 'Virtual'
@@ -75,7 +75,21 @@ oneview_server_profile 'ServerProfile3' do
 end
 
 # Deletes server profile 'ServerProfile3'
-oneview_server_profile 'ServerProfile3' do
+oneview_server_profile 'Delete ServerProfile3' do
   client my_client
+  data(name: 'ServerProfile3')
+  action :delete
+end
+
+# Clean up the other profiles:
+oneview_server_profile 'Delete ServerProfile2' do
+  client my_client
+  data(name: 'ServerProfile2')
+  action :delete
+end
+
+oneview_server_profile 'Delete ServerProfile1' do
+  client my_client
+  data(name: 'ServerProfile1')
   action :delete
 end

--- a/libraries/oneview_helper.rb
+++ b/libraries/oneview_helper.rb
@@ -214,8 +214,8 @@ module OneviewCookbook
       raise(ArgumentError, 'Must specify a resource type') unless type
       return unless id
       c = build_client(client)
-      api_ver ||= node ? node['oneview']['api_version'] : 200
-      variant ||= node ? node['oneview']['api_variant'] : 'C7000'
+      api_ver ||= node['oneview']['api_version'] rescue 200
+      variant ||= node['oneview']['api_variant'] rescue 'C7000'
       klass = base_module.resource_named(type, api_ver, variant)
       data = id.is_a?(Hash) ? id : { name: id }
       r = klass.new(c, data)

--- a/libraries/oneview_helper.rb
+++ b/libraries/oneview_helper.rb
@@ -192,6 +192,37 @@ module OneviewCookbook
       end
       str
     end
+
+    # Retrieve a resource by type and identifier (name or data)
+    # @param [Hash, OneviewSDK::Client] client Appliance info hash or client object.
+    # @param type [String, Symbol] Type of resource to be retrieved. e.g., :GoldenImage, :FCNetwork
+    # @param id [String, Symbol, Hash] Name of the resource or Hash of data to retrieve by.
+    #   Examples: 'EthNet1', { uri: '/rest/fake/123ABC' }
+    # @param ret_attribute [NilClass, String, Symbol] If specified, returns a specific attribute of the resource.
+    #   When nil, the complete resource will be returned.
+    # @param api_ver [Integer] API version used to build the full type namespace.
+    #   Defaults to 200 (unless node attribute is passed)
+    # @param variant [String, Symbol] API variant used to build the full type namespace.
+    #   Defaults to 'C7000' (unless node attribute is passed)
+    # @param node [Chef::Node] Node object used to provide the api_ver and variant. If provided, they will default
+    #   to node['oneview']['api_version'] and node['oneview']['api_variant']
+    # @return [OneviewSDK::Resource] if the `ret_attribute` is nil
+    # @return [String, Array, Hash] that is, the value of the resource attribute defined by `ret_attribute`
+    # @raise [OneviewSDK::NotFound] ResourceNotFound if the resource cannot be found
+    # @raise [OneviewSDK::IncompleteResource] If you don't specify any unique identifiers in `id`
+    def self.load_resource(client, type: nil, id: nil, ret_attribute: nil, api_ver: nil, variant: nil, node: nil, base_module: OneviewSDK)
+      raise(ArgumentError, 'Must specify a resource type') unless type
+      return unless id
+      c = build_client(client)
+      api_ver ||= node ? node['oneview']['api_version'] : 200
+      variant ||= node ? node['oneview']['api_variant'] : 'C7000'
+      klass = base_module.resource_named(type, api_ver, variant)
+      data = id.is_a?(Hash) ? id : { name: id }
+      r = klass.new(c, data)
+      raise(OneviewSDK::NotFound, "#{type} with data '#{data}' was not found") unless r.retrieve!
+      return r unless ret_attribute
+      r[ret_attribute]
+    end
   end
 end
 

--- a/libraries/resource_provider.rb
+++ b/libraries/resource_provider.rb
@@ -228,24 +228,18 @@ module OneviewCookbook
       OneviewCookbook::Helper.recursive_diff(data, desired_data, str, indent)
     end
 
-    # Generic method to retrieve and return a resource from different resources using the type and name of the resource
-    # Note: The resource class base API module is the one used by the current provider
-    # @param [String, Symbol] resource_class_type Type of resource to be retrieved. e.g., :GoldenImage, :FCNetwork
-    # @param [Hash, String, NilClass] resource_id data containing unique IDs for this resource. e.g. uri: 'rest/fake/123456ABCDEF'
-    #   If a String is passed, it assumes the attribute is the `name` for this resource. e.g. 'Resource1' is interpreted as `name: 'Resource1'`.
-    #   If nothing or nil is passed, the method returns nil since there is nothing to be retrieved.
-    # @param [NilClass, String, Symbol] ret_attribute Attribute of resource to be returned by this method. Use nil to return the complete resource
-    # @return [OneviewSDK::Resource] if the `ret_attribute` is nil
-    # @return [String, Array, Hash] that is the value of the attribute defined by the `ret_attribute` for the requested resource
-    # @raise [RuntimeError] ResourceNotFound if the resource cannot be found
-    # @raise [OneviewSDK::IncompleteResource] If you don't specify any unique identifiers in resource_id
+    # Retrieve a resource by type and identifier (name or data)
+    # See the OneviewCookbook::Helper.load_resource method for param details
     def load_resource(resource_class_type, resource_id, ret_attribute = nil)
-      return unless resource_id
-      data = resource_id.is_a?(Hash) ? resource_id : { name: resource_id }
-      r = resource_named(resource_class_type).new(@item.client, data)
-      raise "ResourceNotFound: #{resource_class_type} with data '#{data}' was not found in the appliance." unless r.retrieve!
-      return r unless ret_attribute
-      r[ret_attribute]
+      OneviewCookbook::Helper.load_resource(
+        @item.client,
+        type: resource_class_type,
+        id: resource_id,
+        ret_attribute: ret_attribute,
+        api_ver: @sdk_api_version,
+        variant: @sdk_variant,
+        base_module: @sdk_base_module
+      )
     end
   end
 end

--- a/libraries/resource_providers/api300/synergy/sas_logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api300/synergy/sas_logical_interconnect_provider.rb
@@ -20,7 +20,7 @@ module OneviewCookbook
           return unless drive_id
           begin
             load_resource(:DriveEnclosure, drive_id, 'serialNumber')
-          rescue RuntimeError
+          rescue OneviewSDK::NotFound
             drive_id
           end
         end

--- a/spec/unit/libraries/oneview_helper_spec.rb
+++ b/spec/unit/libraries/oneview_helper_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe OneviewCookbook::Helper do
 
   let(:resource_type) { :EthernetNetwork }
 
-  describe '#self.do_resource_action' do
+  describe '::do_resource_action' do
     it 'calls all the other methods with the correct parameters' do
       context = FakeResource.new
       fake_class = Class.new
@@ -26,7 +26,7 @@ RSpec.describe OneviewCookbook::Helper do
     end
   end
 
-  describe '#self.get_resource_class' do
+  describe '::get_resource_class' do
     before :each do
       allow(described_class).to receive(:load_sdk).with(kind_of(FakeResource)).and_return(true)
     end
@@ -66,7 +66,7 @@ RSpec.describe OneviewCookbook::Helper do
     end
   end
 
-  describe '#self.get_api_module' do
+  describe '::get_api_module' do
     it 'gets the module for valid api versions' do
       [200, 300].each do |version|
         klass = described_class.get_api_module(version)
@@ -85,7 +85,7 @@ RSpec.describe OneviewCookbook::Helper do
     end
   end
 
-  describe '#self.load_sdk' do
+  describe '::load_sdk' do
     before :each do
       @context = FakeResource.new(node: { 'oneview' => { 'ruby_sdk_version' => sdk_version } })
     end
@@ -118,7 +118,7 @@ RSpec.describe OneviewCookbook::Helper do
     end
   end
 
-  describe '#self.build_client' do
+  describe '::build_client' do
     it 'requires a valid oneview object' do
       expect { described_class.build_client(1) }.to raise_error(/Invalid client .* OneviewSDK::Client/)
       expect { described_class.build_client(nil) }.to raise_error(OneviewSDK::InvalidClient, /Must set/)
@@ -182,7 +182,7 @@ RSpec.describe OneviewCookbook::Helper do
     end
   end
 
-  describe '#self.build_image_streamer_client' do
+  describe '::build_image_streamer_client' do
     it 'requires a valid oneview object' do
       expect { described_class.build_image_streamer_client('bananas') }.to raise_error(/Invalid client .* OneviewSDK::ImageStreamer::Client/)
       expect { described_class.build_image_streamer_client(nil) }.to raise_error(OneviewSDK::InvalidClient, /Must set/)
@@ -240,7 +240,7 @@ RSpec.describe OneviewCookbook::Helper do
     end
   end
 
-  describe '#self.convert_keys' do
+  describe '::convert_keys' do
     it 'converts simple hash keys' do
       simple_1 = { a: 1, b: 2, c: 3 }
       described_class.convert_keys(simple_1, :to_s).each { |k, _| expect(k).class == String }
@@ -278,7 +278,7 @@ RSpec.describe OneviewCookbook::Helper do
     end
   end
 
-  describe '#self.get_diff' do
+  describe '::get_diff' do
     before :each do
       @item = OneviewSDK::Resource.new(@client, uri: 'rest/fake', name: 'res', state: 'OK')
       @desired_data = { state: 'Not OK' }
@@ -304,7 +304,7 @@ RSpec.describe OneviewCookbook::Helper do
     end
   end
 
-  describe '#self.recursive_diff' do
+  describe '::recursive_diff' do
     before :each do
       @data = { key1: 'val1', key2: { key3: 'val3', key4: 'val4' }, key5: ['val5.1', 'val5.2'] }
       @item = OneviewSDK::Resource.new(@client, @data)
@@ -348,6 +348,49 @@ RSpec.describe OneviewCookbook::Helper do
       expect(described_class.recursive_diff(nil, @data)).to eq("\nnil -> #{@data}")
       expect(described_class.recursive_diff({ key2: nil }, @data)).to match(/key1: nil -> val1\n+key2: nil -> #{@data[:key2]}/)
       expect(described_class.recursive_diff({ key2: 1 }, @data)).to match(/key1: nil -> val1\n+key2: 1 -> #{@data[:key2]}/)
+    end
+  end
+
+  describe '::load_resource' do
+    let(:sdk_klass) { OneviewSDK::API200::VolumeTemplate }
+    let(:sdk_klass2) { OneviewSDK::ImageStreamer::API300::GoldenImage }
+
+    before :each do
+      @other_res = sdk_klass.new(@client, name: 'T1', description: 'Blah', uri: '/fake')
+    end
+
+    it 'retrieves a resource successfully when it exists (default by name)' do
+      expect(sdk_klass).to receive(:find_by).and_return([@other_res])
+      r = described_class.load_resource(@client, type: :VolumeTemplate, id: 'T1')
+      expect(r).to be_a(sdk_klass)
+      expect(r.data).to eq(@other_res.data)
+    end
+
+    it 'retrieves a resource successfully when it exists (by data Hash)' do
+      expect(sdk_klass).to receive(:find_by).and_return([@other_res])
+      r = described_class.load_resource(@client, type: :VolumeTemplate, id: { uri: '/fake' })
+      expect(r).to be_a(sdk_klass)
+      expect(r.data).to eq(@other_res.data)
+    end
+
+    it 'retrieves image streamer resources when they exist' do
+      g_image = sdk_klass2.new(@client, name: 'I1', description: 'Image')
+      expect(sdk_klass2).to receive(:find_by).and_return([g_image])
+      r = described_class.load_resource(@client, type: :GoldenImage, id: 'I1', base_module: OneviewSDK::ImageStreamer, api_ver: 300)
+      expect(r).to be_a(sdk_klass2)
+      expect(r.data).to eq(g_image.data)
+    end
+
+    it 'fails when the resource does not exist' do
+      expect_any_instance_of(sdk_klass).to receive(:retrieve!).and_return(false)
+      expect { described_class.load_resource(@client, type: :VolumeTemplate, id: 'T2') }
+        .to raise_error(OneviewSDK::NotFound, /not found/)
+    end
+
+    it 'returns a resource attribute when called with the ret_attribute' do
+      expect(sdk_klass).to receive(:find_by).and_return([@other_res])
+      r = described_class.load_resource(@client, type: :VolumeTemplate, id: 'T1', ret_attribute: :uri)
+      expect(r).to eq('/fake')
     end
   end
 end

--- a/spec/unit/libraries/resource_provider_spec.rb
+++ b/spec/unit/libraries/resource_provider_spec.rb
@@ -373,7 +373,7 @@ RSpec.describe OneviewCookbook::ResourceProvider do
 
     it 'fails when the resource does not exist' do
       expect_any_instance_of(sdk_klass).to receive(:retrieve!).and_return(false)
-      expect { @res.load_resource(:VolumeTemplate, 'T2') }.to raise_error(RuntimeError, /ResourceNotFound/)
+      expect { @res.load_resource(:VolumeTemplate, 'T2') }.to raise_error(OneviewSDK::NotFound, /not found/)
     end
 
     it 'returns a resource attribute when called with the ret_attribute' do

--- a/spec/unit/resources/network_set/load_resource_with_properties_spec.rb
+++ b/spec/unit/resources/network_set/load_resource_with_properties_spec.rb
@@ -27,7 +27,7 @@ describe 'oneview_test::network_set_load_resource_with_properties' do
 
   it 'prints a nice error message if the native_set cannot be found' do
     allow_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:retrieve!).and_return(false)
-    expect { real_chef_run }.to raise_error(RuntimeError, /ResourceNotFound:.+FakeEthernetNetwork0/)
+    expect { real_chef_run }.to raise_error(OneviewSDK::NotFound, /FakeEthernetNetwork0/)
   end
 
   it 'prints a nice error message if a network cannot be found' do
@@ -36,6 +36,6 @@ describe 'oneview_test::network_set_load_resource_with_properties' do
     allow_any_instance_of(OneviewCookbook::API200::NetworkSetProvider).to receive(:load_resource)
       .with(:EthernetNetwork, 'FakeEthernetNetwork0').and_return(fake_eth0)
     allow_any_instance_of(OneviewSDK::EthernetNetwork).to receive(:retrieve!).and_return(false)
-    expect { real_chef_run }.to raise_error(RuntimeError, /ResourceNotFound:.+FakeEthernetNetwork1/)
+    expect { real_chef_run }.to raise_error(OneviewSDK::NotFound, /FakeEthernetNetwork1/)
   end
 end

--- a/spec/unit/resources/scope/change_resource_assignments_spec.rb
+++ b/spec/unit/resources/scope/change_resource_assignments_spec.rb
@@ -27,6 +27,6 @@ describe 'oneview_test_api300_synergy::scope_change_resource_assignments' do
   it 'fails if one of the resources listed does not exist' do
     expect_any_instance_of(klass).to receive(:retrieve!).and_return(true)
     expect_any_instance_of(en_klass).to receive(:retrieve!).and_return(false)
-    expect { real_chef_run }.to raise_error(RuntimeError, /ResourceNotFound:.+Encl1/)
+    expect { real_chef_run }.to raise_error(OneviewSDK::NotFound, /Encl1/)
   end
 end

--- a/spec/unit/resources/server_profile/create_from_template_spec.rb
+++ b/spec/unit/resources/server_profile/create_from_template_spec.rb
@@ -28,6 +28,6 @@ describe 'oneview_test::server_profile_create_from_template' do
   it 'requires a valid template name' do
     expect_any_instance_of(OneviewSDK::ServerProfile).to receive(:exists?).and_return(false)
     expect(OneviewSDK::ServerProfileTemplate).to receive(:find_by).and_return([])
-    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+    expect { real_chef_run }.to raise_error(OneviewSDK::NotFound, /not found/)
   end
 end

--- a/spec/unit/resources_image_streamer/artifact_bundle/backup_from_file_spec.rb
+++ b/spec/unit/resources_image_streamer/artifact_bundle/backup_from_file_spec.rb
@@ -26,6 +26,6 @@ describe 'image_streamer_test_api300::artifact_bundle_backup_from_file' do
     allow(File).to receive(:file?).with('/tmp/BKP01.zip').and_return(true)
     expect_any_instance_of(base_sdk::DeploymentGroup).to receive(:retrieve!).and_return(false)
     expect(base_sdk::ArtifactBundle).not_to receive(:create_backup_from_file!)
-    expect { real_chef_run }.to raise_error(RuntimeError, /DeploymentGroup with data '{:name=>"DG1"}' was not found in the appliance./)
+    expect { real_chef_run }.to raise_error(OneviewSDK::NotFound, /DeploymentGroup with data '{:name=>"DG1"}'/)
   end
 end

--- a/spec/unit/resources_image_streamer/artifact_bundle/backup_spec.rb
+++ b/spec/unit/resources_image_streamer/artifact_bundle/backup_spec.rb
@@ -15,6 +15,6 @@ describe 'image_streamer_test_api300::artifact_bundle_backup' do
   it 'does not run backup when resource does not exist' do
     expect_any_instance_of(base_sdk::DeploymentGroup).to receive(:retrieve!).and_return(false)
     expect(base_sdk::ArtifactBundle).not_to receive(:create_backup)
-    expect { real_chef_run }.to raise_error(RuntimeError, /DeploymentGroup with data '{:name=>"DeploymentGroup1"}' was not found in the appliance./)
+    expect { real_chef_run }.to raise_error(OneviewSDK::NotFound, /DeploymentGroup with data '{:name=>"DeploymentGroup1"}'/)
   end
 end

--- a/spec/unit/resources_image_streamer/artifact_bundle/create_if_missing_spec.rb
+++ b/spec/unit/resources_image_streamer/artifact_bundle/create_if_missing_spec.rb
@@ -34,6 +34,6 @@ describe 'image_streamer_test_api300::artifact_bundle_create_if_missing' do
 
   it 'Should raise an error when a resource passed in does not exist' do
     allow_any_instance_of(base_sdk::BuildPlan).to receive(:retrieve!).and_return(false)
-    expect { real_chef_run }.to raise_error RuntimeError, /BuildPlan with data '{:name=>"BP"}' was not found in the appliance./
+    expect { real_chef_run }.to raise_error(OneviewSDK::NotFound, /BuildPlan with data '{:name=>"BP"}'/)
   end
 end

--- a/spec/unit/resources_image_streamer/artifact_bundle/extract_backup_spec.rb
+++ b/spec/unit/resources_image_streamer/artifact_bundle/extract_backup_spec.rb
@@ -19,7 +19,7 @@ describe 'image_streamer_test_api300::artifact_bundle_extract_backup' do
     expect(base_sdk::ArtifactBundle).to receive(:find_by).and_return([fake_artifact_bundle_backup])
     expect_any_instance_of(base_sdk::DeploymentGroup).to receive(:retrieve!).and_return(false)
     expect(base_sdk::ArtifactBundle).not_to receive(:extract_backup)
-    expect { real_chef_run }.to raise_error(RuntimeError, /DeploymentGroup with data '{:name=>"BKP01"}' was not found in the appliance./)
+    expect { real_chef_run }.to raise_error(OneviewSDK::NotFound, /DeploymentGroup with data '{:name=>"BKP01"}'/)
   end
 
   it 'raises an error when backup does not exist' do

--- a/spec/unit/resources_image_streamer/deployment_plan/create_spec.rb
+++ b/spec/unit/resources_image_streamer/deployment_plan/create_spec.rb
@@ -40,6 +40,6 @@ describe 'image_streamer_test_api300::deployment_plan_create' do
 
   it 'raises an error when a resource passed in does not exist' do
     expect_any_instance_of(base_sdk::GoldenImage).to receive(:retrieve!).and_return(false)
-    expect { real_chef_run }.to raise_error(RuntimeError, /ResourceNotFound/)
+    expect { real_chef_run }.to raise_error(OneviewSDK::NotFound, /not found/)
   end
 end

--- a/spec/unit/resources_image_streamer/os_build_plan/create_spec.rb
+++ b/spec/unit/resources_image_streamer/os_build_plan/create_spec.rb
@@ -70,7 +70,7 @@ describe 'image_streamer_test_api300::os_build_plan_create' do
     it 'raise error when the plan script does not exist' do
       allow_any_instance_of(base_sdk::BuildPlan).to receive(:[]).with('buildStep').and_return(build_step_name)
       allow_any_instance_of(base_sdk::PlanScript).to receive(:retrieve!).and_return(false)
-      expect { real_chef_run }.to raise_error(RuntimeError, /ResourceNotFound/)
+      expect { real_chef_run }.to raise_error(OneviewSDK::NotFound, /not found/)
     end
 
     it 'does nothing when the url is specified' do


### PR DESCRIPTION
### Description
This PR is a bit of a hodge-podge, so sorry. It:
- Moves the logic of the `load_resource` method into the Helper module, making it accessible outside Provider instances
- Updates a few examples & docs to be more consistent & accurate
- Adds an example of how make custom `ruby_block` resources
- Adds a yard config file and badge to the README. This will be great for Provider classes

### Issues Resolved
Fixes #228 
Fixes #137

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
