### PR TITLE
API 500 Support for SAN Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.3.1 (Unreleased)
 Adds API 500 support to the following HPE OneView resources:
-  - oneview_scope
   - oneview_san_manager
+  - oneview_scope
 
 Enhancements:
 - [#246](https://github.com/HewlettPackard/oneview-chef/issues/246) Upgrade oneview-sdk gem to version 5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.3.1 (Unreleased)
 Adds API 500 support to the following HPE OneView resources:
   - oneview_scope
+  - oneview_san_manager
 
 Enhancements:
 - [#246](https://github.com/HewlettPackard/oneview-chef/issues/246) Upgrade oneview-sdk gem to version 5.0.0

--- a/examples/san_manager.rb
+++ b/examples/san_manager.rb
@@ -32,7 +32,7 @@ oneview_san_manager '172.18.15.1' do
 end
 
 # Example: remove the SAN manager
-oneview_san_manager '172.18.15.1' do
+oneview_san_manager 'Remove 172.18.15.1' do
   client my_client
   action :remove
 end

--- a/examples/san_manager.rb
+++ b/examples/san_manager.rb
@@ -34,5 +34,6 @@ end
 # Example: remove the SAN manager
 oneview_san_manager 'Remove 172.18.15.1' do
   client my_client
+  data(name: '172.18.15.1')
   action :remove
 end

--- a/examples/san_manager.rb
+++ b/examples/san_manager.rb
@@ -32,8 +32,7 @@ oneview_san_manager '172.18.15.1' do
 end
 
 # Example: remove the SAN manager
-oneview_san_manager 'Remove 172.18.15.1' do
+oneview_san_manager '172.18.15.1' do
   client my_client
-  data(name: '172.18.15.1')
   action :remove
 end

--- a/libraries/resource_providers/api500/c7000/san_manager_provider.rb
+++ b/libraries/resource_providers/api500/c7000/san_manager_provider.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/san_manager_provider'
+
+module OneviewCookbook
+  module API500
+    module C7000
+      # SANManager API500 C7000 provider
+      class SANManagerProvider < OneviewCookbook::API300::C7000::SANManagerProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api500/synergy/san_manager_provider.rb
+++ b/libraries/resource_providers/api500/synergy/san_manager_provider.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/san_manager_provider'
+
+module OneviewCookbook
+  module API500
+    module Synergy
+      # SANManager API500 Synergy provider
+      class SANManagerProvider < OneviewCookbook::API300::Synergy::SANManagerProvider
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description
Adding SAN Manager for HPE OneView API500 support.

### Issues Resolved
#273 

### Check List
- [] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [] New functionality has been documented in the README if applicable.
  - [] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
