### PR TITLE
API 500 Support for Switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Adds API 500 support to the following HPE OneView resources:
   - oneview_server_hardware_type
   - oneview_server_profile
   - oneview_storage_system
+  - oneview_switch
   - oneview_unmanaged_device
   - oneview_user
 

--- a/README.md
+++ b/README.md
@@ -789,10 +789,11 @@ Note: API300 includes the `:patch` operation.
 oneview_switch 'Switch1' do
   client <my_client>
   data <data>
-  operation <op>   # String. Used in patch action only. e.g., 'replace'
-  path <path>      # String. Used in patch option only. e.g., '/name'
-  value <val>      # String. Used in patch option only. e.g., 'New Name'
-  action [:remove, :none, :patch]
+  operation <op>        # String. Used in patch action only. e.g., 'replace'
+  path <path>           # String. Used in patch option only. e.g., '/name'
+  value <val>           # String. Used in patch option only. e.g., 'New Name'
+  scopes <scope_names>  # Array - Optional. Array of scope names. Used in add_to_scopes, remove_from_scopes or replace_scopes options only. e.g., ['Scope1', 'Scope2']
+  action [:remove, :none, :patch, :add_to_scopes, :remove_from_scopes, :replace_scopes]
 end
 ```
 

--- a/examples/switch.rb
+++ b/examples/switch.rb
@@ -24,18 +24,17 @@ oneview_switch 'Switch1' do
 end
 
 # Example: Replace the Scopes for the Switch with a patch.
-oneview_switch 'Switch1' do
+oneview_switch 'Switch2' do
   client my_client
-  api_version 300
-  api_variant 'C7000'
+  data(name: '172.xx.xx.1')
   operation 'replace'
   path '/scopeUris'
-  value '/rest/scopes/3b292baf-8b59-4671-9e5c-deca07496c60'
+  value ['/rest/scopes/7fa5a27f-9d24-401d-9141-16501febee6c']
   action :patch
 end
 
 # Example: Removes the Switch
-oneview_switch 'Switch1' do
+oneview_switch 'Switch3' do
   client my_client
   action :remove
 end

--- a/examples/switch.rb
+++ b/examples/switch.rb
@@ -20,10 +20,8 @@ my_client = {
 }
 
 # Example: No action is executed.
-# In a resource that only has a remove action and other actions without great relevance to be considered
-# a standard action and no action is specified in the block Chef executes this one.
-# To prevent Chef from removing a switch or use an action without great relevance as the standard action
-# we created the none action.
+# In a resource that only has destructive and non intuitive actions, Chef executes the none action to avoid mistakes.
+# To prevent Chef from removing a switch or using a non intuitive action as the standard action, we created the none action.
 oneview_switch 'Switch1' do
   client my_client
 end

--- a/examples/switch.rb
+++ b/examples/switch.rb
@@ -9,10 +9,14 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+# NOTE 1: This example requires two Scopes named "Scope1" and "Scope2" to be present in the appliance.
+# NOTE 2: The api_version client should be greater than 200 if you run the examples using Scopes
+
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
   user: ENV['ONEVIEWSDK_USER'],
-  password: ENV['ONEVIEWSDK_PASSWORD']
+  password: ENV['ONEVIEWSDK_PASSWORD'],
+  api_version: 300
 }
 
 # Example: No action is executed.
@@ -23,18 +27,38 @@ oneview_switch 'Switch1' do
   client my_client
 end
 
-# Example: Replace the Scopes for the Switch with a patch.
-oneview_switch 'Switch2' do
+# Example: Adds 'Switch1' to 'Scope1' and 'Scope2'
+oneview_switch 'Switch1' do
   client my_client
-  data(name: '172.xx.xx.1')
+  scopes ['Scope1', 'Scope2']
+  action :add_to_scopes
+end
+
+# Example: Removes 'Switch1' from 'Scope1'
+oneview_switch 'Switch1' do
+  client my_client
+  scopes ['Scope1']
+  action :remove_from_scopes
+end
+
+# Example: Replaces 'Scope1' and 'Scope2' for 'Switch1'
+oneview_switch 'Switch1' do
+  client my_client
+  scopes ['Scope1', 'Scope2']
+  action :replace_scopes
+end
+
+# Example: Replaces all scopes to empty list of scopes
+oneview_switch 'Switch1' do
+  client my_client
   operation 'replace'
   path '/scopeUris'
-  value ['/rest/scopes/7fa5a27f-9d24-401d-9141-16501febee6c']
+  value []
   action :patch
 end
 
 # Example: Removes the Switch
-oneview_switch 'Switch3' do
+oneview_switch 'Switch1' do
   client my_client
   action :remove
 end

--- a/examples/switch.rb
+++ b/examples/switch.rb
@@ -10,7 +10,7 @@
 # specific language governing permissions and limitations under the License.
 
 # NOTE 1: This example requires two Scopes named "Scope1" and "Scope2" to be present in the appliance.
-# NOTE 2: The api_version client should be greater than 200 if you run the examples using Scopes
+# NOTE 2: The api_version client should be 300 or greater if you run the examples using Scopes
 
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
@@ -20,9 +20,10 @@ my_client = {
 }
 
 # Example: No action is executed.
-# In a resource that has only one action and no action is specified in the block
-# Chef executes this one. To prevent Chef from removing a switch as the standard action we created
-# the none action
+# In a resource that only has a remove action and other actions without great relevance to be considered
+# a standard action and no action is specified in the block Chef executes this one.
+# To prevent Chef from removing a switch or use an action without great relevance as the standard action
+# we created the none action.
 oneview_switch 'Switch1' do
   client my_client
 end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -57,7 +57,7 @@ if defined?(ChefSpec)
     oneview_server_profile:             standard_actions + [:update_from_template],
     oneview_storage_pool:               %i[add_if_missing remove],
     oneview_storage_system:             %i[add remove edit_credentials add_if_missing refresh],
-    oneview_switch:                     %i[remove none patch],
+    oneview_switch:                     scope_actions + %i[remove none],
     oneview_unmanaged_device:           %i[add remove add_if_missing],
     oneview_uplink_set:                 standard_actions,
     oneview_user:                       standard_actions,

--- a/libraries/resource_providers/api300/c7000/switch_provider.rb
+++ b/libraries/resource_providers/api300/c7000/switch_provider.rb
@@ -14,25 +14,6 @@ module OneviewCookbook
     module C7000
       # Switch API300 C7000 provider
       class SwitchProvider < API200::SwitchProvider
-        # Description                         ||  Operation  ||  Path      ||  Value
-        # Add one scopeUri to the server       |  add        |  /scopeUris/-|/scopeUris/[0-#index_of_scopes_on_current_server]  |  scopeUri
-        # Change the scopeUris of the server   |  replace    |  /scopeUris  |  a list of scopeUris
-        # Remove one scopeUri from the server  |  remove     |  /scopeUris/[0-#index_of_scopes_on_current_server]
-        def patch
-          invalid_param = @new_resource.operation.nil? || @new_resource.path.nil?
-          raise "InvalidParameters: Parameters 'operation' and 'path' must be set for patch" if invalid_param
-          # TODO: Add support to Scopes (Currently not supported by oneview-sdk gem 3.1.0)
-          @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-          @context.converge_by "Performing '#{@new_resource.operation}' at #{@new_resource.path} with #{@new_resource.value} in #{@resource_name} '#{@name}'" do
-            body = if @new_resource.value
-                     { op: @new_resource.operation, path: @new_resource.path, value: @new_resource.value }
-                   else
-                     { op: @new_resource.operation, path: @new_resource.path }
-                   end
-            response = @item.client.rest_patch(@item['uri'], { 'body' => [body] }, @sdk_api_version)
-            @item.client.response_handler(response)
-          end
-        end
       end
     end
   end

--- a/libraries/resource_providers/api500/c7000/switch_provider.rb
+++ b/libraries/resource_providers/api500/c7000/switch_provider.rb
@@ -1,4 +1,4 @@
-# (c) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -9,18 +9,14 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-OneviewCookbook::ResourceBaseProperties.load(self)
+require_relative '../../api300/c7000/switch_provider'
 
-# To prevent that the default action is remove
-default_action :none
-
-action :none do
-end
-
-action :remove do
-  OneviewCookbook::Helper.do_resource_action(self, :Switch, :remove)
-end
-
-action :patch do
-  OneviewCookbook::Helper.do_resource_action(self, :Switch, :patch)
+module OneviewCookbook
+  module API500
+    module C7000
+      # Switch API500 C7000 provider
+      class SwitchProvider < OneviewCookbook::API300::C7000::SwitchProvider
+      end
+    end
+  end
 end

--- a/resources/switch.rb
+++ b/resources/switch.rb
@@ -11,6 +11,8 @@
 
 OneviewCookbook::ResourceBaseProperties.load(self)
 
+property :scopes, Array
+
 # To prevent that the default action is remove
 default_action :none
 
@@ -19,6 +21,18 @@ end
 
 action :remove do
   OneviewCookbook::Helper.do_resource_action(self, :Switch, :remove)
+end
+
+action :add_to_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :Switch, :add_to_scopes)
+end
+
+action :remove_from_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :Switch, :remove_from_scopes)
+end
+
+action :replace_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :Switch, :replace_scopes)
 end
 
 action :patch do

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/switch_add_to_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/switch_add_to_scopes.rb
@@ -1,3 +1,7 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: switch_add_to_scopes
+#
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -8,13 +12,12 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+#
 
-module OneviewCookbook
-  module API500
-    module C7000
-      # Switch API500 C7000 provider
-      class SwitchProvider < API300::C7000::SwitchProvider
-      end
-    end
-  end
+oneview_switch 'Switch1' do
+  client node['oneview_test']['client']
+  api_version 300
+  api_variant 'C7000'
+  scopes ['Scope1', 'Scope2']
+  action :add_to_scopes
 end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/switch_remove_from_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/switch_remove_from_scopes.rb
@@ -1,3 +1,7 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: switch_remove_from_scopes
+#
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -8,13 +12,12 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+#
 
-module OneviewCookbook
-  module API500
-    module C7000
-      # Switch API500 C7000 provider
-      class SwitchProvider < API300::C7000::SwitchProvider
-      end
-    end
-  end
+oneview_switch 'Switch1' do
+  client node['oneview_test']['client']
+  api_version 300
+  api_variant 'C7000'
+  scopes ['Scope1', 'Scope2']
+  action :remove_from_scopes
 end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/switch_replace_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/switch_replace_scopes.rb
@@ -1,3 +1,7 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: switch_replace_scopes
+#
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -8,13 +12,12 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+#
 
-module OneviewCookbook
-  module API500
-    module C7000
-      # Switch API500 C7000 provider
-      class SwitchProvider < API300::C7000::SwitchProvider
-      end
-    end
-  end
+oneview_switch 'Switch1' do
+  client node['oneview_test']['client']
+  api_version 300
+  api_variant 'C7000'
+  scopes ['Scope1', 'Scope2']
+  action :replace_scopes
 end

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -232,6 +232,9 @@ describe 'oneview_test::default' do
     # oneview_switch
     expect(chef_run).to_not remove_oneview_switch('')
     expect(chef_run).to_not none_oneview_switch('')
+    expect(chef_run).to_not add_oneview_switch_to_scopes('')
+    expect(chef_run).to_not remove_oneview_switch_from_scopes('')
+    expect(chef_run).to_not replace_oneview_switch_scopes('')
     expect(chef_run).to_not patch_oneview_switch('')
 
     # oneview_unmanaged_device

--- a/spec/unit/resources/switch/add_to_scopes_spec.rb
+++ b/spec/unit/resources/switch/add_to_scopes_spec.rb
@@ -1,0 +1,11 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::switch_add_to_scopes' do
+  let(:resource_name) { 'switch' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API300::C7000::Switch }
+  let(:scope_class) { OneviewSDK::API300::C7000::Scope }
+  let(:target_match_method) { [:add_oneview_switch_to_scopes, 'Switch1'] }
+  it_behaves_like 'action :add_to_scopes'
+end

--- a/spec/unit/resources/switch/patch_spec.rb
+++ b/spec/unit/resources/switch/patch_spec.rb
@@ -4,22 +4,15 @@ describe 'oneview_test_api300_synergy::switch_patch' do
   include_context 'chef context'
   let(:resource_name) { 'switch' }
   let(:api) { OneviewSDK::API300::C7000 }
-  let(:patch_body) { { 'body' => [op: 'test', path: 'test/', value: 'TestMessage'] } }
 
   it 'performs patch operation' do
-    allow_any_instance_of(api::Switch).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(api::Switch).to receive(:[]).and_call_original
-    allow_any_instance_of(api::Switch).to receive(:[]).with('uri').and_return('rest/fake')
-    allow_any_instance_of(api::Switch).to receive(:client).and_return(client300)
-
-    expect_any_instance_of(OneviewSDK::Client).to receive(:rest_patch).with('rest/fake', patch_body, 300).and_return('patch' => 'ok')
-    expect_any_instance_of(OneviewSDK::Client).to receive(:response_handler).with('patch' => 'ok').and_return(true)
-
+    expect_any_instance_of(api::Switch).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(api::Switch).to receive(:patch).with('test', 'test/', 'TestMessage').and_return(true)
     expect(real_chef_run).to patch_oneview_switch('Switch1')
   end
 
   it 'fails if the resource is not found' do
     expect_any_instance_of(api::Switch).to receive(:retrieve!).and_return(false)
-    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /ResourceNotFound: Patch failed to apply since oneview_switch 'Switch1' does not exist/)
   end
 end

--- a/spec/unit/resources/switch/patch_spec.rb
+++ b/spec/unit/resources/switch/patch_spec.rb
@@ -1,18 +1,10 @@
 require_relative './../../../spec_helper'
 
 describe 'oneview_test_api300_synergy::switch_patch' do
-  include_context 'chef context'
   let(:resource_name) { 'switch' }
-  let(:api) { OneviewSDK::API300::C7000 }
+  include_context 'chef context'
 
-  it 'performs patch operation' do
-    expect_any_instance_of(api::Switch).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(api::Switch).to receive(:patch).with('test', 'test/', 'TestMessage').and_return(true)
-    expect(real_chef_run).to patch_oneview_switch('Switch1')
-  end
-
-  it 'fails if the resource is not found' do
-    expect_any_instance_of(api::Switch).to receive(:retrieve!).and_return(false)
-    expect { real_chef_run }.to raise_error(RuntimeError, /ResourceNotFound: Patch failed to apply since oneview_switch 'Switch1' does not exist/)
-  end
+  let(:target_class) { OneviewSDK::API300::C7000::Switch }
+  let(:target_match_method) { [:patch_oneview_switch, 'Switch1'] }
+  it_behaves_like 'action :patch'
 end

--- a/spec/unit/resources/switch/remove_from_scopes_spec.rb
+++ b/spec/unit/resources/switch/remove_from_scopes_spec.rb
@@ -1,0 +1,11 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::switch_remove_from_scopes' do
+  let(:resource_name) { 'switch' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API300::C7000::Switch }
+  let(:scope_class) { OneviewSDK::API300::C7000::Scope }
+  let(:target_match_method) { [:remove_oneview_switch_from_scopes, 'Switch1'] }
+  it_behaves_like 'action :remove_from_scopes'
+end

--- a/spec/unit/resources/switch/replace_scopes_spec.rb
+++ b/spec/unit/resources/switch/replace_scopes_spec.rb
@@ -1,0 +1,11 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::switch_replace_scopes' do
+  let(:resource_name) { 'switch' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API300::C7000::Switch }
+  let(:scope_class) { OneviewSDK::API300::C7000::Scope }
+  let(:target_match_method) { [:replace_oneview_switch_scopes, 'Switch1'] }
+  it_behaves_like 'action :replace_scopes'
+end


### PR DESCRIPTION
### Description
Adding Switch for HPE OneView API500 support.

### Issues Resolved
#270 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
