### PR TITLE
API 500 Support for FC Network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Adds API 500 support to the following HPE OneView resources:
   - oneview_ethernet_network
   - oneview_event
   - oneview_fabric
+  - oneview_fc_network
   - oneview_firmware
   - oneview_id_pool
   - oneview_managed_san

--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ Note: The `:bandwidth` can be defined inside `data` attribute. However, it will 
 oneview_ethernet_network 'Eth1' do
   client <my_client>
   data <resource_data>
-  operation <op>         # String. Used in patch action only. e.g., 'replace'
-  path <path>            # String. Used in patch option only. e.g., '/name'
-  value <val>            # String, Array. Used in patch option only. e.g., 'New Name'
-  scopes [<scope_names>] # Array - Optional. Array of scope names. Used in add_to_scopes, remove_from_scopes or replace_scopes options only. e.g., ['Scope1', 'Scope2']
+  operation <op>       # String. Used in patch action only. e.g., 'replace'
+  path <path>          # String. Used in patch option only. e.g., '/name'
+  value <val>          # String, Array. Used in patch option only. e.g., 'New Name'
+  scopes <scope_names> # Array - Optional. Array of scope names. Used in add_to_scopes, remove_from_scopes or replace_scopes options only. e.g., ['Scope1', 'Scope2']
   action [:create, :create_if_missing, :delete, :reset_connection_template, :patch, :add_to_scopes, :remove_from_scopes, :replace_scopes]
 end
 ```
@@ -158,7 +158,7 @@ oneview_fc_network 'Fc1' do
   operation <op>            # String. Used in patch action only. e.g., 'add'
   path <path>               # String. Used in patch option only. e.g., '/scopeUris/-'
   value <val>               # String. Used in patch option only. e.g., 'scope uri'
-  scopes [<scope_names>]    # Array - Optional. Array of scope names. Used in add_to_scopes, remove_from_scopes or replace_scopes options only. e.g., ['Scope1', 'Scope2']
+  scopes <scope_names>      # Array - Optional. Array of scope names. Used in add_to_scopes, remove_from_scopes or replace_scopes options only. e.g., ['Scope1', 'Scope2']
   action [:create, :create_if_missing, :delete, :reset_connection_template, :patch, :add_to_scopes, :remove_from_scopes, :replace_scopes]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -154,9 +154,10 @@ end
 oneview_fc_network 'Fc1' do
   client <my_client>
   data <resource_data>
-  operation <op> # String. Used in patch action only. e.g., 'add'
-  path <path>    # String. Used in patch option only. e.g., '/scopeUris/-'
-  value <val>    # String. Used in patch option only. e.g., 'scope uri'
+  associated_san <san_name> # String - Optional. Can also set managedSanUri in data
+  operation <op>            # String. Used in patch action only. e.g., 'add'
+  path <path>               # String. Used in patch option only. e.g., '/scopeUris/-'
+  value <val>               # String. Used in patch option only. e.g., 'scope uri'
   action [:create, :create_if_missing, :delete, :patch]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ end
 oneview_fc_network 'Fc1' do
   client <my_client>
   data <resource_data>
-  action [:create, :create_if_missing, :delete]
+  action [:create, :create_if_missing, :delete, :patch]
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ end
 oneview_fc_network 'Fc1' do
   client <my_client>
   data <resource_data>
+  operation <op> # String. Used in patch action only. e.g., 'add'
+  path <path>    # String. Used in patch option only. e.g., '/scopeUris/-'
+  value <val>    # String. Used in patch option only. e.g., 'scope uri'
   action [:create, :create_if_missing, :delete, :patch]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ oneview_fc_network 'Fc1' do
   operation <op>            # String. Used in patch action only. e.g., 'add'
   path <path>               # String. Used in patch option only. e.g., '/scopeUris/-'
   value <val>               # String. Used in patch option only. e.g., 'scope uri'
-  action [:create, :create_if_missing, :delete, :patch]
+  scopes [<scope_names>]    # Array - Optional. Array of scope names. Used in add_to_scopes, remove_from_scopes or replace_scopes options only. e.g., ['Scope1', 'Scope2']
+  action [:create, :create_if_missing, :delete, :reset_connection_template, :patch, :add_to_scopes, :remove_from_scopes, :replace_scopes]
 end
 ```
 

--- a/examples/fc_network.rb
+++ b/examples/fc_network.rb
@@ -15,7 +15,7 @@ my_client = {
   password: ENV['ONEVIEWSDK_PASSWORD']
 }
 
-oneview_fc_network 'Fc1' do
+oneview_fc_network 'Fc1-Create' do
   data(
     autoLoginRedistribution: true,
     fabricType: 'FabricAttach'
@@ -24,7 +24,17 @@ oneview_fc_network 'Fc1' do
   action :create
 end
 
-oneview_fc_network 'Fc1' do
+oneview_fc_network 'Fc1-Scope' do
   client my_client
+  data(name: 'Fc1-Create')
+  operation 'add'
+  path '/scopeUris/-'
+  value '/rest/scopes/7887dc77-c4b7-474a-9b9e-b7cba3d11d93'
+  action :patch
+end
+
+oneview_fc_network 'Fc1-Delete' do
+  client my_client
+  data(name: 'Fc1-Create')
   action :delete
 end

--- a/examples/fc_network.rb
+++ b/examples/fc_network.rb
@@ -15,7 +15,7 @@ my_client = {
   password: ENV['ONEVIEWSDK_PASSWORD']
 }
 
-oneview_fc_network 'Fc1-Create' do
+oneview_fc_network 'Fc1' do
   data(
     autoLoginRedistribution: true,
     fabricType: 'FabricAttach'
@@ -24,17 +24,15 @@ oneview_fc_network 'Fc1-Create' do
   action :create
 end
 
-oneview_fc_network 'Fc1-Scope' do
+oneview_fc_network 'Fc1' do
   client my_client
-  data(name: 'Fc1-Create')
   operation 'add'
   path '/scopeUris/-'
   value '/rest/scopes/7887dc77-c4b7-474a-9b9e-b7cba3d11d93'
   action :patch
 end
 
-oneview_fc_network 'Fc1-Delete' do
+oneview_fc_network 'Fc1' do
   client my_client
-  data(name: 'Fc1-Create')
   action :delete
 end

--- a/examples/fc_network.rb
+++ b/examples/fc_network.rb
@@ -15,7 +15,8 @@
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
   user: ENV['ONEVIEWSDK_USER'],
-  password: ENV['ONEVIEWSDK_PASSWORD']
+  password: ENV['ONEVIEWSDK_PASSWORD'],
+  api_version: 300
 }
 
 # Example: Create and manage a new fc network

--- a/examples/fc_network.rb
+++ b/examples/fc_network.rb
@@ -25,6 +25,16 @@ oneview_fc_network 'Fc1' do
 end
 
 oneview_fc_network 'Fc1' do
+  data(
+    autoLoginRedistribution: true,
+    fabricType: 'FabricAttach'
+  )
+  associated_san 'SAN1_0'
+  client my_client
+  action :create_if_missing
+end
+
+oneview_fc_network 'Fc1' do
   client my_client
   operation 'add'
   path '/scopeUris/-'

--- a/examples/fc_network.rb
+++ b/examples/fc_network.rb
@@ -9,12 +9,16 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+# NOTE 1: This example requires two Scopes named "Scope1" and "Scope2" to be present in the appliance.
+# NOTE 2: The api_version client should be greater than 200 if you run the examples using Scopes
+
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
   user: ENV['ONEVIEWSDK_USER'],
   password: ENV['ONEVIEWSDK_PASSWORD']
 }
 
+# Example: Create and manage a new fc network
 oneview_fc_network 'Fc1' do
   data(
     autoLoginRedistribution: true,
@@ -24,24 +28,58 @@ oneview_fc_network 'Fc1' do
   action :create
 end
 
+# Example: Create a new fc network only if it doesn't exist.
 oneview_fc_network 'Fc1' do
   data(
     autoLoginRedistribution: true,
-    fabricType: 'FabricAttach'
+    fabricType: 'FabricAttach',
+    bandwidth: {
+      typicalBandwidth: 2000,
+      maximumBandwidth: 9000
+    }
   )
   associated_san 'SAN1_0'
   client my_client
   action :create_if_missing
 end
 
+# Example: Adds 'Fc1' to 'Scope1' and 'Scope2'
 oneview_fc_network 'Fc1' do
   client my_client
-  operation 'add'
-  path '/scopeUris/-'
-  value '/rest/scopes/7887dc77-c4b7-474a-9b9e-b7cba3d11d93'
+  scopes ['Scope1', 'Scope2']
+  action :add_to_scopes
+end
+
+# Example: Removes 'Fc1' from 'Scope1'
+oneview_fc_network 'Fc1' do
+  client my_client
+  scopes ['Scope1']
+  action :remove_from_scopes
+end
+
+# Example: Replaces 'Scope1' and 'Scope2' for 'Fc1'
+oneview_fc_network 'Fc1' do
+  client my_client
+  scopes ['Scope1', 'Scope2']
+  action :replace_scopes
+end
+
+# Example: Replaces all scopes to empty list of scopes
+oneview_fc_network 'Fc1' do
+  client my_client
+  operation 'replace'
+  path '/scopeUris'
+  value []
   action :patch
 end
 
+# Example: Reset the connection template for a fc network
+oneview_fc_network 'Fc1' do
+  client my_client
+  action :reset_connection_template
+end
+
+# Example: Delete an fc network
 oneview_fc_network 'Fc1' do
   client my_client
   action :delete

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -28,7 +28,7 @@ if defined?(ChefSpec)
     oneview_ethernet_network:           standard_actions + scope_actions + %i[reset_connection_template],
     oneview_event:                      [:create],
     oneview_fabric:                     [:set_reserved_vlan_range],
-    oneview_fc_network:                 standard_actions + [:patch],
+    oneview_fc_network:                 standard_actions + scope_actions + %i[reset_connection_template],
     oneview_fcoe_network:               standard_actions,
     oneview_firmware:                   %i[add remove create_custom_spp],
     oneview_id_pool:                    %i[update allocate_list allocate_count collect_ids],

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -28,7 +28,7 @@ if defined?(ChefSpec)
     oneview_ethernet_network:           standard_actions + scope_actions + %i[reset_connection_template],
     oneview_event:                      [:create],
     oneview_fabric:                     [:set_reserved_vlan_range],
-    oneview_fc_network:                 standard_actions,
+    oneview_fc_network:                 standard_actions + [:patch],
     oneview_fcoe_network:               standard_actions,
     oneview_firmware:                   %i[add remove create_custom_spp],
     oneview_id_pool:                    %i[update allocate_list allocate_count collect_ids],

--- a/libraries/resource_providers/api200/fc_network_provider.rb
+++ b/libraries/resource_providers/api200/fc_network_provider.rb
@@ -12,7 +12,7 @@
 module OneviewCookbook
   module API200
     # FC Network Provider resource methods
-    class FCNetworkProvider < ResourceProvider
+    class FCNetworkProvider < EthernetNetworkProvider
       def load_associated_san
         return unless @new_resource.associated_san
         san = resource_named(:ManagedSAN).new(@item.client, name: @new_resource.associated_san)

--- a/libraries/resource_providers/api200/fc_network_provider.rb
+++ b/libraries/resource_providers/api200/fc_network_provider.rb
@@ -13,6 +13,22 @@ module OneviewCookbook
   module API200
     # FC Network Provider resource methods
     class FCNetworkProvider < ResourceProvider
+      def load_associated_san
+        return unless @new_resource.associated_san
+        san = resource_named(:ManagedSAN).new(@item.client, name: @new_resource.associated_san)
+        raise "SAN '#{san['name']}' not found!" unless san.retrieve!
+        @item['managedSanUri'] = san['uri']
+      end
+
+      def create_or_update
+        load_associated_san
+        super
+      end
+
+      def create_if_missing
+        load_associated_san
+        super
+      end
     end
   end
 end

--- a/libraries/resource_providers/api200/fc_network_provider.rb
+++ b/libraries/resource_providers/api200/fc_network_provider.rb
@@ -9,6 +9,8 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+require_relative 'ethernet_network_provider'
+
 module OneviewCookbook
   module API200
     # FC Network Provider resource methods

--- a/libraries/resource_providers/api500/c7000/fc_network_provider.rb
+++ b/libraries/resource_providers/api500/c7000/fc_network_provider.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/fc_network_provider'
+
+module OneviewCookbook
+  module API500
+    module C7000
+      # FCNetwork API500 C7000 provider
+      class FCNetworkProvider < OneviewCookbook::API300::C7000::FCNetworkProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api500/c7000/fc_network_provider.rb
+++ b/libraries/resource_providers/api500/c7000/fc_network_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/c7000/fc_network_provider'
-
 module OneviewCookbook
   module API500
     module C7000

--- a/libraries/resource_providers/api500/synergy/fc_network_provider.rb
+++ b/libraries/resource_providers/api500/synergy/fc_network_provider.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/fc_network_provider'
+
+module OneviewCookbook
+  module API500
+    module Synergy
+      # FCNetwork API500 Synergy provider
+      class FCNetworkProvider < OneviewCookbook::API300::Synergy::FCNetworkProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api500/synergy/fc_network_provider.rb
+++ b/libraries/resource_providers/api500/synergy/fc_network_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/synergy/fc_network_provider'
-
 module OneviewCookbook
   module API500
     module Synergy

--- a/resources/fc_network.rb
+++ b/resources/fc_network.rb
@@ -24,3 +24,7 @@ end
 action :delete do
   OneviewCookbook::Helper.do_resource_action(self, :FCNetwork, :delete)
 end
+
+action :patch do
+  OneviewCookbook::Helper.do_resource_action(self, :FCNetwork, :patch)
+end

--- a/resources/fc_network.rb
+++ b/resources/fc_network.rb
@@ -13,6 +13,8 @@ OneviewCookbook::ResourceBaseProperties.load(self)
 
 default_action :create
 
+property :associated_san, String
+
 action :create do
   OneviewCookbook::Helper.do_resource_action(self, :FCNetwork, :create_or_update)
 end

--- a/resources/fc_network.rb
+++ b/resources/fc_network.rb
@@ -14,6 +14,7 @@ OneviewCookbook::ResourceBaseProperties.load(self)
 default_action :create
 
 property :associated_san, String
+property :scopes, Array
 
 action :create do
   OneviewCookbook::Helper.do_resource_action(self, :FCNetwork, :create_or_update)
@@ -27,6 +28,22 @@ action :delete do
   OneviewCookbook::Helper.do_resource_action(self, :FCNetwork, :delete)
 end
 
+action :add_to_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :FCNetwork, :add_to_scopes)
+end
+
+action :remove_from_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :FCNetwork, :remove_from_scopes)
+end
+
+action :replace_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :FCNetwork, :replace_scopes)
+end
+
 action :patch do
   OneviewCookbook::Helper.do_resource_action(self, :FCNetwork, :patch)
+end
+
+action :reset_connection_template do
+  OneviewCookbook::Helper.do_resource_action(self, :FCNetwork, :reset_connection_template)
 end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/fc_network_create.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/fc_network_create.rb
@@ -16,6 +16,7 @@
 
 oneview_fc_network 'FCNetwork1' do
   client node['oneview_test']['client']
+  associated_san 'SAN1'
   data(
     autoLoginRedistribution: true,
     fabricType: 'FabricAttach'

--- a/spec/fixtures/cookbooks/oneview_test/recipes/fc_network_create_if_missing.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/fc_network_create_if_missing.rb
@@ -16,6 +16,7 @@
 
 oneview_fc_network 'FCNetwork2' do
   client node['oneview_test']['client']
+  associated_san 'SAN1'
   data(
     autoLoginRedistribution: true,
     fabricType: 'FabricAttach'

--- a/spec/fixtures/cookbooks/oneview_test/recipes/fc_network_reset_connection_template.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/fc_network_reset_connection_template.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: fc_network_reset_connection_template
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_fc_network 'FCNetwork4' do
+  client node['oneview_test']['client']
+  action :reset_connection_template
+end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/fc_network_add_to_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/fc_network_add_to_scopes.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: fc_network_add_to_scopes
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_fc_network 'FCNetwork1' do
+  client node['oneview_test']['client']
+  scopes ['Scope1', 'Scope2']
+  action :add_to_scopes
+end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/fc_network_patch.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/fc_network_patch.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: fcv_network_patch
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_fc_network 'FCNetwork4' do
+  client node['oneview_test']['client']
+  operation 'test'
+  path 'test/'
+  value 'TestMessage'
+  action :patch
+end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/fc_network_patch.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/fc_network_patch.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: oneview_test_api300_synergy
-# Recipe:: fcv_network_patch
+# Recipe:: fc_network_patch
 #
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/fc_network_remove_from_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/fc_network_remove_from_scopes.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: fc_network_remove_from_scopes
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_fc_network 'FCNetwork1' do
+  client node['oneview_test']['client']
+  scopes ['Scope1', 'Scope2']
+  action :remove_from_scopes
+end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/fc_network_replace_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/fc_network_replace_scopes.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: fc_network_replace_scopes
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_fc_network 'FCNetwork1' do
+  client node['oneview_test']['client']
+  scopes ['Scope1', 'Scope2']
+  action :replace_scopes
+end

--- a/spec/unit/resources/fc_network/add_to_scopes_spec.rb
+++ b/spec/unit/resources/fc_network/add_to_scopes_spec.rb
@@ -1,0 +1,37 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::fc_network_add_to_scopes' do
+  let(:resource_name) { 'fc_network' }
+  include_context 'chef context'
+
+  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
+  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
+
+  before do
+    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
+    allow(scope1).to receive(:retrieve!).and_return(true)
+    allow(scope2).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).and_call_original
+  end
+
+  it 'adds all scopes when are not added' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return([])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:add_scope).with(scope1)
+    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:add_scope).with(scope2)
+    expect(real_chef_run).to add_oneview_fc_network_to_scopes('FCNetwork1')
+  end
+
+  it 'adds only the scope that is not added' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).not_to receive(:add_scope).with(scope1)
+    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:add_scope).with(scope2)
+    expect(real_chef_run).to add_oneview_fc_network_to_scopes('FCNetwork1')
+  end
+
+  it 'does nothing when scopes are already added' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).not_to receive(:add_scope)
+    expect(real_chef_run).to add_oneview_fc_network_to_scopes('FCNetwork1')
+  end
+end

--- a/spec/unit/resources/fc_network/create_if_missing_spec.rb
+++ b/spec/unit/resources/fc_network/create_if_missing_spec.rb
@@ -7,13 +7,20 @@ describe 'oneview_test::fc_network_create_if_missing' do
   it 'creates it when it does not exist' do
     expect_any_instance_of(OneviewSDK::FCNetwork).to receive(:exists?).and_return(false)
     expect_any_instance_of(OneviewSDK::FCNetwork).to receive(:create).and_return(true)
+    expect_any_instance_of(OneviewSDK::ManagedSAN).to receive(:retrieve!).and_return(true)
     expect(real_chef_run).to create_oneview_fc_network_if_missing('FCNetwork2')
   end
 
   it 'does nothing when it exists' do
     expect_any_instance_of(OneviewSDK::FCNetwork).to receive(:exists?).and_return(true)
     expect_any_instance_of(OneviewSDK::FCNetwork).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(OneviewSDK::ManagedSAN).to receive(:retrieve!).and_return(true)
     expect_any_instance_of(OneviewSDK::FCNetwork).to_not receive(:create)
     expect(real_chef_run).to create_oneview_fc_network_if_missing('FCNetwork2')
+  end
+
+  it 'fails if the SAN is not found' do
+    expect_any_instance_of(OneviewSDK::ManagedSAN).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /'SAN1' not found!/)
   end
 end

--- a/spec/unit/resources/fc_network/create_spec.rb
+++ b/spec/unit/resources/fc_network/create_spec.rb
@@ -7,6 +7,7 @@ describe 'oneview_test::fc_network_create' do
   it 'creates it when it does not exist' do
     expect_any_instance_of(OneviewSDK::FCNetwork).to receive(:exists?).and_return(false)
     expect_any_instance_of(OneviewSDK::FCNetwork).to receive(:create).and_return(true)
+    expect_any_instance_of(OneviewSDK::ManagedSAN).to receive(:retrieve!).and_return(true)
     expect(real_chef_run).to create_oneview_fc_network('FCNetwork1')
   end
 
@@ -15,6 +16,7 @@ describe 'oneview_test::fc_network_create' do
     expect_any_instance_of(OneviewSDK::FCNetwork).to receive(:retrieve!).and_return(true)
     expect_any_instance_of(OneviewSDK::FCNetwork).to receive(:like?).and_return(false)
     expect_any_instance_of(OneviewSDK::FCNetwork).to receive(:update).and_return(true)
+    expect_any_instance_of(OneviewSDK::ManagedSAN).to receive(:retrieve!).and_return(true)
     expect(real_chef_run).to create_oneview_fc_network('FCNetwork1')
   end
 
@@ -24,6 +26,12 @@ describe 'oneview_test::fc_network_create' do
     expect_any_instance_of(OneviewSDK::FCNetwork).to receive(:like?).and_return(true)
     expect_any_instance_of(OneviewSDK::FCNetwork).to_not receive(:update)
     expect_any_instance_of(OneviewSDK::FCNetwork).to_not receive(:create)
+    expect_any_instance_of(OneviewSDK::ManagedSAN).to receive(:retrieve!).and_return(true)
     expect(real_chef_run).to create_oneview_fc_network('FCNetwork1')
+  end
+
+  it 'fails if the SAN is not found' do
+    expect_any_instance_of(OneviewSDK::ManagedSAN).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /'SAN1' not found!/)
   end
 end

--- a/spec/unit/resources/fc_network/patch_spec.rb
+++ b/spec/unit/resources/fc_network/patch_spec.rb
@@ -1,0 +1,12 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::fc_network_patch' do
+  let(:resource_name) { 'fc_network' }
+  include_context 'chef context'
+
+  it 'performs patch operation' do
+    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:patch).with('test', 'test/', 'TestMessage').and_return(true)
+    expect(real_chef_run).to patch_oneview_fc_network('FCNetwork4')
+  end
+end

--- a/spec/unit/resources/fc_network/remove_from_scopes_spec.rb
+++ b/spec/unit/resources/fc_network/remove_from_scopes_spec.rb
@@ -1,0 +1,37 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::fc_network_remove_from_scopes' do
+  let(:resource_name) { 'fc_network' }
+  include_context 'chef context'
+
+  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
+  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
+
+  before do
+    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
+    allow(scope1).to receive(:retrieve!).and_return(true)
+    allow(scope2).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).and_call_original
+  end
+
+  it 'removes all scopes when are not removed' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:remove_scope).with(scope1)
+    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:remove_scope).with(scope2)
+    expect(real_chef_run).to remove_oneview_fc_network_from_scopes('FCNetwork1')
+  end
+
+  it 'removes only the one scope that is not removed' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:remove_scope).with(scope1)
+    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).not_to receive(:remove_scope).with(scope2)
+    expect(real_chef_run).to remove_oneview_fc_network_from_scopes('FCNetwork1')
+  end
+
+  it 'does nothing when scope is already removed' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/other-scope'])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).not_to receive(:remove_scope)
+    expect(real_chef_run).to remove_oneview_fc_network_from_scopes('FCNetwork1')
+  end
+end

--- a/spec/unit/resources/fc_network/replace_scopes_spec.rb
+++ b/spec/unit/resources/fc_network/replace_scopes_spec.rb
@@ -1,0 +1,35 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::fc_network_replace_scopes' do
+  let(:resource_name) { 'fc_network' }
+  include_context 'chef context'
+
+  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
+  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
+
+  before do
+    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
+    allow(scope1).to receive(:retrieve!).and_return(true)
+    allow(scope2).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).and_call_original
+  end
+
+  it 'replace scopes' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return([])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:replace_scopes).with([scope1, scope2])
+    expect(real_chef_run).to replace_oneview_fc_network_scopes('FCNetwork1')
+  end
+
+  it 'replace scopes even when already one of scopes added' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:replace_scopes).with([scope1, scope2])
+    expect(real_chef_run).to replace_oneview_fc_network_scopes('FCNetwork1')
+  end
+
+  it 'does nothing when all scopes are already replaced' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/2', '/rest/fake/1'])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).not_to receive(:replace_scopes)
+    expect(real_chef_run).to replace_oneview_fc_network_scopes('FCNetwork1')
+  end
+end

--- a/spec/unit/resources/fc_network/reset_connection_template_spec.rb
+++ b/spec/unit/resources/fc_network/reset_connection_template_spec.rb
@@ -1,0 +1,40 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test::fc_network_reset_connection_template' do
+  let(:resource_name) { 'fc_network' }
+  include_context 'chef context'
+
+  let(:default_bandwidth) do
+    {
+      'bandwidth' => {
+        'maximumBandwidth' => 10_000,
+        'typicalBandwidth' => 2500
+      }
+    }
+  end
+
+  before do
+    allow_any_instance_of(OneviewSDK::FCNetwork).to receive(:[]).and_call_original
+    allow_any_instance_of(OneviewSDK::FCNetwork).to receive(:[]).with('connectionTemplateUri').and_return('/rest/fake-template/1')
+    allow_any_instance_of(OneviewSDK::FCNetwork).to receive(:retrieve!).and_return(true)
+    allow(OneviewSDK::ConnectionTemplate).to receive(:get_default).and_return(default_bandwidth)
+    allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:retrieve!).and_return(true)
+  end
+
+  it 'updates it when it exists but not alike' do
+    allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:like?).and_return(false)
+    expect_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:update).and_return(true)
+    expect(real_chef_run).to reset_oneview_fc_network_connection_template('FCNetwork4')
+  end
+
+  it 'does nothing when it exists and is alike' do
+    allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:like?).and_return(true)
+    expect_any_instance_of(OneviewSDK::ConnectionTemplate).to_not receive(:update)
+    expect(real_chef_run).to reset_oneview_fc_network_connection_template('FCNetwork4')
+  end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::FCNetwork).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
+end

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -62,6 +62,7 @@ describe 'oneview_test::default' do
     expect(chef_run).to_not create_oneview_fc_network('')
     expect(chef_run).to_not create_oneview_fc_network_if_missing('')
     expect(chef_run).to_not delete_oneview_fc_network('')
+    expect(chef_run).to_not patch_oneview_fc_network('')
 
     # oneview_fcoe_network
     expect(chef_run).to_not create_oneview_fcoe_network('')

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -62,7 +62,11 @@ describe 'oneview_test::default' do
     expect(chef_run).to_not create_oneview_fc_network('')
     expect(chef_run).to_not create_oneview_fc_network_if_missing('')
     expect(chef_run).to_not delete_oneview_fc_network('')
+    expect(chef_run).to_not add_oneview_fc_network_to_scopes('')
+    expect(chef_run).to_not remove_oneview_fc_network_from_scopes('')
+    expect(chef_run).to_not replace_oneview_fc_network_scopes('')
     expect(chef_run).to_not patch_oneview_fc_network('')
+    expect(chef_run).to_not reset_oneview_fc_network_connection_template('')
 
     # oneview_fcoe_network
     expect(chef_run).to_not create_oneview_fcoe_network('')


### PR DESCRIPTION
### Description
Adding FC Network for HPE OneView API500 support.

### Issues Resolved
#251 
#94 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
