### PR TITLE
API 500 Support for Unmanaged Device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.3.1 (Unreleased)
 Adds API 500 support to the following HPE OneView resources:
   - oneview_scope
+  - oneview_unmanaged_device
 
 Enhancements:
 - [#246](https://github.com/HewlettPackard/oneview-chef/issues/246) Upgrade oneview-sdk gem to version 5.0.0

--- a/examples/unmanaged_device.rb
+++ b/examples/unmanaged_device.rb
@@ -25,8 +25,7 @@ oneview_unmanaged_device 'UnmanagedDevice1' do
 end
 
 # Example: Removes an unmanaged device
-oneview_unmanaged_device 'UnmanagedDevice2' do
+oneview_unmanaged_device 'UnmanagedDevice1' do
   client my_client
-  data(name: 'UnmanagedDevice1')
   action :remove
 end

--- a/libraries/resource_providers/api500/c7000/unmanaged_device_provider.rb
+++ b/libraries/resource_providers/api500/c7000/unmanaged_device_provider.rb
@@ -1,4 +1,4 @@
-# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -9,24 +9,14 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-my_client = {
-  url: ENV['ONEVIEWSDK_URL'],
-  user: ENV['ONEVIEWSDK_USER'],
-  password: ENV['ONEVIEWSDK_PASSWORD']
-}
+require_relative '../../api300/c7000/unmanaged_device_provider'
 
-# Example: Adds an unmanaged device (default action)
-oneview_unmanaged_device 'UnmanagedDevice1' do
-  client my_client
-  data(
-    model: 'Procurve 4200VL',
-    deviceType: 'Server'
-  )
-end
-
-# Example: Removes an unmanaged device
-oneview_unmanaged_device 'UnmanagedDevice2' do
-  client my_client
-  data(name: 'UnmanagedDevice1')
-  action :remove
+module OneviewCookbook
+  module API500
+    module C7000
+      # UnmanagedDevice API500 C7000 provider
+      class UnmanagedDeviceProvider < OneviewCookbook::API300::C7000::UnmanagedDeviceProvider
+      end
+    end
+  end
 end

--- a/libraries/resource_providers/api500/synergy/unmanaged_device_provider.rb
+++ b/libraries/resource_providers/api500/synergy/unmanaged_device_provider.rb
@@ -1,4 +1,4 @@
-# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -9,24 +9,14 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-my_client = {
-  url: ENV['ONEVIEWSDK_URL'],
-  user: ENV['ONEVIEWSDK_USER'],
-  password: ENV['ONEVIEWSDK_PASSWORD']
-}
+require_relative '../../api300/synergy/unmanaged_device_provider'
 
-# Example: Adds an unmanaged device (default action)
-oneview_unmanaged_device 'UnmanagedDevice1' do
-  client my_client
-  data(
-    model: 'Procurve 4200VL',
-    deviceType: 'Server'
-  )
-end
-
-# Example: Removes an unmanaged device
-oneview_unmanaged_device 'UnmanagedDevice2' do
-  client my_client
-  data(name: 'UnmanagedDevice1')
-  action :remove
+module OneviewCookbook
+  module API500
+    module Synergy
+      # UnmanagedDevice API500 Synergy provider
+      class UnmanagedDeviceProvider < OneviewCookbook::API300::Synergy::UnmanagedDeviceProvider
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description
Adding Unmanaged Device for HPE OneView API500 support.

### Issues Resolved
#262 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
