### PR TITLE
Adds connection list to Server Profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.2 (Unreleased)
+Enhancements:
+- [#233](https://github.com/HewlettPackard/oneview-chef/issues/233) ServerProfile connections cannot have more than one connection with the same network
+
 ## 2.2.1
 Enhancements:
 - [#228](https://github.com/HewlettPackard/oneview-chef/issues/228) Add ::load_resource method to OneviewCookbook::Helper

--- a/README.md
+++ b/README.md
@@ -729,7 +729,7 @@ end
 
 You can specify the association of the server profile with each of the resources using the resource properties. Also it is easy to add connections using the connection properties:
 
-- **\<resource_name\>_connections** (Hash) Optional - Specify connections with the desired resource type. The Hash should have `<network_name> => <connection_data>` associations. See the examples for more information.
+- **\<resource_name\>_connections** (Array/Hash) Optional - Specify connections with the desired resource type. The Hash entry should have `<network_name> => <connection_data>` associations. The Array contains these Hash entries. See the examples for more information.
 
 
 ### [oneview_server_profile](examples/server_profile.rb)

--- a/examples/server_profile.rb
+++ b/examples/server_profile.rb
@@ -74,6 +74,32 @@ oneview_server_profile 'ServerProfile3' do
   action :create_if_missing
 end
 
+# Creates or updates ServerProfile3 with multiple boot connections in the same network
+oneview_server_profile 'ServerProfile3' do
+  client my_client
+  enclosure_group 'EnclosureGroup2'
+  server_hardware_type 'BL460c Gen8'
+  data(
+    'macType' => 'Virtual',
+    'wwnType' => 'Virtual'
+  )
+  ethernet_network_connections [
+    'EthernetNetwork1' => {
+      'name' => 'PrimaryBoot',
+      "boot": {
+        "priority": "Primary"
+      }
+    },
+    'EthernetNetwork1' => {
+      'name' => 'SecondaryBoot',
+      "boot": {
+        "priority": "Secondary"
+      }
+    }
+  ]
+  action :create
+end
+
 # Deletes server profile 'ServerProfile3'
 oneview_server_profile 'Delete ServerProfile3' do
   client my_client

--- a/examples/server_profile.rb
+++ b/examples/server_profile.rb
@@ -80,20 +80,29 @@ oneview_server_profile 'ServerProfile3' do
   enclosure_group 'EnclosureGroup2'
   server_hardware_type 'BL460c Gen8'
   data(
-    'macType' => 'Virtual',
-    'wwnType' => 'Virtual'
+    "bootMode" => {
+      'manageMode' => true,
+      'mode' => 'BIOS'
+    },
+    'boot' => {
+      'manageBoot' => true
+    }
   )
   ethernet_network_connections [
-    'EthernetNetwork1' => {
-      'name' => 'PrimaryBoot',
-      "boot": {
-        "priority": "Primary"
+    {
+      'EthernetNetwork1' => {
+        'name' => 'PrimaryBoot',
+        "boot": {
+          "priority": "Primary"
+        }
       }
     },
-    'EthernetNetwork1' => {
-      'name' => 'SecondaryBoot',
-      "boot": {
-        "priority": "Secondary"
+    {
+      'EthernetNetwork1' => {
+        'name' => 'SecondaryBoot',
+        "boot": {
+          "priority": "Secondary"
+        }
       }
     }
   ]

--- a/libraries/resource_providers/api200/server_profile_provider.rb
+++ b/libraries/resource_providers/api200/server_profile_provider.rb
@@ -17,7 +17,18 @@ module OneviewCookbook
     module ServerProfileProviderHelpers
       def set_connections(type, connection_list)
         return false unless connection_list
-        connection_list.each { |net_name, options| @item.add_connection(load_resource(type, net_name), options) }
+        # Is a Hash-like or an Array of Hash-like objects
+        is_hashy = connection_list.respond_to?(:keys)
+        is_hashy_array = connection_list.respond_to?(:first) && connection_list.first.respond_to?(:keys)
+        if is_hashy
+          connection_list.each { |net_name, options| @item.add_connection(load_resource(type, net_name), options) }
+        elsif is_hashy_array
+          connection_list.each do |c|
+            c.map { |net_name, options| @item.add_connection(load_resource(type, net_name), options) }
+          end
+        else
+          raise(StandardError, "Invalid #{type} connection list: #{connection_list}")
+        end
         true
       end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@
 name             'oneview'
 maintainer       'Hewlett Packard Enterprise'
 maintainer_email 'chef-cookbooks@groups.ext.hpe.com'
-license          'Apache v2.0'
+license          'Apache-2.0'
 description      'Provides HPE OneView & Image Streamer resources'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 

--- a/resources/server_profile.rb
+++ b/resources/server_profile.rb
@@ -16,9 +16,9 @@ property :server_hardware_type, String
 property :enclosure_group, String
 property :enclosure, String
 property :firmware_driver, String
-property :ethernet_network_connections, Hash
-property :fc_network_connections, Hash
-property :network_set_connections, Hash
+property :ethernet_network_connections, Object
+property :fc_network_connections, Object
+property :network_set_connections, Object
 property :server_profile_template, String
 property :os_deployment_plan, String
 

--- a/resources/server_profile_template.rb
+++ b/resources/server_profile_template.rb
@@ -16,9 +16,9 @@ default_action :create
 property :server_hardware_type, String
 property :enclosure_group, String
 property :firmware_driver, String
-property :ethernet_network_connections, Hash
-property :network_set_connections, Hash
-property :fc_network_connections, Hash
+property :ethernet_network_connections, Object
+property :network_set_connections, Object
+property :fc_network_connections, Object
 property :profile_name, String
 
 default_action :create

--- a/spec/unit/resources/server_profile/properties_spec.rb
+++ b/spec/unit/resources/server_profile/properties_spec.rb
@@ -47,7 +47,7 @@ describe 'oneview_test::server_profile_properties' do
     expect(real_chef_run).to create_oneview_server_profile('ServerProfile4')
   end
 
-  it 'raises an error when loading invalid connections are lists' do
+  it 'raises an error when loading invalid connection lists' do
     sh1 = OneviewSDK::ServerHardware.new(@client, name: 'ServerHardware1', uri: 'rest/fake0')
 
     allow_any_instance_of(provider).to receive(:set_connections).and_call_original

--- a/spec/unit/resources/server_profile/properties_spec.rb
+++ b/spec/unit/resources/server_profile/properties_spec.rb
@@ -23,6 +23,46 @@ describe 'oneview_test::server_profile_properties' do
 
     expect(real_chef_run).to create_oneview_server_profile('ServerProfile4')
   end
+
+  it 'loads the associated resources when the connections are lists' do
+    sh1 = OneviewSDK::ServerHardware.new(@client, name: 'ServerHardware1', uri: 'rest/fake0')
+    en1 = OneviewSDK::EthernetNetwork.new(@client, name: 'EthernetNetwork1', uri: 'rest/fake1')
+
+    allow_any_instance_of(provider).to receive(:set_connections).and_call_original
+    allow_any_instance_of(provider).to receive(:set_connections)
+      .with(:EthernetNetwork, anything)
+      .and_wrap_original { |m, *args| m.call(args.first, [args.last]) }
+
+    allow_any_instance_of(provider).to receive(:load_resource).and_call_original
+    allow_any_instance_of(provider).to receive(:load_resource).with(anything, 'ServerHardware1').and_return(sh1)
+    allow_any_instance_of(provider).to receive(:load_resource).with(anything, 'EthernetNetwork1').and_return(en1)
+
+    expect_any_instance_of(OneviewSDK::ServerProfile).to receive(:set_server_hardware).with(sh1)
+    expect_any_instance_of(OneviewSDK::ServerProfile).to receive(:add_connection).with(en1, 'it' => 'works')
+
+    # Mock create
+    expect_any_instance_of(OneviewSDK::ServerProfile).to receive(:exists?).and_return(false)
+    expect_any_instance_of(OneviewSDK::ServerProfile).to receive(:create).and_return(true)
+
+    expect(real_chef_run).to create_oneview_server_profile('ServerProfile4')
+  end
+
+  it 'raises an error when loading invalid connections are lists' do
+    sh1 = OneviewSDK::ServerHardware.new(@client, name: 'ServerHardware1', uri: 'rest/fake0')
+
+    allow_any_instance_of(provider).to receive(:set_connections).and_call_original
+    allow_any_instance_of(provider).to receive(:set_connections)
+      .with(:EthernetNetwork, anything)
+      .and_wrap_original { |m, *args| m.call(args.first, 'I am potato') }
+
+    allow_any_instance_of(provider).to receive(:load_resource).and_call_original
+    allow_any_instance_of(provider).to receive(:load_resource).with(anything, 'ServerHardware1').and_return(sh1)
+
+    expect_any_instance_of(OneviewSDK::ServerProfile).to receive(:set_server_hardware).with(sh1)
+    expect_any_instance_of(OneviewSDK::ServerProfile).to_not receive(:add_connection)
+
+    expect { real_chef_run }.to raise_error(StandardError, /Invalid EthernetNetwork connection list/)
+  end
 end
 
 describe 'oneview_test_api300_synergy::server_profile_properties' do


### PR DESCRIPTION
### Description
Now the Server Profile connection can receive also a list of hashes to add the connections.

### Issues Resolved
#233 
#231

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
