### PR TITLE
Upgraded gems and fixed consequences

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,15 @@ AllCops:
     - 'examples/*'
     - 'bin/*'
 
+Layout/EndOfLine:
+  Enabled: false
+
+Metrics/BlockLength:
+  CountComments: false
+  Max: 50
+  Exclude:
+    - 'spec/**/*'
+
 Metrics/AbcSize:
   Enabled: false
 
@@ -31,7 +40,7 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
-Style/EmptyLineBetweenDefs:
+Layout/EmptyLineBetweenDefs:
   Exclude:
     - 'libraries/matchers.rb'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,14 @@ rvm:
   - 2.1
   - 2.2.6
   - 2.3.1
+  - 2.4
 
 before_install: gem update bundler
 
 script:
   - rake test
   - bundle exec codeclimate-test-reporter
+
+matrix:
+  allow_failures:
+    - rvm: 2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.1 (Unreleased)
+Enhancements:
+- [#246](https://github.com/HewlettPackard/oneview-chef/issues/246) Upgrade oneview-sdk gem to version 5.0.0
+
 ## 2.3.0
 Adds support to the following HPE OneView resources:
   - Added oneview_event resource

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@ source 'https://rubygems.org'
 
 ruby RUBY_VERSION # Needed to consider & solve for Ruby version requirements
 
-gem 'berkshelf', '~> 4.3.5'
+gem 'berkshelf'
 gem 'chef', '~> 12.0'
-gem 'chefspec', '~> 7.1'
-gem 'codeclimate-test-reporter', '~> 1.0.0'
+gem 'chefspec'
+gem 'codeclimate-test-reporter'
 gem 'foodcritic', '~> 7.1.0'
 gem 'oneview-sdk', '~> 5.0.0'
 gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,12 @@ gem 'berkshelf', '~> 4.3.5'
 gem 'chef', '~> 12.0'
 gem 'chefspec', '~> 7.1'
 gem 'codeclimate-test-reporter', '~> 1.0.0'
-gem 'foodcritic', '~> 11.3'
+gem 'foodcritic', '~> 7.1.0'
 gem 'oneview-sdk', '~> 5.0.0'
 gem 'pry'
 gem 'rubocop', '~> 0.49.1'
-gem 'simplecov', '~> 0.15'
-gem 'stove', '~> 5.2'
+gem 'simplecov'
+gem 'stove'
 
 begin
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.6')

--- a/Gemfile
+++ b/Gemfile
@@ -2,16 +2,16 @@ source 'https://rubygems.org'
 
 ruby RUBY_VERSION # Needed to consider & solve for Ruby version requirements
 
-gem 'berkshelf'
+gem 'berkshelf', '~> 4.3.5'
 gem 'chef', '~> 12.0'
-gem 'chefspec'
+gem 'chefspec', '~> 7.1'
 gem 'codeclimate-test-reporter', '~> 1.0.0'
-gem 'foodcritic'
-gem 'oneview-sdk', '~> 4.5.1'
+gem 'foodcritic', '~> 11.3'
+gem 'oneview-sdk', '~> 5.0.0'
 gem 'pry'
-gem 'rubocop', '= 0.40.0'
-gem 'simplecov'
-gem 'stove'
+gem 'rubocop', '~> 0.49.1'
+gem 'simplecov', '~> 0.15'
+gem 'stove', '~> 5.2'
 
 begin
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.6')

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then use any of the resources provided by this cookbook.
 ```ruby
 # my_cookbook/metadata.rb
 ...
-depends 'oneview', '~> 2.2'
+depends 'oneview', '~> 5.0.0'
 ```
 
 ### Credentials

--- a/Rakefile
+++ b/Rakefile
@@ -43,10 +43,10 @@ FoodCritic::Rake::LintTask.new(:foodcritic) do |t|
 end
 
 desc 'Runs all style checks'
-task style: [:rubocop, :foodcritic]
+task style: %i[rubocop foodcritic]
 
 desc 'Runs all style and unit tests'
-task test: [:style, :unit]
+task test: %i[style unit]
 
 # Stove publishing Rake Task
 Stove::RakeTask.new

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,7 +12,7 @@
 # Set which version of the SDK to install and use:
 # Warning: Changing the SDK version may cause issues within the Cookbook
 # Edit only if you know exactly what are you doing
-default['oneview']['ruby_sdk_version'] = '~> 4.5.1'
+default['oneview']['ruby_sdk_version'] = '~> 5.0'
 
 # Save resource info to a node attribute? Possible values/types:
 #  - true  : Save all info (Merged hash of OneView info and Chef resource properties)

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -12,63 +12,63 @@
 if defined?(ChefSpec)
   # Instead of defining each matcher method, we're going to save some time by doing some meta programming
   # To see a full list of the actual matchers, see spec/unit/resources/matchers_spec.rb
-  standard_actions = [:create, :create_if_missing, :delete]
+  standard_actions = %i[create create_if_missing delete]
   # Lists all the possible action verbs
-  action_list = %w(create add delete remove set reset refresh update configure reconfigure edit none discover apply reapply activate
-                   stage new patch replace change load download upload extract backup allocate collect)
+  action_list = %w[create add delete remove set reset refresh update configure reconfigure edit none discover apply reapply activate
+                   stage new patch replace change load download upload extract backup allocate collect]
 
   oneview_resources = {
     oneview_resource:                   standard_actions,
-    oneview_connection_template:        [:update, :reset],
-    oneview_datacenter:                 [:add, :remove, :add_if_missing],
-    oneview_drive_enclosure:            [:hard_reset, :patch, :refresh, :set_uid_light, :set_power_state],
-    oneview_enclosure:                  [:add, :remove, :refresh, :reconfigure, :patch],
+    oneview_connection_template:        %i[update reset],
+    oneview_datacenter:                 %i[add remove add_if_missing],
+    oneview_drive_enclosure:            %i[hard_reset patch refresh set_uid_light set_power_state],
+    oneview_enclosure:                  %i[add remove refresh reconfigure patch],
     oneview_enclosure_group:            standard_actions + [:set_script],
     oneview_ethernet_network:           standard_actions + [:reset_connection_template],
     oneview_event:                      [:create],
     oneview_fabric:                     [:set_reserved_vlan_range],
     oneview_fc_network:                 standard_actions,
     oneview_fcoe_network:               standard_actions,
-    oneview_firmware:                   [:add, :remove, :create_custom_spp],
-    oneview_id_pool:                    [:update, :allocate_list, :allocate_count, :collect_ids],
-    oneview_interconnect:               [:set_uid_light, :set_power_state, :reset, :reset_port_protection, :update_port],
-    oneview_logical_enclosure:          [:create_if_missing, :create, :update_from_group, :reconfigure, :set_script, :delete],
+    oneview_firmware:                   %i[add remove create_custom_spp],
+    oneview_id_pool:                    %i[update allocate_list allocate_count collect_ids],
+    oneview_interconnect:               %i[set_uid_light set_power_state reset reset_port_protection update_port],
+    oneview_logical_enclosure:          %i[create_if_missing create update_from_group reconfigure set_script delete],
     oneview_logical_interconnect_group: standard_actions,
-    oneview_logical_interconnect:       [:none, :add_interconnect, :remove_interconnect, :update_internal_networks, :update_settings,
-                                         :update_ethernet_settings, :update_port_monitor, :update_qos_configuration, :update_telemetry_configuration,
-                                         :update_snmp_configuration, :update_firmware, :stage_firmware, :activate_firmware, :update_from_group,
-                                         :reapply_configuration],
+    oneview_logical_interconnect:       %i[none add_interconnect remove_interconnect update_internal_networks update_settings
+                                           update_ethernet_settings update_port_monitor update_qos_configuration update_telemetry_configuration
+                                           update_snmp_configuration update_firmware stage_firmware activate_firmware update_from_group
+                                           reapply_configuration],
     oneview_logical_switch_group:       standard_actions,
     oneview_logical_switch:             standard_actions + [:refresh],
-    oneview_managed_san:                [:refresh, :set_policy, :set_public_attributes],
+    oneview_managed_san:                %i[refresh set_policy set_public_attributes],
     oneview_network_set:                standard_actions,
-    oneview_power_device:               [:add, :add_if_missing, :discover, :remove],
-    oneview_rack:                       [:add, :remove, :add_if_missing, :add_to_rack, :remove_from_rack],
-    oneview_san_manager:                [:add, :add_if_missing, :remove],
-    oneview_sas_logical_interconnect:   [:none, :update_firmware, :stage_firmware, :activate_firmware, :update_from_group, :reapply_configuration,
-                                         :replace_drive_enclosure],
-    oneview_sas_interconnect:           [:reset, :hard_reset, :patch, :refresh, :set_uid_light, :set_power_state],
+    oneview_power_device:               %i[add add_if_missing discover remove],
+    oneview_rack:                       %i[add remove add_if_missing add_to_rack remove_from_rack],
+    oneview_san_manager:                %i[add add_if_missing remove],
+    oneview_sas_logical_interconnect:   %i[none update_firmware stage_firmware activate_firmware update_from_group reapply_configuration
+                                           replace_drive_enclosure],
+    oneview_sas_interconnect:           %i[reset hard_reset patch refresh set_uid_light set_power_state],
     oneview_sas_logical_interconnect_group: standard_actions,
     oneview_scope:                      standard_actions + [:change_resource_assignments],
-    oneview_server_hardware:            [:add_if_missing, :remove, :refresh, :set_power_state, :update_ilo_firmware, :patch],
-    oneview_server_hardware_type:       [:edit, :remove],
+    oneview_server_hardware:            %i[add_if_missing remove refresh set_power_state update_ilo_firmware patch],
+    oneview_server_hardware_type:       %i[edit remove],
     oneview_server_profile_template:    standard_actions + [:new_profile],
     oneview_server_profile:             standard_actions + [:update_from_template],
-    oneview_storage_pool:               [:add_if_missing, :remove],
-    oneview_storage_system:             [:add, :remove, :edit_credentials, :add_if_missing],
-    oneview_switch:                     [:remove, :none, :patch],
-    oneview_unmanaged_device:           [:add, :remove, :add_if_missing],
+    oneview_storage_pool:               %i[add_if_missing remove],
+    oneview_storage_system:             %i[add remove edit_credentials add_if_missing],
+    oneview_switch:                     %i[remove none patch],
+    oneview_unmanaged_device:           %i[add remove add_if_missing],
     oneview_uplink_set:                 standard_actions,
     oneview_user:                       standard_actions,
-    oneview_volume:                     standard_actions + [:create_snapshot, :delete_snapshot],
+    oneview_volume:                     standard_actions + %i[create_snapshot delete_snapshot],
     oneview_volume_template:            standard_actions
   }
 
   image_streamer_resources = {
-    image_streamer_artifact_bundle: [:create_if_missing, :update_name, :delete, :download, :upload, :extract,
-                                     :backup, :backup_from_file, :download_backup, :extract_backup],
+    image_streamer_artifact_bundle: %i[create_if_missing update_name delete download upload extract
+                                       backup backup_from_file download_backup extract_backup],
     image_streamer_deployment_plan: standard_actions,
-    image_streamer_golden_image:    standard_actions + [:upload_if_missing, :download, :download_details_archive],
+    image_streamer_golden_image:    standard_actions + %i[upload_if_missing download download_details_archive],
     image_streamer_os_build_plan:   standard_actions,
     image_streamer_plan_script:     standard_actions
   }

--- a/libraries/resource_providers/api200/logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api200/logical_interconnect_provider.rb
@@ -68,7 +68,7 @@ module OneviewCookbook
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         current_firmware = @item.get_firmware
         @context.firmware_data['command'] = action
-        dif_values = @context.firmware_data.select { |k, v| current_firmware[k] != v }
+        dif_values = @context.firmware_data.reject { |k, v| current_firmware[k] == v }
         fw_defined = @context.firmware || @context.firmware_data['sppName']
         raise "Unspecified property: 'firmware'. Please set it before attempting this action." unless fw_defined
         return Chef::Log.info("Firmware #{@context.firmware} from logical interconnect '#{@name}' is up to date") if dif_values.empty?

--- a/libraries/resource_providers/api300.rb
+++ b/libraries/resource_providers/api300.rb
@@ -12,7 +12,7 @@
 module OneviewCookbook
   # Module for Oneview API 300 Resources
   module API300
-    SUPPORTED_VARIANTS ||= %w(C7000 Synergy).freeze
+    SUPPORTED_VARIANTS ||= %w[C7000 Synergy].freeze
 
     # Get resource class that matches the type given
     # @param [String] type Name of the desired class type

--- a/spec/fixtures/cookbooks/oneview_test/recipes/fcoe_network_create.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/fcoe_network_create.rb
@@ -17,7 +17,7 @@
 oneview_fcoe_network 'FCoENetwork1' do
   client node['oneview_test']['client']
   data(
-    vlanId:  701
+    vlanId: 701
   )
   action :create
 end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/fcoe_network_create_if_missing.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/fcoe_network_create_if_missing.rb
@@ -17,7 +17,7 @@
 oneview_fcoe_network 'FCoENetwork2' do
   client node['oneview_test']['client']
   data(
-    vlanId:  702
+    vlanId: 702
   )
   action :create_if_missing
 end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/fcoe_network_delete.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/fcoe_network_delete.rb
@@ -17,7 +17,7 @@
 oneview_fcoe_network 'FCoENetwork3' do
   client node['oneview_test']['client']
   data(
-    vlanId:  703
+    vlanId: 703
   )
   action :delete
 end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/server_hardware_refresh.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/server_hardware_refresh.rb
@@ -17,7 +17,7 @@
 oneview_server_hardware 'ServerHardware1' do
   client node['oneview_test']['client']
   refresh_options(
-    refreshActions: [:ClearSyslog, :PowerOff]
+    refreshActions: %i[ClearSyslog PowerOff]
   )
   action :refresh
 end

--- a/spec/unit/libraries/oneview_helper_spec.rb
+++ b/spec/unit/libraries/oneview_helper_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe OneviewCookbook::Helper do
       fake_class = Class.new
       fake_res = 'fake'
       expect(described_class).to receive(:get_resource_class).with(context, resource_type, OneviewCookbook)
-        .and_return(fake_class)
+                                                             .and_return(fake_class)
       expect(fake_class).to receive(:new).with(context).and_return(fake_res)
       expect(fake_res).to receive(:send).with(:delete).and_return(true)
       expect(described_class.do_resource_action(context, resource_type, :delete)).to eq(true)
@@ -242,13 +242,13 @@ RSpec.describe OneviewCookbook::Helper do
 
   describe '::convert_keys' do
     it 'converts simple hash keys' do
-      simple_1 = { a: 1, b: 2, c: 3 }
-      described_class.convert_keys(simple_1, :to_s).each { |k, _| expect(k).class == String }
+      simple1 = { a: 1, b: 2, c: 3 }
+      described_class.convert_keys(simple1, :to_s).each { |k, _| expect(k).class == String }
     end
 
     it 'converts unary hash key' do
-      simple_2 = { a: 1 }
-      conv = described_class.convert_keys(simple_2, :to_s)
+      simple2 = { a: 1 }
+      conv = described_class.convert_keys(simple2, :to_s)
       expect(conv['a']).to eq(1)
     end
 
@@ -257,23 +257,23 @@ RSpec.describe OneviewCookbook::Helper do
     end
 
     it 'converts nested hash keys' do
-      nested_1 = { a: 1, b: { a: 21, b: 22 }, c: 3 }
-      conv = described_class.convert_keys(nested_1, :to_s)
+      nested1 = { a: 1, b: { a: 21, b: 22 }, c: 3 }
+      conv = described_class.convert_keys(nested1, :to_s)
       conv.each { |k, _| expect(k).class == String }
       expect(conv['b']['a']).to eq(21)
     end
 
     it 'converts double nested hash keys' do
-      nested_2 = { a: 1, b: { a: 21, b: { a: 221, b: 222 } }, c: 3 }
-      conv = described_class.convert_keys(nested_2, :to_s)
+      nested2 = { a: 1, b: { a: 21, b: { a: 221, b: 222 } }, c: 3 }
+      conv = described_class.convert_keys(nested2, :to_s)
       conv.each { |k, _| expect(k).class == String }
       conv['b'].each { |k, _| expect(k).class == String }
       conv['b']['b'].each { |k, _| expect(k).class == String }
     end
 
     it 'converts empty nested hash keys' do
-      nested_3 = { a: 1, b: {}, c: 3 }
-      conv = described_class.convert_keys(nested_3, :to_s)
+      nested3 = { a: 1, b: {}, c: 3 }
+      conv = described_class.convert_keys(nested3, :to_s)
       conv.each { |k, _| expect(k).class == String }
     end
   end

--- a/spec/unit/resources/enclosure/reconfigure_spec.rb
+++ b/spec/unit/resources/enclosure/reconfigure_spec.rb
@@ -7,9 +7,9 @@ describe 'oneview_test::enclosure_reconfigure' do
   it 'reconfigure enclosure already triggered' do
     expect_any_instance_of(OneviewSDK::Enclosure).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewSDK::Enclosure).to receive(:[]).with('reconfigurationState')
-      .and_return('Pending')
+                                                                .and_return('Pending')
     allow_any_instance_of(OneviewSDK::Enclosure).to receive(:[]).with('name')
-      .and_return('Enclosure1')
+                                                                .and_return('Enclosure1')
     expect_any_instance_of(OneviewSDK::Enclosure).to_not receive(:configuration).and_return(true)
     expect(real_chef_run).to reconfigure_oneview_enclosure('Enclosure1')
   end
@@ -17,9 +17,9 @@ describe 'oneview_test::enclosure_reconfigure' do
   it 'reconfigure enclosure with default options' do
     expect_any_instance_of(OneviewSDK::Enclosure).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewSDK::Enclosure).to receive(:[]).with('reconfigurationState')
-      .and_return('NotReapplyingConfiguration')
+                                                                .and_return('NotReapplyingConfiguration')
     allow_any_instance_of(OneviewSDK::Enclosure).to receive(:[]).with('name')
-      .and_return('Enclosure1')
+                                                                .and_return('Enclosure1')
     expect_any_instance_of(OneviewSDK::Enclosure).to receive(:configuration).and_return(true)
     expect(real_chef_run).to reconfigure_oneview_enclosure('Enclosure1')
   end

--- a/spec/unit/resources/enclosure/refresh_spec.rb
+++ b/spec/unit/resources/enclosure/refresh_spec.rb
@@ -7,9 +7,9 @@ describe 'oneview_test::enclosure_refresh' do
   it 'refresh enclosure already triggered' do
     expect_any_instance_of(OneviewSDK::Enclosure).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewSDK::Enclosure).to receive(:[]).with('refreshState')
-      .and_return('RefreshPending')
+                                                                .and_return('RefreshPending')
     allow_any_instance_of(OneviewSDK::Enclosure).to receive(:[]).with('name')
-      .and_return('Enclosure1')
+                                                                .and_return('Enclosure1')
     expect_any_instance_of(OneviewSDK::Enclosure).to_not receive(:set_refresh_state)
     expect(real_chef_run).to refresh_oneview_enclosure('Enclosure1')
   end
@@ -17,9 +17,9 @@ describe 'oneview_test::enclosure_refresh' do
   it 'refresh enclosure with default options' do
     expect_any_instance_of(OneviewSDK::Enclosure).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewSDK::Enclosure).to receive(:[]).with('refreshState')
-      .and_return('NotRefreshing')
+                                                                .and_return('NotRefreshing')
     allow_any_instance_of(OneviewSDK::Enclosure).to receive(:[]).with('name')
-      .and_return('Enclosure1')
+                                                                .and_return('Enclosure1')
     expect_any_instance_of(OneviewSDK::Enclosure).to receive(:set_refresh_state).and_return(true)
     expect(real_chef_run).to refresh_oneview_enclosure('Enclosure1')
   end

--- a/spec/unit/resources/firmware/create_custom_spp_spec.rb
+++ b/spec/unit/resources/firmware/create_custom_spp_spec.rb
@@ -16,7 +16,7 @@ describe 'oneview_test::firmware_create_custom_spp' do
     allow_any_instance_of(OneviewSDK::FirmwareDriver).to receive(:[]).and_call_original
     allow_any_instance_of(OneviewSDK::FirmwareDriver).to receive(:[]).with('uri').and_return('/rest/firmware-drivers/fw1')
     allow_any_instance_of(OneviewSDK::FirmwareDriver).to receive(:[]).with('hotfixUris')
-      .and_return('/rest/firmware-drivers/fw2', '/rest/firmware-drivers/fw3')
+                                                                     .and_return('/rest/firmware-drivers/fw2', '/rest/firmware-drivers/fw3')
     expect_any_instance_of(OneviewSDK::FirmwareDriver).to receive(:create)
     expect(real_chef_run).to create_oneview_firmware_custom_spp('CustomSPP1')
   end

--- a/spec/unit/resources/logical_enclosure/create_spec.rb
+++ b/spec/unit/resources/logical_enclosure/create_spec.rb
@@ -16,9 +16,9 @@ describe 'oneview_test::logical_enclosure_create' do
 
   before :each do
     allow(OneviewSDK::EnclosureGroup).to receive(:find_by).with(instance_of(OneviewSDK::Client), name: 'EG1')
-      .and_return([{ 'uri' => '/rest/fake' }])
+                                                          .and_return([{ 'uri' => '/rest/fake' }])
     allow(OneviewSDK::Enclosure).to receive(:find_by).at_most(2).times
-      .and_return([OneviewSDK::Enclosure.new(client, uri: '/rest/fake')])
+                                                     .and_return([OneviewSDK::Enclosure.new(client, uri: '/rest/fake')])
   end
 
   it 'creates it when it does not exist' do

--- a/spec/unit/resources/logical_enclosure/reconfigure_spec.rb
+++ b/spec/unit/resources/logical_enclosure/reconfigure_spec.rb
@@ -26,11 +26,13 @@ describe 'oneview_test::logical_enclosure_reconfigure' do
   before :each do
     allow_any_instance_of(OneviewSDK::LogicalEnclosure).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewSDK::LogicalEnclosure).to receive(:[]).with('enclosureUris')
-      .and_return(['/rest/enclosures/encl1', '/rest/enclosures/encl2'])
+                                                                       .and_return(['/rest/enclosures/encl1', '/rest/enclosures/encl2'])
     allow_any_instance_of(OneviewSDK::LogicalEnclosure).to receive(:[]).with('name').and_call_original
-    allow(OneviewSDK::Enclosure).to receive(:find_by).with(instance_of(OneviewSDK::Client), 'uri' => '/rest/enclosures/encl1')
+    allow(OneviewSDK::Enclosure).to receive(:find_by)
+      .with(instance_of(OneviewSDK::Client), { 'uri' => '/rest/enclosures/encl1' }, anything, anything)
       .and_return([encl1])
-    allow(OneviewSDK::Enclosure).to receive(:find_by).with(instance_of(OneviewSDK::Client), 'uri' => '/rest/enclosures/encl2')
+    allow(OneviewSDK::Enclosure).to receive(:find_by)
+      .with(instance_of(OneviewSDK::Client), { 'uri' => '/rest/enclosures/encl2' }, anything, anything)
       .and_return([encl2])
   end
 

--- a/spec/unit/resources/logical_switch_group/create_if_missing_spec.rb
+++ b/spec/unit/resources/logical_switch_group/create_if_missing_spec.rb
@@ -6,7 +6,7 @@ describe 'oneview_test::logical_switch_group_create_if_missing' do
 
   before(:each) do
     allow(OneviewSDK::Switch).to receive(:get_type).with(anything, 'Cisco Nexus 50xx')
-      .and_return('uri' => 'rest/fake/switch-uri')
+                                                   .and_return('uri' => 'rest/fake/switch-uri')
   end
 
   it 'creates it when it does not exist' do

--- a/spec/unit/resources/logical_switch_group/create_spec.rb
+++ b/spec/unit/resources/logical_switch_group/create_spec.rb
@@ -6,7 +6,7 @@ describe 'oneview_test::logical_switch_group_create' do
 
   before(:each) do
     allow(OneviewSDK::Switch).to receive(:get_type).with(anything, 'Cisco Nexus 50xx')
-      .and_return('uri' => 'rest/fake/switch-uri')
+                                                   .and_return('uri' => 'rest/fake/switch-uri')
   end
 
   it 'creates it when it does not exist' do

--- a/spec/unit/resources/managed_san/refresh_spec.rb
+++ b/spec/unit/resources/managed_san/refresh_spec.rb
@@ -7,9 +7,9 @@ describe 'oneview_test::managed_san_refresh' do
   it 'refresh managed_san already triggered' do
     expect_any_instance_of(OneviewSDK::ManagedSAN).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewSDK::ManagedSAN).to receive(:[]).with('refreshState')
-      .and_return('RefreshPending')
+                                                                 .and_return('RefreshPending')
     allow_any_instance_of(OneviewSDK::ManagedSAN).to receive(:[]).with('name')
-      .and_return('ManagedSAN1')
+                                                                 .and_return('ManagedSAN1')
     expect_any_instance_of(OneviewSDK::ManagedSAN).to_not receive(:set_refresh_state)
     expect(real_chef_run).to refresh_oneview_managed_san('ManagedSAN1')
   end
@@ -17,9 +17,9 @@ describe 'oneview_test::managed_san_refresh' do
   it 'refresh managed_san with default options' do
     expect_any_instance_of(OneviewSDK::ManagedSAN).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewSDK::ManagedSAN).to receive(:[]).with('refreshState')
-      .and_return('NotRefreshing')
+                                                                 .and_return('NotRefreshing')
     allow_any_instance_of(OneviewSDK::ManagedSAN).to receive(:[]).with('name')
-      .and_return('ManagedSAN1')
+                                                                 .and_return('ManagedSAN1')
     expect_any_instance_of(OneviewSDK::ManagedSAN).to receive(:set_refresh_state).and_return(true)
     expect(real_chef_run).to refresh_oneview_managed_san('ManagedSAN1')
   end

--- a/spec/unit/resources/sas_logical_interconnect/replace_drive_enclosure_spec.rb
+++ b/spec/unit/resources/sas_logical_interconnect/replace_drive_enclosure_spec.rb
@@ -17,9 +17,9 @@ describe 'oneview_test_api300_synergy::sas_logical_interconnect_replace_drive_en
     # Create a new Drive Enclosure
     # Retrieves and returns the SNs
     allow_any_instance_of(provider).to receive(:load_resource).with(:DriveEnclosure, 'OLD_DRIVE', 'serialNumber')
-      .and_return('SNFAKE1')
+                                                              .and_return('SNFAKE1')
     allow_any_instance_of(provider).to receive(:load_resource).with(:DriveEnclosure, 'NEW_DRIVE', 'serialNumber')
-      .and_return('SNFAKE2')
+                                                              .and_return('SNFAKE2')
     # It finds the resource
     expect_any_instance_of(klass).to receive(:retrieve!).and_return(true)
     # It calls the replace method
@@ -56,7 +56,7 @@ describe 'oneview_test_api300_synergy::sas_logical_interconnect_replace_drive_en
     # Check the data first and find the serials
     # Old drive enclosure cannot be found by name
     allow_any_instance_of(provider).to receive(:load_resource).with(:DriveEnclosure, 'OLD_DRIVE', 'serialNumber')
-      .and_return(nil)
+                                                              .and_return(nil)
     expect_any_instance_of(klass).to_not receive(:replace_drive_enclosure)
     expect { real_chef_run }.to raise_error(RuntimeError, /InvalidParameters: Old drive enclosure/)
   end
@@ -65,9 +65,9 @@ describe 'oneview_test_api300_synergy::sas_logical_interconnect_replace_drive_en
     # Check the data first and find the serials
     # New drive enclosure cannot be found by name
     allow_any_instance_of(provider).to receive(:load_resource).with(:DriveEnclosure, 'OLD_DRIVE', 'serialNumber')
-      .and_return('SNFAKE1')
+                                                              .and_return('SNFAKE1')
     allow_any_instance_of(provider).to receive(:load_resource).with(:DriveEnclosure, 'NEW_DRIVE', 'serialNumber')
-      .and_return(nil)
+                                                              .and_return(nil)
     expect_any_instance_of(klass).to_not receive(:replace_drive_enclosure)
     expect { real_chef_run }.to raise_error(RuntimeError, /InvalidParameters: New drive enclosure/)
   end
@@ -75,9 +75,9 @@ describe 'oneview_test_api300_synergy::sas_logical_interconnect_replace_drive_en
   it 'fails if the SAS logical interconnect is not found' do
     # Check the data first and find the serials
     allow_any_instance_of(provider).to receive(:load_resource).with(:DriveEnclosure, 'OLD_DRIVE', 'serialNumber')
-      .and_return('SNFAKE1')
+                                                              .and_return('SNFAKE1')
     allow_any_instance_of(provider).to receive(:load_resource).with(:DriveEnclosure, 'NEW_DRIVE', 'serialNumber')
-      .and_return('SNFAKE2')
+                                                              .and_return('SNFAKE2')
     expect_any_instance_of(klass).to receive(:retrieve!).and_return(false)
     expect_any_instance_of(klass).to_not receive(:replace_drive_enclosure)
     expect { real_chef_run }.to raise_error(RuntimeError, /not found/)

--- a/spec/unit/resources/server_hardware/refresh_spec.rb
+++ b/spec/unit/resources/server_hardware/refresh_spec.rb
@@ -7,9 +7,9 @@ describe 'oneview_test::server_hardware_refresh' do
   it 'refresh server hardware already triggered' do
     expect_any_instance_of(OneviewSDK::ServerHardware).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewSDK::ServerHardware).to receive(:[]).with('refreshState')
-      .and_return('RefreshPending')
+                                                                     .and_return('RefreshPending')
     allow_any_instance_of(OneviewSDK::ServerHardware).to receive(:[]).with('name')
-      .and_return('ServerHardware1')
+                                                                     .and_return('ServerHardware1')
     expect_any_instance_of(OneviewSDK::ServerHardware).to_not receive(:set_refresh_state)
     expect(real_chef_run).to refresh_oneview_server_hardware('ServerHardware1')
   end
@@ -17,9 +17,9 @@ describe 'oneview_test::server_hardware_refresh' do
   it 'refresh server hardware with default options' do
     expect_any_instance_of(OneviewSDK::ServerHardware).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewSDK::ServerHardware).to receive(:[]).with('refreshState')
-      .and_return('NotRefreshing')
+                                                                     .and_return('NotRefreshing')
     allow_any_instance_of(OneviewSDK::ServerHardware).to receive(:[]).with('name')
-      .and_return('ServerHardware1')
+                                                                     .and_return('ServerHardware1')
     expect_any_instance_of(OneviewSDK::ServerHardware).to receive(:set_refresh_state).and_return(true)
     expect(real_chef_run).to refresh_oneview_server_hardware('ServerHardware1')
   end

--- a/spec/unit/resources/server_profile/properties_spec.rb
+++ b/spec/unit/resources/server_profile/properties_spec.rb
@@ -29,10 +29,10 @@ describe 'oneview_test::server_profile_properties' do
     en1 = OneviewSDK::EthernetNetwork.new(@client, name: 'EthernetNetwork1', uri: 'rest/fake1')
 
     allow_any_instance_of(provider).to receive(:set_connections).and_call_original
-    allow_any_instance_of(provider).to receive(:set_connections)
-      .with(:EthernetNetwork, anything)
-      .and_wrap_original { |m, *args| m.call(args.first, [args.last]) }
-
+    # mock_set_connections = proc { |m, *args|  }
+    allow_any_instance_of(provider).to receive(:set_connections).with(:EthernetNetwork, anything).and_wrap_original do |m, *args|
+      m.call(args.first, [args.last])
+    end
     allow_any_instance_of(provider).to receive(:load_resource).and_call_original
     allow_any_instance_of(provider).to receive(:load_resource).with(anything, 'ServerHardware1').and_return(sh1)
     allow_any_instance_of(provider).to receive(:load_resource).with(anything, 'EthernetNetwork1').and_return(en1)
@@ -51,9 +51,10 @@ describe 'oneview_test::server_profile_properties' do
     sh1 = OneviewSDK::ServerHardware.new(@client, name: 'ServerHardware1', uri: 'rest/fake0')
 
     allow_any_instance_of(provider).to receive(:set_connections).and_call_original
-    allow_any_instance_of(provider).to receive(:set_connections)
-      .with(:EthernetNetwork, anything)
-      .and_wrap_original { |m, *args| m.call(args.first, 'I am potato') }
+    # mock_set_connections = proc {   }
+    allow_any_instance_of(provider).to receive(:set_connections).with(:EthernetNetwork, anything).and_wrap_original do |m, *args|
+      m.call(args.first, 'I am potato')
+    end
 
     allow_any_instance_of(provider).to receive(:load_resource).and_call_original
     allow_any_instance_of(provider).to receive(:load_resource).with(anything, 'ServerHardware1').and_return(sh1)
@@ -97,7 +98,7 @@ describe 'oneview_test_api300_synergy::server_profile_properties' do
 
     allow_any_instance_of(base_sdk::ServerProfile).to receive(:[]).and_call_original
     allow_any_instance_of(base_sdk::ServerProfile).to receive(:[]).with('osDeploymentSettings')
-      .and_return('osCustomAttributes' => ['name' => 'works', 'value' => 'too'])
+                                                                  .and_return('osCustomAttributes' => ['name' => 'works', 'value' => 'too'])
 
     expect_any_instance_of(base_sdk::ServerProfile).to receive(:set_os_deployment_settings)
       .with(osdp, ['name' => 'works', 'value' => 'too'])
@@ -121,7 +122,9 @@ describe 'oneview_test_api300_synergy::server_profile_properties' do
     allow_any_instance_of(provider).to receive(:load_resource).with(:OSDeploymentPlan, 'OSDeploymentPlan1').and_return(osdp)
 
     allow_any_instance_of(base_sdk::ServerProfile).to receive(:[]).and_call_original
-    allow_any_instance_of(base_sdk::ServerProfile).to receive(:[]).with('osDeploymentSettings')
+    allow_any_instance_of(base_sdk::ServerProfile)
+      .to receive(:[])
+      .with('osDeploymentSettings')
       .and_return('osCustomAttributes' => [{ 'name' => 'b', 'value' => 'custom' },
                                            { 'name' => 'c', 'value' => 'override' },
                                            { 'name' => 'd', 'value' => 'custom' }])

--- a/spec/unit/resources/server_profile/update_from_template_spec.rb
+++ b/spec/unit/resources/server_profile/update_from_template_spec.rb
@@ -10,7 +10,7 @@ describe 'oneview_test::server_profile_update_from_template' do
 
   before :each do
     allow_any_instance_of(klass).to receive(:get_compliance_preview)
-      .and_return(isOnlineUpdate: true, automaticUpdates: [:stuff, :things], manualUpdates: [])
+      .and_return(isOnlineUpdate: true, automaticUpdates: %i[stuff things], manualUpdates: [])
     allow(Chef::Log).to receive(:info)
   end
 

--- a/spec/unit/resources/user/create_spec.rb
+++ b/spec/unit/resources/user/create_spec.rb
@@ -18,8 +18,7 @@ describe 'oneview_test::user_create' do
     expect_any_instance_of(klass).to receive(:update).once.and_return(true)
     expect_any_instance_of(klass).to receive(:update).with(password: 'secret123').once.and_return(true)
     expect(OneviewSDK::Client).to receive(:new).once.and_call_original
-    expect(OneviewSDK::Client).to receive(:new).once
-      .and_raise(OneviewSDK::BadRequest, 'errorCode":"AUTHN_AUTH_DIR_FAIL","message":"Invalid username or password or directory.')
+    expect(OneviewSDK::Client).to receive(:new).once.and_raise(OneviewSDK::BadRequest, 'Invalid username or password')
     expect(Chef::Log).to_not receive(:info).with(/password is up to date/)
     expect(real_chef_run).to create_oneview_user('User1')
   end
@@ -31,8 +30,7 @@ describe 'oneview_test::user_create' do
     expect_any_instance_of(klass).to_not receive(:create)
     expect_any_instance_of(klass).to receive(:update).once.with(password: 'secret123').and_return(true)
     expect(OneviewSDK::Client).to receive(:new).once.and_call_original
-    expect(OneviewSDK::Client).to receive(:new).once
-      .and_raise(OneviewSDK::BadRequest, 'errorCode":"AUTHN_AUTH_DIR_FAIL","message":"Invalid username or password or directory.')
+    expect(OneviewSDK::Client).to receive(:new).once.and_raise(OneviewSDK::BadRequest, 'Invalid username or password')
     expect(Chef::Log).to_not receive(:info).with(/password is up to date/)
     expect(real_chef_run).to create_oneview_user('User1')
   end

--- a/spec/unit/resources/volume/create_if_missing_spec.rb
+++ b/spec/unit/resources/volume/create_if_missing_spec.rb
@@ -13,7 +13,9 @@ describe 'oneview_test::volume_create_if_missing' do
     )
     allow_any_instance_of(OneviewSDK::StorageSystem).to receive(:exists?).and_return(false)
     allow_any_instance_of(OneviewCookbook::API200::VolumeProvider).to receive(:load_resource).and_call_original
-    allow_any_instance_of(OneviewCookbook::API200::VolumeProvider).to receive(:load_resource).with(:StorageSystem, anything)
+    allow_any_instance_of(OneviewCookbook::API200::VolumeProvider)
+      .to receive(:load_resource)
+      .with(:StorageSystem, anything)
       .and_return(OneviewSDK::StorageSystem.new(client, name: 'StorageSystem1', uri: '/rest/storage-systems/1'))
   end
 

--- a/spec/unit/resources/volume/create_spec.rb
+++ b/spec/unit/resources/volume/create_spec.rb
@@ -13,7 +13,9 @@ describe 'oneview_test::volume_create' do
     )
     allow_any_instance_of(OneviewSDK::StorageSystem).to receive(:exists?).and_return(false)
     allow_any_instance_of(OneviewCookbook::API200::VolumeProvider).to receive(:load_resource).and_call_original
-    allow_any_instance_of(OneviewCookbook::API200::VolumeProvider).to receive(:load_resource).with(:StorageSystem, anything)
+    allow_any_instance_of(OneviewCookbook::API200::VolumeProvider)
+      .to receive(:load_resource)
+      .with(:StorageSystem, anything)
       .and_return(OneviewSDK::StorageSystem.new(client, name: 'StorageSystem1', uri: '/rest/storage-systems/1'))
     allow_any_instance_of(OneviewSDK::Volume).to receive(:exists?).and_return(false)
   end

--- a/spec/unit/resources/volume_template/create_if_missing_spec.rb
+++ b/spec/unit/resources/volume_template/create_if_missing_spec.rb
@@ -8,7 +8,9 @@ describe 'oneview_test::volume_template_create_if_missing' do
     allow_any_instance_of(OneviewSDK::VolumeTemplate).to receive(:exists?).and_return(false)
     allow_any_instance_of(OneviewSDK::VolumeTemplate).to receive(:retrieve!).and_return(false)
     allow_any_instance_of(OneviewCookbook::API200::VolumeTemplateProvider).to receive(:load_resource).and_call_original
-    allow_any_instance_of(OneviewCookbook::API200::VolumeTemplateProvider).to receive(:load_resource).with(:StorageSystem, anything)
+    allow_any_instance_of(OneviewCookbook::API200::VolumeTemplateProvider)
+      .to receive(:load_resource)
+      .with(:StorageSystem, anything)
       .and_return(OneviewSDK::StorageSystem.new(client, name: 'StorageSystem1', uri: '/rest/storage-systems/1'))
     allow(OneviewSDK::StoragePool).to receive(:find_by)
       .and_return([OneviewSDK::StoragePool.new(client, uri: 'rest/sp1')])
@@ -20,7 +22,9 @@ describe 'oneview_test::volume_template_create_if_missing' do
     allow_any_instance_of(OneviewSDK::VolumeTemplate).to receive(:exists?).and_return(true)
     allow_any_instance_of(OneviewSDK::VolumeTemplate).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewCookbook::API200::VolumeTemplateProvider).to receive(:load_resource).and_call_original
-    allow_any_instance_of(OneviewCookbook::API200::VolumeTemplateProvider).to receive(:load_resource).with(:StorageSystem, anything)
+    allow_any_instance_of(OneviewCookbook::API200::VolumeTemplateProvider)
+      .to receive(:load_resource)
+      .with(:StorageSystem, anything)
       .and_return(OneviewSDK::StorageSystem.new(client, name: 'StorageSystem1', uri: '/rest/storage-systems/1'))
     allow_any_instance_of(OneviewSDK::StorageSystem).to receive(:exists?).and_return(true)
     allow_any_instance_of(OneviewSDK::StorageSystem).to receive(:retrieve!).and_return(true)

--- a/spec/unit/resources/volume_template/create_spec.rb
+++ b/spec/unit/resources/volume_template/create_spec.rb
@@ -8,7 +8,9 @@ describe 'oneview_test::volume_template_create' do
     allow_any_instance_of(OneviewSDK::VolumeTemplate).to receive(:exists?).and_return(false)
     allow_any_instance_of(OneviewSDK::VolumeTemplate).to receive(:retrieve!).and_return(false)
     allow_any_instance_of(OneviewCookbook::API200::VolumeTemplateProvider).to receive(:load_resource).and_call_original
-    allow_any_instance_of(OneviewCookbook::API200::VolumeTemplateProvider).to receive(:load_resource).with(:StorageSystem, anything)
+    allow_any_instance_of(OneviewCookbook::API200::VolumeTemplateProvider)
+      .to receive(:load_resource)
+      .with(:StorageSystem, anything)
       .and_return(OneviewSDK::StorageSystem.new(client, name: 'StorageSystem1', uri: '/rest/storage-systems/1'))
     allow_any_instance_of(OneviewSDK::StorageSystem).to receive(:exists?).and_return(true)
     allow_any_instance_of(OneviewSDK::StorageSystem).to receive(:retrieve!).and_return(true)
@@ -22,7 +24,9 @@ describe 'oneview_test::volume_template_create' do
     allow_any_instance_of(OneviewSDK::VolumeTemplate).to receive(:exists?).and_return(true)
     allow_any_instance_of(OneviewSDK::VolumeTemplate).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewCookbook::API200::VolumeTemplateProvider).to receive(:load_resource).and_call_original
-    allow_any_instance_of(OneviewCookbook::API200::VolumeTemplateProvider).to receive(:load_resource).with(:StorageSystem, anything)
+    allow_any_instance_of(OneviewCookbook::API200::VolumeTemplateProvider)
+      .to receive(:load_resource)
+      .with(:StorageSystem, anything)
       .and_return(OneviewSDK::StorageSystem.new(client, name: 'StorageSystem1', uri: '/rest/storage-systems/1'))
     allow_any_instance_of(OneviewSDK::StorageSystem).to receive(:exists?).and_return(true)
     allow_any_instance_of(OneviewSDK::StorageSystem).to receive(:retrieve!).and_return(true)
@@ -37,7 +41,9 @@ describe 'oneview_test::volume_template_create' do
     allow_any_instance_of(OneviewSDK::VolumeTemplate).to receive(:exists?).and_return(true)
     allow_any_instance_of(OneviewSDK::VolumeTemplate).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewCookbook::API200::VolumeTemplateProvider).to receive(:load_resource).and_call_original
-    allow_any_instance_of(OneviewCookbook::API200::VolumeTemplateProvider).to receive(:load_resource).with(:StorageSystem, anything)
+    allow_any_instance_of(OneviewCookbook::API200::VolumeTemplateProvider)
+      .to receive(:load_resource)
+      .with(:StorageSystem, anything)
       .and_return(OneviewSDK::StorageSystem.new(client, name: 'StorageSystem1', uri: '/rest/storage-systems/1'))
     allow_any_instance_of(OneviewSDK::StorageSystem).to receive(:exists?).and_return(true)
     allow_any_instance_of(OneviewSDK::StorageSystem).to receive(:retrieve!).and_return(true)


### PR DESCRIPTION
### Description
Updates the gems, includig the oneview-sdk (5.0.0).

Also fixes all the consequences (mainly new rucobop style).

### Issues Resolved
#246 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [ ] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
