### PR TITLE
API 500 Support for Network Set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Adds API 500 support to the following HPE OneView resources:
   - oneview_firmware
   - oneview_id_pool
   - oneview_managed_san
+  - oneview_network_set
   - oneview_rack
   - oneview_san_manager
   - oneview_sas_logical_interconnect_group

--- a/README.md
+++ b/README.md
@@ -177,10 +177,11 @@ oneview_network_set 'NetSet1' do
   native_network <native_network_name>  # String: Optional
   ethernet_network_list <networks_list> # Array of network names as Strings: Optional
   data <resource_data>
-  operation <op>                        # String. Used in patch action only. e.g., 'add'
-  path <path>                           # String. Used in patch option only. e.g., '/scopeUris/-'
-  value <val>                           # String. Used in patch option only. e.g., 'scope uri'
-  action [:create, :create_if_missing, :delete, :patch]
+  operation <op>       # String. Used in patch action only. e.g., 'replace'
+  path <path>          # String. Used in patch option only. e.g., '/name'
+  value <val>          # String, Array. Used in patch option only. e.g., 'New Name'
+  scopes <scope_names> # Array - Optional. Array of scope names. Used in add_to_scopes, remove_from_scopes or replace_scopes options only. e.g., ['Scope1', 'Scope2']
+  action [:create, :create_if_missing, :delete, :reset_connection_template, :patch, :add_to_scopes, :remove_from_scopes, :replace_scopes]
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ oneview_network_set 'NetSet1' do
   native_network <native_network_name>  # String: Optional
   ethernet_network_list <networks_list> # Array of network names as Strings: Optional
   data <resource_data>
-  action [:create, :create_if_missing, :delete]
+  action [:create, :create_if_missing, :delete, :patch]
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ oneview_network_set 'NetSet1' do
   native_network <native_network_name>  # String: Optional
   ethernet_network_list <networks_list> # Array of network names as Strings: Optional
   data <resource_data>
+  operation <op>                        # String. Used in patch action only. e.g., 'add'
+  path <path>                           # String. Used in patch option only. e.g., '/scopeUris/-'
+  value <val>                           # String. Used in patch option only. e.g., 'scope uri'
   action [:create, :create_if_missing, :delete, :patch]
 end
 ```

--- a/examples/network_set.rb
+++ b/examples/network_set.rb
@@ -50,6 +50,16 @@ oneview_network_set 'ChefNetworkSet_2' do
   action :create_if_missing
 end
 
+# Example: Add the Scope with URI 7887dc77-c4b7-474a-9b9e-b7cba3d11d93 to ChefNetworkSet_0
+oneview_network_set 'ChefNetworkSet_3' do
+  client my_client
+  data(name: 'ChefNetworkSet_0')
+  operation 'add'
+  path '/scopeUris/-'
+  value '/rest/scopes/bef7c18c-3618-4c86-b85a-4c62a2f0d034'
+  action :patch
+end
+
 # Examples: Delete the network sets
 (0..2).each do |i|
   oneview_network_set "Delete ChefNetworkSet_#{i}" do

--- a/examples/network_set.rb
+++ b/examples/network_set.rb
@@ -9,10 +9,14 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+# NOTE 1: This example requires two Scopes named "Scope1" and "Scope2" to be present in the appliance.
+# NOTE 2: The api_version client should be greater than 200 if you run the examples using Scopes
+
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
   user: ENV['ONEVIEWSDK_USER'],
-  password: ENV['ONEVIEWSDK_PASSWORD']
+  password: ENV['ONEVIEWSDK_PASSWORD'],
+  api_version: 300
 }
 
 # Create a few networks for the next examples
@@ -45,19 +49,51 @@ end
 # Example: Create a network set only if it doesn't exist (no updates)
 oneview_network_set 'ChefNetworkSet_2' do
   client my_client
+  data(
+    bandwidth: {
+      typicalBandwidth: 2000,
+      maximumBandwidth: 9000
+    }
+  )
   native_network 'Chef-Eth-Net-2'
   ethernet_network_list ['Chef-Eth-Net-1']
   action :create_if_missing
 end
 
-# Example: Add the Scope with URI 7887dc77-c4b7-474a-9b9e-b7cba3d11d93 to ChefNetworkSet_0
-oneview_network_set 'ChefNetworkSet_3' do
+# Example: Adds 'ChefNetworkSet_1' to 'Scope1' and 'Scope2'
+oneview_network_set 'ChefNetworkSet_1' do
   client my_client
-  data(name: 'ChefNetworkSet_0')
-  operation 'add'
-  path '/scopeUris/-'
-  value '/rest/scopes/bef7c18c-3618-4c86-b85a-4c62a2f0d034'
+  scopes ['Scope1', 'Scope2']
+  action :add_to_scopes
+end
+
+# Example: Removes 'ChefNetworkSet_1' from 'Scope1'
+oneview_network_set 'ChefNetworkSet_1' do
+  client my_client
+  scopes ['Scope1']
+  action :remove_from_scopes
+end
+
+# Example: Replaces 'Scope1' and 'Scope2' for 'ChefNetworkSet_1'
+oneview_network_set 'ChefNetworkSet_1' do
+  client my_client
+  scopes ['Scope1', 'Scope2']
+  action :replace_scopes
+end
+
+# Example: Replaces all scopes to empty list of scopes
+oneview_network_set 'ChefNetworkSet_1' do
+  client my_client
+  operation 'replace'
+  path '/scopeUris'
+  value []
   action :patch
+end
+
+# Example: Reset the connection template for a network
+oneview_network_set 'ChefNetworkSet_2' do
+  client my_client
+  action :reset_connection_template
 end
 
 # Examples: Delete the network sets

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -42,7 +42,7 @@ if defined?(ChefSpec)
     oneview_logical_switch_group:       standard_actions,
     oneview_logical_switch:             standard_actions + [:refresh],
     oneview_managed_san:                %i[refresh set_policy set_public_attributes],
-    oneview_network_set:                standard_actions,
+    oneview_network_set:                standard_actions + [:patch],
     oneview_power_device:               %i[add add_if_missing discover remove],
     oneview_rack:                       %i[add remove add_if_missing add_to_rack remove_from_rack],
     oneview_san_manager:                %i[add add_if_missing remove],

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -42,7 +42,7 @@ if defined?(ChefSpec)
     oneview_logical_switch_group:       standard_actions,
     oneview_logical_switch:             standard_actions + [:refresh],
     oneview_managed_san:                %i[refresh set_policy set_public_attributes],
-    oneview_network_set:                standard_actions + [:patch],
+    oneview_network_set:                standard_actions + scope_actions + %i[reset_connection_template],
     oneview_power_device:               %i[add add_if_missing discover remove],
     oneview_rack:                       %i[add remove add_if_missing add_to_rack remove_from_rack],
     oneview_san_manager:                %i[add add_if_missing remove],

--- a/libraries/resource_providers/api200/network_set_provider.rb
+++ b/libraries/resource_providers/api200/network_set_provider.rb
@@ -9,10 +9,13 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+require_relative 'connection_template_provider'
+
 module OneviewCookbook
   module API200
     # NetworkSet API200 provider
     class NetworkSetProvider < ResourceProvider
+      include API200::ConnectionTemplateProvider::ConnectionTemplateHelper
       def load_resource_with_properties
         @item.set_native_network(load_resource(:EthernetNetwork, @new_resource.native_network)) if @new_resource.native_network
         return unless @new_resource.ethernet_network_list
@@ -24,6 +27,7 @@ module OneviewCookbook
       def create_or_update
         ret_val = false
         load_resource_with_properties
+        bandwidth = @item.data.delete('bandwidth')
         temp = Marshal.load(Marshal.dump(@item.data))
         if @item.exists?
           create_if_exists(temp)
@@ -34,6 +38,7 @@ module OneviewCookbook
           end
           ret_val = true
         end
+        update_connection_template(bandwidth: bandwidth) if bandwidth
         save_res_info
         ret_val
       end
@@ -61,8 +66,10 @@ module OneviewCookbook
       end
 
       def create_if_missing
+        bandwidth = @item.data.delete('bandwidth')
         load_resource_with_properties
-        super
+        created = super
+        update_connection_template(bandwidth: bandwidth) if bandwidth && created
       end
     end
   end

--- a/libraries/resource_providers/api500/c7000/network_set_provider.rb
+++ b/libraries/resource_providers/api500/c7000/network_set_provider.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/network_set_provider'
+
+module OneviewCookbook
+  module API500
+    module C7000
+      # NetworkSet API500 C7000 provider
+      class NetworkSetProvider < OneviewCookbook::API300::C7000::NetworkSetProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api500/c7000/network_set_provider.rb
+++ b/libraries/resource_providers/api500/c7000/network_set_provider.rb
@@ -9,13 +9,11 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/c7000/network_set_provider'
-
 module OneviewCookbook
   module API500
     module C7000
       # NetworkSet API500 C7000 provider
-      class NetworkSetProvider < OneviewCookbook::API300::C7000::NetworkSetProvider
+      class NetworkSetProvider < API300::C7000::NetworkSetProvider
       end
     end
   end

--- a/libraries/resource_providers/api500/synergy/network_set_provider.rb
+++ b/libraries/resource_providers/api500/synergy/network_set_provider.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/network_set_provider'
+
+module OneviewCookbook
+  module API500
+    module Synergy
+      # NetworkSet API500 Synergy provider
+      class NetworkSetProvider < OneviewCookbook::API300::Synergy::NetworkSetProvider
+      end
+    end
+  end
+end

--- a/resources/network_set.rb
+++ b/resources/network_set.rb
@@ -27,3 +27,7 @@ end
 action :delete do
   OneviewCookbook::Helper.do_resource_action(self, :NetworkSet, :delete)
 end
+
+action :patch do
+  OneviewCookbook::Helper.do_resource_action(self, :NetworkSet, :patch)
+end

--- a/resources/network_set.rb
+++ b/resources/network_set.rb
@@ -13,6 +13,7 @@ OneviewCookbook::ResourceBaseProperties.load(self)
 
 property :native_network, String
 property :ethernet_network_list, Array # Array containing network names
+property :scopes, Array # Array containing scope names
 
 default_action :create
 
@@ -28,6 +29,22 @@ action :delete do
   OneviewCookbook::Helper.do_resource_action(self, :NetworkSet, :delete)
 end
 
+action :add_to_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :NetworkSet, :add_to_scopes)
+end
+
+action :remove_from_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :NetworkSet, :remove_from_scopes)
+end
+
+action :replace_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :NetworkSet, :replace_scopes)
+end
+
 action :patch do
   OneviewCookbook::Helper.do_resource_action(self, :NetworkSet, :patch)
+end
+
+action :reset_connection_template do
+  OneviewCookbook::Helper.do_resource_action(self, :NetworkSet, :reset_connection_template)
 end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/network_set_reset_connection_template.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/network_set_reset_connection_template.rb
@@ -1,3 +1,7 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: network_set_reset_connection_template
+#
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -8,13 +12,9 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+#
 
-module OneviewCookbook
-  module API500
-    module Synergy
-      # NetworkSet API500 Synergy provider
-      class NetworkSetProvider < API300::Synergy::NetworkSetProvider
-      end
-    end
-  end
+oneview_network_set 'NetworkSet5' do
+  client node['oneview_test']['client']
+  action :reset_connection_template
 end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/network_set_add_to_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/network_set_add_to_scopes.rb
@@ -1,3 +1,7 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: network_set_add_to_scopes
+#
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -8,13 +12,10 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+#
 
-module OneviewCookbook
-  module API500
-    module Synergy
-      # NetworkSet API500 Synergy provider
-      class NetworkSetProvider < API300::Synergy::NetworkSetProvider
-      end
-    end
-  end
+oneview_network_set 'NetworkSet1' do
+  client node['oneview_test']['client']
+  scopes ['Scope1', 'Scope2']
+  action :add_to_scopes
 end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/network_set_patch.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/network_set_patch.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: network_set_patch
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_network_set 'NetworkSet5' do
+  client node['oneview_test']['client']
+  operation 'test'
+  path 'test/'
+  value 'TestMessage'
+  action :patch
+end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/network_set_patch.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/network_set_patch.rb
@@ -14,7 +14,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-oneview_network_set 'NetworkSet5' do
+oneview_network_set 'NetworkSet1' do
   client node['oneview_test']['client']
   operation 'test'
   path 'test/'

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/network_set_remove_from_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/network_set_remove_from_scopes.rb
@@ -1,3 +1,7 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: network_set_remove_from_scopes
+#
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -8,13 +12,10 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+#
 
-module OneviewCookbook
-  module API500
-    module Synergy
-      # NetworkSet API500 Synergy provider
-      class NetworkSetProvider < API300::Synergy::NetworkSetProvider
-      end
-    end
-  end
+oneview_network_set 'NetworkSet1' do
+  client node['oneview_test']['client']
+  scopes ['Scope1', 'Scope2']
+  action :remove_from_scopes
 end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/network_set_replace_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/network_set_replace_scopes.rb
@@ -1,3 +1,7 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: network_set_replace_scopes
+#
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -8,13 +12,10 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+#
 
-module OneviewCookbook
-  module API500
-    module Synergy
-      # NetworkSet API500 Synergy provider
-      class NetworkSetProvider < API300::Synergy::NetworkSetProvider
-      end
-    end
-  end
+oneview_network_set 'NetworkSet1' do
+  client node['oneview_test']['client']
+  scopes ['Scope1', 'Scope2']
+  action :replace_scopes
 end

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -135,6 +135,7 @@ describe 'oneview_test::default' do
     expect(chef_run).to_not create_oneview_network_set('')
     expect(chef_run).to_not create_oneview_network_set_if_missing('')
     expect(chef_run).to_not delete_oneview_network_set('')
+    expect(chef_run).to_not patch_oneview_network_set('')
 
     # oneview_power_device
     expect(chef_run).to_not add_oneview_power_device('')

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -135,7 +135,11 @@ describe 'oneview_test::default' do
     expect(chef_run).to_not create_oneview_network_set('')
     expect(chef_run).to_not create_oneview_network_set_if_missing('')
     expect(chef_run).to_not delete_oneview_network_set('')
+    expect(chef_run).to_not add_oneview_network_set_to_scopes('')
+    expect(chef_run).to_not remove_oneview_network_set_from_scopes('')
+    expect(chef_run).to_not replace_oneview_network_set_scopes('')
     expect(chef_run).to_not patch_oneview_network_set('')
+    expect(chef_run).to_not reset_oneview_network_set_connection_template('')
 
     # oneview_power_device
     expect(chef_run).to_not add_oneview_power_device('')

--- a/spec/unit/resources/network_set/add_to_scopes_spec.rb
+++ b/spec/unit/resources/network_set/add_to_scopes_spec.rb
@@ -1,0 +1,37 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::network_set_add_to_scopes' do
+  let(:resource_name) { 'network_set' }
+  include_context 'chef context'
+
+  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
+  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
+
+  before do
+    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
+    allow(scope1).to receive(:retrieve!).and_return(true)
+    allow(scope2).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).and_call_original
+  end
+
+  it 'adds all scopes when are not added' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return([])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:add_scope).with(scope1)
+    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:add_scope).with(scope2)
+    expect(real_chef_run).to add_oneview_network_set_to_scopes('NetworkSet1')
+  end
+
+  it 'adds only the scope that is not added' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).not_to receive(:add_scope).with(scope1)
+    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:add_scope).with(scope2)
+    expect(real_chef_run).to add_oneview_network_set_to_scopes('NetworkSet1')
+  end
+
+  it 'does nothing when scopes are already added' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).not_to receive(:add_scope)
+    expect(real_chef_run).to add_oneview_network_set_to_scopes('NetworkSet1')
+  end
+end

--- a/spec/unit/resources/network_set/patch_spec.rb
+++ b/spec/unit/resources/network_set/patch_spec.rb
@@ -1,0 +1,12 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::network_set_patch' do
+  let(:resource_name) { 'network_set' }
+  include_context 'chef context'
+
+  it 'performs patch operation' do
+    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:patch).with('test', 'test/', 'TestMessage').and_return(true)
+    expect(real_chef_run).to patch_oneview_network_set('NetworkSet5')
+  end
+end

--- a/spec/unit/resources/network_set/patch_spec.rb
+++ b/spec/unit/resources/network_set/patch_spec.rb
@@ -7,6 +7,6 @@ describe 'oneview_test_api300_synergy::network_set_patch' do
   it 'performs patch operation' do
     expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:patch).with('test', 'test/', 'TestMessage').and_return(true)
-    expect(real_chef_run).to patch_oneview_network_set('NetworkSet5')
+    expect(real_chef_run).to patch_oneview_network_set('NetworkSet1')
   end
 end

--- a/spec/unit/resources/network_set/remove_from_scopes_spec.rb
+++ b/spec/unit/resources/network_set/remove_from_scopes_spec.rb
@@ -1,0 +1,37 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::network_set_remove_from_scopes' do
+  let(:resource_name) { 'network_set' }
+  include_context 'chef context'
+
+  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
+  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
+
+  before do
+    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
+    allow(scope1).to receive(:retrieve!).and_return(true)
+    allow(scope2).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).and_call_original
+  end
+
+  it 'removes all scopes when are not removed' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:remove_scope).with(scope1)
+    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:remove_scope).with(scope2)
+    expect(real_chef_run).to remove_oneview_network_set_from_scopes('NetworkSet1')
+  end
+
+  it 'removes only the one scope that is not removed' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:remove_scope).with(scope1)
+    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).not_to receive(:remove_scope).with(scope2)
+    expect(real_chef_run).to remove_oneview_network_set_from_scopes('NetworkSet1')
+  end
+
+  it 'does nothing when scope is already removed' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return(['/rest/fake/other-scope'])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).not_to receive(:remove_scope)
+    expect(real_chef_run).to remove_oneview_network_set_from_scopes('NetworkSet1')
+  end
+end

--- a/spec/unit/resources/network_set/replace_scopes_spec.rb
+++ b/spec/unit/resources/network_set/replace_scopes_spec.rb
@@ -1,0 +1,35 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::network_set_replace_scopes' do
+  let(:resource_name) { 'network_set' }
+  include_context 'chef context'
+
+  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
+  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
+
+  before do
+    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
+    allow(scope1).to receive(:retrieve!).and_return(true)
+    allow(scope2).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).and_call_original
+  end
+
+  it 'replace scopes' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return([])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:replace_scopes).with([scope1, scope2])
+    expect(real_chef_run).to replace_oneview_network_set_scopes('NetworkSet1')
+  end
+
+  it 'replace scopes even when already one of scopes added' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:replace_scopes).with([scope1, scope2])
+    expect(real_chef_run).to replace_oneview_network_set_scopes('NetworkSet1')
+  end
+
+  it 'does nothing when all scopes are already replaced' do
+    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return(['/rest/fake/2', '/rest/fake/1'])
+    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).not_to receive(:replace_scopes)
+    expect(real_chef_run).to replace_oneview_network_set_scopes('NetworkSet1')
+  end
+end

--- a/spec/unit/resources/network_set/reset_connection_template_spec.rb
+++ b/spec/unit/resources/network_set/reset_connection_template_spec.rb
@@ -1,0 +1,40 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test::network_set_reset_connection_template' do
+  let(:resource_name) { 'network_set' }
+  include_context 'chef context'
+
+  let(:default_bandwidth) do
+    {
+      'bandwidth' => {
+        'maximumBandwidth' => 10_000,
+        'typicalBandwidth' => 2500
+      }
+    }
+  end
+
+  before do
+    allow_any_instance_of(OneviewSDK::NetworkSet).to receive(:[]).and_call_original
+    allow_any_instance_of(OneviewSDK::NetworkSet).to receive(:[]).with('connectionTemplateUri').and_return('/rest/fake-template/1')
+    allow_any_instance_of(OneviewSDK::NetworkSet).to receive(:retrieve!).and_return(true)
+    allow(OneviewSDK::ConnectionTemplate).to receive(:get_default).and_return(default_bandwidth)
+    allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:retrieve!).and_return(true)
+  end
+
+  it 'updates it when it exists but not alike' do
+    allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:like?).and_return(false)
+    expect_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:update).and_return(true)
+    expect(real_chef_run).to reset_oneview_network_set_connection_template('NetworkSet5')
+  end
+
+  it 'does nothing when it exists and is alike' do
+    allow_any_instance_of(OneviewSDK::ConnectionTemplate).to receive(:like?).and_return(true)
+    expect_any_instance_of(OneviewSDK::ConnectionTemplate).to_not receive(:update)
+    expect(real_chef_run).to reset_oneview_network_set_connection_template('NetworkSet5')
+  end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::NetworkSet).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
+end


### PR DESCRIPTION
### Description
Adding Network Set for HPE OneView API500 support.

### Issues Resolved
#257 
#94 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
