### PR TITLE
API 500 Support for Managed SAN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Adds API 500 support to the following HPE OneView resources:
   - oneview_fabric
   - oneview_firmware
   - oneview_id_pool
+  - oneview_managed_san
   - oneview_rack
   - oneview_san_manager
   - oneview_scope

--- a/libraries/resource_providers/api200/managed_san_provider.rb
+++ b/libraries/resource_providers/api200/managed_san_provider.rb
@@ -33,16 +33,11 @@ module OneviewCookbook
       end
 
       def set_public_attributes
-        temp = Marshal.load(Marshal.dump(@item['publicAttributes']))
+        temp_attributes = Marshal.load(Marshal.dump(@item['publicAttributes']))
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         # compares two hashes
-        results = []
-        temp_attributes = temp.sort_by { |element| element['name'] }
-        item_attributes = @item['publicAttributes'].sort_by { |element| element['name'] }
-        temp_attributes = temp_attributes.each_with_index do |element, index|
-          results << element.all? { |k, v| v == item_attributes[index][k] }
-        end
-        return Chef::Log.info "#{@resource_name} '#{@name}' public attributes are up to date" if results.all?
+        results = (temp_attributes - @item['publicAttributes']) + (@item['publicAttributes'] - temp_attributes)
+        return Chef::Log.info "#{@resource_name} '#{@name}' public attributes are up to date" if results.empty?
         Chef::Log.info "Updating #{@resource_name} '#{@name}' public attributes"
         @context.converge_by "#{@resource_name} '#{@name}' public attributes updated" do
           @item.set_public_attributes(temp_attributes)

--- a/libraries/resource_providers/api500/c7000/managed_san_provider.rb
+++ b/libraries/resource_providers/api500/c7000/managed_san_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/c7000/managed_san_provider'
-
 module OneviewCookbook
   module API500
     module C7000

--- a/libraries/resource_providers/api500/c7000/managed_san_provider.rb
+++ b/libraries/resource_providers/api500/c7000/managed_san_provider.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/managed_san_provider'
+
+module OneviewCookbook
+  module API500
+    module C7000
+      # ManagedSAN API500 C7000 provider
+      class ManagedSANProvider < OneviewCookbook::API300::C7000::ManagedSANProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api500/synergy/managed_san_provider.rb
+++ b/libraries/resource_providers/api500/synergy/managed_san_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/synergy/managed_san_provider'
-
 module OneviewCookbook
   module API500
     module Synergy

--- a/libraries/resource_providers/api500/synergy/managed_san_provider.rb
+++ b/libraries/resource_providers/api500/synergy/managed_san_provider.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/managed_san_provider'
+
+module OneviewCookbook
+  module API500
+    module Synergy
+      # ManagedSAN API500 Synergy provider
+      class ManagedSANProvider < OneviewCookbook::API300::Synergy::ManagedSANProvider
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description
Adding Managed SAN for HPE OneView API500 support.

### Issues Resolved
#275 

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
