### PR TITLE
API 500 Support for Logical Switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Adds API 500 support to the following HPE OneView resources:
   - oneview_firmware
   - oneview_id_pool
   - oneview_logical_interconnect_group
+  - oneview_logical_switch
   - oneview_logical_switch_group
   - oneview_managed_san
   - oneview_network_set

--- a/README.md
+++ b/README.md
@@ -449,7 +449,11 @@ oneview_logical_switch 'LogicalSwitch_1' do
   client <my_client>
   data <resource_data>               # Logical Switch options
   credentials <switches_credentials> # Specify the credentials for all the switches
-  action [:create, :create_if_missing, :delete, :refresh]
+  operation <op>                     # String. Used in patch action only. e.g., 'add'
+  path <path>                        # String. Used in patch option only. e.g., '/scopeUris/-'
+  value <val>                        # String. Used in patch option only. e.g., 'scope uri'
+  scopes <scope_names>               # Array - Optional. Array of scope names. Used in add_to_scopes, remove_from_scopes or replace_scopes options only. e.g., ['Scope1', 'Scope2']
+  action [:create, :create_if_missing, :delete, :refresh, :patch, :add_to_scopes, :remove_from_scopes, :replace_scopes]
 end
 ```
 

--- a/examples/ethernet_network.rb
+++ b/examples/ethernet_network.rb
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 # NOTE 1: This example requires two Scopes named "Scope1" and "Scope2" to be present in the appliance.
-# NOTE 2: The api_version client should be greater than 200 if you run the examples using Scopes
+# NOTE 2: The api_version client should be 300 or greater if you run the examples using Scopes
 
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],

--- a/examples/fc_network.rb
+++ b/examples/fc_network.rb
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 # NOTE 1: This example requires two Scopes named "Scope1" and "Scope2" to be present in the appliance.
-# NOTE 2: The api_version client should be greater than 200 if you run the examples using Scopes
+# NOTE 2: The api_version client should be 300 or greater if you run the examples using Scopes
 
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],

--- a/examples/logical_interconnect_group_synergy.rb
+++ b/examples/logical_interconnect_group_synergy.rb
@@ -14,7 +14,7 @@
 # FC Network: FCNetwork1
 # Scopes: Scope1, Scope2
 
-# NOTE: The api_version client should be greater than 200 if you run the examples using Scopes
+# NOTE: The api_version client should be 300 or greater if you run the examples using Scopes
 
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],

--- a/examples/logical_switch.rb
+++ b/examples/logical_switch.rb
@@ -35,8 +35,9 @@ end
 
 # Creates a Logical Switch named LogicalSwitch1 based on the LogicalSwitchGroup1 only if it does not exists
 # The number of credentials must be equal the number of switches the group supports
-oneview_logical_switch 'LogicalSwitch1' do
+oneview_logical_switch 'LogicalSwitch2' do
   client my_client
+  data(name: 'LogicalSwitch1')
   logical_switch_group 'LogicalSwitchGroup1'
   credentials([
     { host: '172.xx.xx.1', ssh_credentials: ssh_credentials_1, snmp_credentials: default_snmpv1_credentials },
@@ -47,13 +48,25 @@ end
 
 # Refreshes the LogicalSwitch1
 # This action reclaims the top-of-rack switches associated with the Logical Switch
-oneview_logical_switch 'LogicalSwitch1' do
+oneview_logical_switch 'LogicalSwitch3' do
   client my_client
+  data(name: 'LogicalSwitch1')
   action :refresh
 end
 
-# Removes the LogicalSwitch1 and all of its associated Switches
-oneview_logical_switch 'LogicalSwitch1' do
+# Example: Add the Scope with URI /rest/scopes/7fa5a27f-9d24-401d-9141-16501febee6c to LogicalSwitch1
+oneview_logical_switch 'LogicalSwitch4' do
   client my_client
+  data(name: 'LogicalSwitch1')
+  operation 'add'
+  path '/scopeUris/-'
+  value '/rest/scopes/7fa5a27f-9d24-401d-9141-16501febee6c'
+  action :patch
+end
+
+# Removes the LogicalSwitch1 and all of its associated Switches
+oneview_logical_switch 'LogicalSwitch5' do
+  client my_client
+  data(name: 'LogicalSwitch1')
   action :delete
 end

--- a/examples/logical_switch.rb
+++ b/examples/logical_switch.rb
@@ -9,10 +9,14 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+# NOTE 1: This example requires two Scopes named "Scope1" and "Scope2" to be present in the appliance.
+# NOTE 2: The api_version client should be greater than 200 if you run the examples using Scopes
+
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
   user: ENV['ONEVIEWSDK_USER'],
-  password: ENV['ONEVIEWSDK_PASSWORD']
+  password: ENV['ONEVIEWSDK_PASSWORD'],
+  api_version: 300
 }
 
 # Load credentials to use in the switches in the Logical Switch
@@ -35,9 +39,8 @@ end
 
 # Creates a Logical Switch named LogicalSwitch1 based on the LogicalSwitchGroup1 only if it does not exists
 # The number of credentials must be equal the number of switches the group supports
-oneview_logical_switch 'LogicalSwitch2' do
+oneview_logical_switch 'LogicalSwitch1' do
   client my_client
-  data(name: 'LogicalSwitch1')
   logical_switch_group 'LogicalSwitchGroup1'
   credentials([
     { host: '172.xx.xx.1', ssh_credentials: ssh_credentials_1, snmp_credentials: default_snmpv1_credentials },
@@ -48,25 +51,43 @@ end
 
 # Refreshes the LogicalSwitch1
 # This action reclaims the top-of-rack switches associated with the Logical Switch
-oneview_logical_switch 'LogicalSwitch3' do
+oneview_logical_switch 'LogicalSwitch1' do
   client my_client
-  data(name: 'LogicalSwitch1')
   action :refresh
 end
 
-# Example: Add the Scope with URI /rest/scopes/7fa5a27f-9d24-401d-9141-16501febee6c to LogicalSwitch1
-oneview_logical_switch 'LogicalSwitch4' do
+# Example: Adds 'LogicalSwitch1' to 'Scope1' and 'Scope2'
+oneview_logical_switch 'LogicalSwitch1' do
   client my_client
-  data(name: 'LogicalSwitch1')
-  operation 'add'
-  path '/scopeUris/-'
-  value '/rest/scopes/7fa5a27f-9d24-401d-9141-16501febee6c'
+  scopes ['Scope1', 'Scope2']
+  action :add_to_scopes
+end
+
+# Example: Removes 'LogicalSwitch1' from 'Scope1'
+oneview_logical_switch 'LogicalSwitch1' do
+  client my_client
+  scopes ['Scope1']
+  action :remove_from_scopes
+end
+
+# Example: Replaces 'Scope1' and 'Scope2' for 'LogicalSwitch1'
+oneview_logical_switch 'LogicalSwitch1' do
+  client my_client
+  scopes ['Scope1', 'Scope2']
+  action :replace_scopes
+end
+
+# Example: Replaces all scopes to empty list of scopes
+oneview_logical_switch 'LogicalSwitch1' do
+  client my_client
+  operation 'replace'
+  path '/scopeUris'
+  value []
   action :patch
 end
 
 # Removes the LogicalSwitch1 and all of its associated Switches
-oneview_logical_switch 'LogicalSwitch5' do
+oneview_logical_switch 'LogicalSwitch1' do
   client my_client
-  data(name: 'LogicalSwitch1')
   action :delete
 end

--- a/examples/logical_switch.rb
+++ b/examples/logical_switch.rb
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 # NOTE 1: This example requires two Scopes named "Scope1" and "Scope2" to be present in the appliance.
-# NOTE 2: The api_version client should be greater than 200 if you run the examples using Scopes
+# NOTE 2: The api_version client should be 300 or greater if you run the examples using Scopes
 
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],

--- a/examples/logical_switch_group.rb
+++ b/examples/logical_switch_group.rb
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 # NOTE 1: This example requires two Scopes named "Scope1" and "Scope2" to be present in the appliance.
-# NOTE 2: The api_version client should be greater than 200 if you run the examples using Scopes
+# NOTE 2: The api_version client should be 300 or greater if you run the examples using Scopes
 
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],

--- a/examples/network_set.rb
+++ b/examples/network_set.rb
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 # NOTE 1: This example requires two Scopes named "Scope1" and "Scope2" to be present in the appliance.
-# NOTE 2: The api_version client should be greater than 200 if you run the examples using Scopes
+# NOTE 2: The api_version client should be 300 or greater if you run the examples using Scopes
 
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -40,7 +40,7 @@ if defined?(ChefSpec)
                                            update_snmp_configuration update_firmware stage_firmware activate_firmware update_from_group
                                            reapply_configuration],
     oneview_logical_switch_group:       standard_actions + scope_actions,
-    oneview_logical_switch:             standard_actions + [:refresh],
+    oneview_logical_switch:             standard_actions + scope_actions + %i[refresh],
     oneview_managed_san:                %i[refresh set_policy set_public_attributes],
     oneview_network_set:                standard_actions + scope_actions + %i[reset_connection_template],
     oneview_power_device:               %i[add add_if_missing discover remove],

--- a/libraries/resource_providers/api500/c7000/logical_switch_provider.rb
+++ b/libraries/resource_providers/api500/c7000/logical_switch_provider.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/logical_switch_provider'
+
+module OneviewCookbook
+  module API500
+    module C7000
+      # LogicalSwitch API500 C7000 provider
+      class LogicalSwitchProvider < OneviewCookbook::API300::C7000::LogicalSwitchProvider
+      end
+    end
+  end
+end

--- a/resources/logical_switch.rb
+++ b/resources/logical_switch.rb
@@ -31,3 +31,7 @@ end
 action :delete do
   OneviewCookbook::Helper.do_resource_action(self, :LogicalSwitch, :delete)
 end
+
+action :patch do
+  OneviewCookbook::Helper.do_resource_action(self, :LogicalSwitch, :patch)
+end

--- a/resources/logical_switch.rb
+++ b/resources/logical_switch.rb
@@ -13,6 +13,7 @@ OneviewCookbook::ResourceBaseProperties.load(self)
 
 property :logical_switch_group, String
 property :credentials, Array
+property :scopes, Array
 
 default_action :create
 
@@ -30,6 +31,18 @@ end
 
 action :delete do
   OneviewCookbook::Helper.do_resource_action(self, :LogicalSwitch, :delete)
+end
+
+action :add_to_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :LogicalSwitch, :add_to_scopes)
+end
+
+action :remove_from_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :LogicalSwitch, :remove_from_scopes)
+end
+
+action :replace_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :LogicalSwitch, :replace_scopes)
 end
 
 action :patch do

--- a/spec/fixtures/cookbooks/oneview_test/recipes/logical_switch_patch.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/logical_switch_patch.rb
@@ -1,0 +1,25 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: logical_switch_patch
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_logical_switch 'LogicalSwitch5' do
+  client node['oneview_test']['client']
+  api_version 300
+  api_variant 'C7000'
+  operation 'test'
+  path 'test/'
+  value 'TestMessage'
+  action :patch
+end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/logical_switch_add_to_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/logical_switch_add_to_scopes.rb
@@ -1,3 +1,7 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: logical_switch_add_to_scopes
+#
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -8,13 +12,12 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+#
 
-module OneviewCookbook
-  module API500
-    module C7000
-      # LogicalSwitch API500 C7000 provider
-      class LogicalSwitchProvider < API300::C7000::LogicalSwitchProvider
-      end
-    end
-  end
+oneview_logical_switch 'LogicalSwitch1' do
+  client node['oneview_test']['client']
+  api_version 300
+  api_variant 'C7000'
+  scopes ['Scope1', 'Scope2']
+  action :add_to_scopes
 end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/logical_switch_patch.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/logical_switch_patch.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: oneview_test
+# Cookbook Name:: oneview_test_api300_synergy
 # Recipe:: logical_switch_patch
 #
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
@@ -14,7 +14,7 @@
 # specific language governing permissions and limitations under the License.
 #
 
-oneview_logical_switch 'LogicalSwitch5' do
+oneview_logical_switch 'LogicalSwitch1' do
   client node['oneview_test']['client']
   api_version 300
   api_variant 'C7000'

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/logical_switch_remove_from_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/logical_switch_remove_from_scopes.rb
@@ -1,3 +1,7 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: logical_switch_remove_from_scopes
+#
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -8,13 +12,12 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+#
 
-module OneviewCookbook
-  module API500
-    module C7000
-      # LogicalSwitch API500 C7000 provider
-      class LogicalSwitchProvider < API300::C7000::LogicalSwitchProvider
-      end
-    end
-  end
+oneview_logical_switch 'LogicalSwitch1' do
+  client node['oneview_test']['client']
+  api_version 300
+  api_variant 'C7000'
+  scopes ['Scope1', 'Scope2']
+  action :remove_from_scopes
 end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/logical_switch_replace_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/logical_switch_replace_scopes.rb
@@ -1,3 +1,7 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: logical_switch_replace_scopes
+#
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -8,13 +12,12 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+#
 
-module OneviewCookbook
-  module API500
-    module C7000
-      # LogicalSwitch API500 C7000 provider
-      class LogicalSwitchProvider < API300::C7000::LogicalSwitchProvider
-      end
-    end
-  end
+oneview_logical_switch 'LogicalSwitch1' do
+  client node['oneview_test']['client']
+  api_version 300
+  api_variant 'C7000'
+  scopes ['Scope1', 'Scope2']
+  action :replace_scopes
 end

--- a/spec/unit/resources/logical_switch/add_to_scopes_spec.rb
+++ b/spec/unit/resources/logical_switch/add_to_scopes_spec.rb
@@ -4,34 +4,8 @@ describe 'oneview_test_api300_synergy::logical_switch_add_to_scopes' do
   let(:resource_name) { 'logical_switch' }
   include_context 'chef context'
 
-  let(:scope1) { OneviewSDK::API300::C7000::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
-  let(:scope2) { OneviewSDK::API300::C7000::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
-
-  before do
-    allow(OneviewSDK::API300::C7000::Scope).to receive(:new).and_return(scope1, scope2)
-    allow(scope1).to receive(:retrieve!).and_return(true)
-    allow(scope2).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).and_call_original
-  end
-
-  it 'adds all scopes when are not added' do
-    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return([])
-    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:add_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:add_scope).with(scope2)
-    expect(real_chef_run).to add_oneview_logical_switch_to_scopes('LogicalSwitch1')
-  end
-
-  it 'adds only the scope that is not added' do
-    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).not_to receive(:add_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:add_scope).with(scope2)
-    expect(real_chef_run).to add_oneview_logical_switch_to_scopes('LogicalSwitch1')
-  end
-
-  it 'does nothing when scopes are already added' do
-    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
-    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).not_to receive(:add_scope)
-    expect(real_chef_run).to add_oneview_logical_switch_to_scopes('LogicalSwitch1')
-  end
+  let(:target_class) { OneviewSDK::API300::C7000::LogicalSwitch }
+  let(:scope_class) { OneviewSDK::API300::C7000::Scope }
+  let(:target_match_method) { [:add_oneview_logical_switch_to_scopes, 'LogicalSwitch1'] }
+  it_behaves_like 'action :add_to_scopes'
 end

--- a/spec/unit/resources/logical_switch/add_to_scopes_spec.rb
+++ b/spec/unit/resources/logical_switch/add_to_scopes_spec.rb
@@ -1,0 +1,37 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::logical_switch_add_to_scopes' do
+  let(:resource_name) { 'logical_switch' }
+  include_context 'chef context'
+
+  let(:scope1) { OneviewSDK::API300::C7000::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
+  let(:scope2) { OneviewSDK::API300::C7000::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
+
+  before do
+    allow(OneviewSDK::API300::C7000::Scope).to receive(:new).and_return(scope1, scope2)
+    allow(scope1).to receive(:retrieve!).and_return(true)
+    allow(scope2).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).and_call_original
+  end
+
+  it 'adds all scopes when are not added' do
+    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return([])
+    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:add_scope).with(scope1)
+    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:add_scope).with(scope2)
+    expect(real_chef_run).to add_oneview_logical_switch_to_scopes('LogicalSwitch1')
+  end
+
+  it 'adds only the scope that is not added' do
+    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
+    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).not_to receive(:add_scope).with(scope1)
+    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:add_scope).with(scope2)
+    expect(real_chef_run).to add_oneview_logical_switch_to_scopes('LogicalSwitch1')
+  end
+
+  it 'does nothing when scopes are already added' do
+    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
+    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).not_to receive(:add_scope)
+    expect(real_chef_run).to add_oneview_logical_switch_to_scopes('LogicalSwitch1')
+  end
+end

--- a/spec/unit/resources/logical_switch/patch_spec.rb
+++ b/spec/unit/resources/logical_switch/patch_spec.rb
@@ -1,0 +1,12 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test::logical_switch_patch' do
+  include_context 'chef context'
+  let(:resource_name) { 'logical_switch' }
+
+  it 'performs patch operation' do
+    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:patch).with('test', 'test/', 'TestMessage').and_return(true)
+    expect(real_chef_run).to patch_oneview_logical_switch('LogicalSwitch5')
+  end
+end

--- a/spec/unit/resources/logical_switch/patch_spec.rb
+++ b/spec/unit/resources/logical_switch/patch_spec.rb
@@ -1,12 +1,12 @@
 require_relative './../../../spec_helper'
 
-describe 'oneview_test::logical_switch_patch' do
+describe 'oneview_test_api300_synergy::logical_switch_patch' do
   include_context 'chef context'
   let(:resource_name) { 'logical_switch' }
 
   it 'performs patch operation' do
     expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:retrieve!).and_return(true)
     allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:patch).with('test', 'test/', 'TestMessage').and_return(true)
-    expect(real_chef_run).to patch_oneview_logical_switch('LogicalSwitch5')
+    expect(real_chef_run).to patch_oneview_logical_switch('LogicalSwitch1')
   end
 end

--- a/spec/unit/resources/logical_switch/patch_spec.rb
+++ b/spec/unit/resources/logical_switch/patch_spec.rb
@@ -1,12 +1,10 @@
 require_relative './../../../spec_helper'
 
 describe 'oneview_test_api300_synergy::logical_switch_patch' do
-  include_context 'chef context'
   let(:resource_name) { 'logical_switch' }
+  include_context 'chef context'
 
-  it 'performs patch operation' do
-    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:patch).with('test', 'test/', 'TestMessage').and_return(true)
-    expect(real_chef_run).to patch_oneview_logical_switch('LogicalSwitch1')
-  end
+  let(:target_class) { OneviewSDK::API300::C7000::LogicalSwitch }
+  let(:target_match_method) { [:patch_oneview_logical_switch, 'LogicalSwitch1'] }
+  it_behaves_like 'action :patch'
 end

--- a/spec/unit/resources/logical_switch/remove_from_scopes_spec.rb
+++ b/spec/unit/resources/logical_switch/remove_from_scopes_spec.rb
@@ -4,34 +4,8 @@ describe 'oneview_test_api300_synergy::logical_switch_remove_from_scopes' do
   let(:resource_name) { 'logical_switch' }
   include_context 'chef context'
 
-  let(:scope1) { OneviewSDK::API300::C7000::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
-  let(:scope2) { OneviewSDK::API300::C7000::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
-
-  before do
-    allow(OneviewSDK::API300::C7000::Scope).to receive(:new).and_return(scope1, scope2)
-    allow(scope1).to receive(:retrieve!).and_return(true)
-    allow(scope2).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).and_call_original
-  end
-
-  it 'removes all scopes when are not removed' do
-    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
-    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:remove_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:remove_scope).with(scope2)
-    expect(real_chef_run).to remove_oneview_logical_switch_from_scopes('LogicalSwitch1')
-  end
-
-  it 'removes only the one scope that is not removed' do
-    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:remove_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).not_to receive(:remove_scope).with(scope2)
-    expect(real_chef_run).to remove_oneview_logical_switch_from_scopes('LogicalSwitch1')
-  end
-
-  it 'does nothing when scope is already removed' do
-    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return(['/rest/fake/other-scope'])
-    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).not_to receive(:remove_scope)
-    expect(real_chef_run).to remove_oneview_logical_switch_from_scopes('LogicalSwitch1')
-  end
+  let(:target_class) { OneviewSDK::API300::C7000::LogicalSwitch }
+  let(:scope_class) { OneviewSDK::API300::C7000::Scope }
+  let(:target_match_method) { [:remove_oneview_logical_switch_from_scopes, 'LogicalSwitch1'] }
+  it_behaves_like 'action :remove_from_scopes'
 end

--- a/spec/unit/resources/logical_switch/remove_from_scopes_spec.rb
+++ b/spec/unit/resources/logical_switch/remove_from_scopes_spec.rb
@@ -1,0 +1,37 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::logical_switch_remove_from_scopes' do
+  let(:resource_name) { 'logical_switch' }
+  include_context 'chef context'
+
+  let(:scope1) { OneviewSDK::API300::C7000::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
+  let(:scope2) { OneviewSDK::API300::C7000::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
+
+  before do
+    allow(OneviewSDK::API300::C7000::Scope).to receive(:new).and_return(scope1, scope2)
+    allow(scope1).to receive(:retrieve!).and_return(true)
+    allow(scope2).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).and_call_original
+  end
+
+  it 'removes all scopes when are not removed' do
+    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
+    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:remove_scope).with(scope1)
+    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:remove_scope).with(scope2)
+    expect(real_chef_run).to remove_oneview_logical_switch_from_scopes('LogicalSwitch1')
+  end
+
+  it 'removes only the one scope that is not removed' do
+    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
+    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:remove_scope).with(scope1)
+    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).not_to receive(:remove_scope).with(scope2)
+    expect(real_chef_run).to remove_oneview_logical_switch_from_scopes('LogicalSwitch1')
+  end
+
+  it 'does nothing when scope is already removed' do
+    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return(['/rest/fake/other-scope'])
+    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).not_to receive(:remove_scope)
+    expect(real_chef_run).to remove_oneview_logical_switch_from_scopes('LogicalSwitch1')
+  end
+end

--- a/spec/unit/resources/logical_switch/replace_scopes_spec.rb
+++ b/spec/unit/resources/logical_switch/replace_scopes_spec.rb
@@ -4,32 +4,8 @@ describe 'oneview_test_api300_synergy::logical_switch_replace_scopes' do
   let(:resource_name) { 'logical_switch' }
   include_context 'chef context'
 
-  let(:scope1) { OneviewSDK::API300::C7000::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
-  let(:scope2) { OneviewSDK::API300::C7000::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
-
-  before do
-    allow(OneviewSDK::API300::C7000::Scope).to receive(:new).and_return(scope1, scope2)
-    allow(scope1).to receive(:retrieve!).and_return(true)
-    allow(scope2).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).and_call_original
-  end
-
-  it 'replace scopes' do
-    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return([])
-    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:replace_scopes).with([scope1, scope2])
-    expect(real_chef_run).to replace_oneview_logical_switch_scopes('LogicalSwitch1')
-  end
-
-  it 'replace scopes even when already one of scopes added' do
-    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:replace_scopes).with([scope1, scope2])
-    expect(real_chef_run).to replace_oneview_logical_switch_scopes('LogicalSwitch1')
-  end
-
-  it 'does nothing when all scopes are already replaced' do
-    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return(['/rest/fake/2', '/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).not_to receive(:replace_scopes)
-    expect(real_chef_run).to replace_oneview_logical_switch_scopes('LogicalSwitch1')
-  end
+  let(:target_class) { OneviewSDK::API300::C7000::LogicalSwitch }
+  let(:scope_class) { OneviewSDK::API300::C7000::Scope }
+  let(:target_match_method) { [:replace_oneview_logical_switch_scopes, 'LogicalSwitch1'] }
+  it_behaves_like 'action :replace_scopes'
 end

--- a/spec/unit/resources/logical_switch/replace_scopes_spec.rb
+++ b/spec/unit/resources/logical_switch/replace_scopes_spec.rb
@@ -1,0 +1,35 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::logical_switch_replace_scopes' do
+  let(:resource_name) { 'logical_switch' }
+  include_context 'chef context'
+
+  let(:scope1) { OneviewSDK::API300::C7000::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
+  let(:scope2) { OneviewSDK::API300::C7000::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
+
+  before do
+    allow(OneviewSDK::API300::C7000::Scope).to receive(:new).and_return(scope1, scope2)
+    allow(scope1).to receive(:retrieve!).and_return(true)
+    allow(scope2).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).and_call_original
+  end
+
+  it 'replace scopes' do
+    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return([])
+    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:replace_scopes).with([scope1, scope2])
+    expect(real_chef_run).to replace_oneview_logical_switch_scopes('LogicalSwitch1')
+  end
+
+  it 'replace scopes even when already one of scopes added' do
+    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
+    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:replace_scopes).with([scope1, scope2])
+    expect(real_chef_run).to replace_oneview_logical_switch_scopes('LogicalSwitch1')
+  end
+
+  it 'does nothing when all scopes are already replaced' do
+    allow_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).to receive(:[]).with('scopeUris').and_return(['/rest/fake/2', '/rest/fake/1'])
+    expect_any_instance_of(OneviewSDK::API300::C7000::LogicalSwitch).not_to receive(:replace_scopes)
+    expect(real_chef_run).to replace_oneview_logical_switch_scopes('LogicalSwitch1')
+  end
+end

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -145,6 +145,9 @@ describe 'oneview_test::default' do
     expect(chef_run).to_not create_oneview_logical_switch_if_missing('')
     expect(chef_run).to_not delete_oneview_logical_switch('')
     expect(chef_run).to_not refresh_oneview_logical_switch('')
+    expect(chef_run).to_not add_oneview_logical_switch_to_scopes('')
+    expect(chef_run).to_not remove_oneview_logical_switch_from_scopes('')
+    expect(chef_run).to_not replace_oneview_logical_switch_scopes('')
     expect(chef_run).to_not patch_oneview_logical_switch('')
 
     # oneview_managed_san

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -145,6 +145,7 @@ describe 'oneview_test::default' do
     expect(chef_run).to_not create_oneview_logical_switch_if_missing('')
     expect(chef_run).to_not delete_oneview_logical_switch('')
     expect(chef_run).to_not refresh_oneview_logical_switch('')
+    expect(chef_run).to_not patch_oneview_logical_switch('')
 
     # oneview_managed_san
     expect(chef_run).to_not set_oneview_managed_san_public_attributes('')


### PR DESCRIPTION
### Description
Adding Logical Switch for HPE OneView API500 support.

### Issues Resolved
#269 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
