### PR TITLE
API 500 Support for Firmware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Adds API 500 support to the following HPE OneView resources:
   - oneview_datacenter
   - oneview_event
   - oneview_fabric
+  - oneview_firmware
   - oneview_rack
   - oneview_san_manager
   - oneview_scope

--- a/examples/firmware.rb
+++ b/examples/firmware.rb
@@ -20,6 +20,11 @@ oneview_firmware '/bundles/firmware_bundle_name.iso' do
   client my_client
 end
 
+# Example: Upload a hotfix
+oneview_firmware '/bundles/hotfix_name.rpm' do
+  client my_client
+end
+
 # Example: Create a custom spp
 # Uses spp_name and hotfixes_names
 oneview_firmware 'CustomSPP' do
@@ -40,8 +45,13 @@ oneview_firmware 'CustomSPP' do
   action :create_custom_spp
 end
 
-# Example: Remove a firmware
-oneview_firmware '/bundles/firmware_bundle_name.iso' do
-  client my_client
-  action :remove
+# Firmware names added in the example
+firmware_list = ['/bundles/firmware_bundle_name.iso', '/bundles/hotfix_name.rpm', 'CustomSPP']
+
+# Example: Remove firmwares added in the example
+firmware_list.each do |fw|
+  oneview_firmware "#{fw}" do
+    client my_client
+    action :remove
+  end
 end

--- a/libraries/resource_providers/api500/c7000/firmware_driver_provider.rb
+++ b/libraries/resource_providers/api500/c7000/firmware_driver_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/c7000/firmware_driver_provider'
-
 module OneviewCookbook
   module API500
     module C7000

--- a/libraries/resource_providers/api500/c7000/firmware_driver_provider.rb
+++ b/libraries/resource_providers/api500/c7000/firmware_driver_provider.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../api300/c7000/firmware_driver_provider'
+
+module OneviewCookbook
+  module API500
+    module C7000
+      # Firmware API500 C7000 provider
+      class FirmwareDriverProvider < API300::C7000::FirmwareDriverProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api500/synergy/firmware_driver_provider.rb
+++ b/libraries/resource_providers/api500/synergy/firmware_driver_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/synergy/firmware_driver_provider'
-
 module OneviewCookbook
   module API500
     module Synergy

--- a/libraries/resource_providers/api500/synergy/firmware_driver_provider.rb
+++ b/libraries/resource_providers/api500/synergy/firmware_driver_provider.rb
@@ -1,0 +1,22 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative '../../api300/synergy/firmware_driver_provider'
+
+module OneviewCookbook
+  module API500
+    module Synergy
+      # Firmware API500 Synergy provider
+      class FirmwareDriverProvider < API300::Synergy::FirmwareDriverProvider
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description
Adding Firmware for HPE OneView API500 support.

### Issues Resolved
#280 
#281 

### Check List
- [] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [] New functionality has been documented in the README if applicable.
  - [] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
