### PR TITLE
Major refactor to suit new Chef 13 requirements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Metrics/CyclomaticComplexity:
   Enabled: false
 
 Metrics/LineLength:
-  Max: 150
+  Max: 200
 
 Metrics/MethodLength:
   CountComments: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,9 @@ AllCops:
     - 'examples/*'
     - 'bin/*'
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Layout/EndOfLine:
   Enabled: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Adds API 500 support to the following HPE OneView resources:
 
 Enhancements:
 - [#246](https://github.com/HewlettPackard/oneview-chef/issues/246) Upgrade oneview-sdk gem to version 5.0.0
+- [#247](https://github.com/HewlettPackard/oneview-chef/issues/247) Remove deprecation and warnings for Chef 13
+
+Bug fixes:
+- [#284](https://github.com/HewlettPackard/oneview-chef/issues/284) Nested and cyclic requires are causing the first resource to be skipped.
+- [#287](https://github.com/HewlettPackard/oneview-chef/issues/287) Disable FrozenString magic comment cop from Rubocop until the support is done.
 
 ## 2.3.0
 Adds support to the following HPE OneView resources:

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby RUBY_VERSION # Needed to consider & solve for Ruby version requirements
 
 gem 'berkshelf'
-gem 'chef', '~> 12.0'
+gem 'chef', '~> 13.0'
 gem 'chefspec'
 gem 'codeclimate-test-reporter'
 gem 'foodcritic', '~> 7.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby RUBY_VERSION # Needed to consider & solve for Ruby version requirements
 
 gem 'berkshelf'
-gem 'chef', '~> 13.0'
+gem 'chef', '>= 12.0'
 gem 'chefspec'
 gem 'codeclimate-test-reporter'
 gem 'foodcritic', '~> 7.1.0'

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 Chef cookbook that provides resources for managing HPE OneView.
 
 ## Requirements
- - Chef 12.0 or higher
- - For oneview resources: HPE OneView 2.0 or 3.0 (API versions 200 or 300). May work with other versions too, but no guarantees
+ - Chef 13.0 or higher
+ - For oneview resources: HPE OneView 2.0, 3.0 or 3.10 (API versions 200, 300 or 500). May work with other versions too, but no guarantees
  - For image_streamer resources: HPE Synergy Image Streamer appliance (API version 300)
 
 ## Usage
@@ -23,7 +23,7 @@ Then use any of the resources provided by this cookbook.
 ```ruby
 # my_cookbook/metadata.rb
 ...
-depends 'oneview', '~> 5.0.0'
+depends 'oneview', '~> 3.0.0'
 ```
 
 ### Credentials
@@ -270,7 +270,7 @@ oneview_logical_interconnect 'LogicalInterconnect1' do
   internal_networks <networks_names> # Array: Optional for :update_internal_networks
   trap_destinations <trap_options>   # Hash: Optional for :update_snmp_configuration
   enclosure <enclosure_name>         # String: Required for :add_interconnect and :remove_interconnect
-  bay_number <bay>                   # Fixnum: Required for :add_interconnect and :remove_interconnect
+  bay_number <bay>                   # Integer: Required for :add_interconnect and :remove_interconnect
   action [:none, :add_interconnect, :remove_interconnect, :update_internal_networks,
           :update_settings,:update_ethernet_settings, :update_port_monitor, :update_qos_configuration,
           :update_telemetry_configuration, :update_snmp_configuration, :update_firmware, :stage_firmware,

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then use any of the resources provided by this cookbook.
 ```ruby
 # my_cookbook/metadata.rb
 ...
-depends 'oneview', '~> 3.0.0'
+depends 'oneview', '~> 2.3.1'
 ```
 
 ### Credentials

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 Chef cookbook that provides resources for managing HPE OneView.
 
 ## Requirements
- - Chef 13.0 or higher
+ - Ruby 2.2.6 or higher (We recommend using Ruby 2.4.1 or higher)
+ - Chef 12.0 or higher (We recommend using Chef 13.12 or higher if possible)
  - For oneview resources: HPE OneView 2.0, 3.0 or 3.10 (API versions 200, 300 or 500). May work with other versions too, but no guarantees
  - For image_streamer resources: HPE Synergy Image Streamer appliance (API version 300)
 

--- a/libraries/oneview_helper.rb
+++ b/libraries/oneview_helper.rb
@@ -55,24 +55,24 @@ module OneviewCookbook
     def self.get_resource_class(context, resource_type, base_module = OneviewCookbook)
       load_sdk(context)
       # Loads the api version if the property was specified directly
-      context_api_version = context.api_version if context.property_is_set?(:api_version)
+      context_api_version = context.new_resource.api_version if context.property_is_set?(:api_version)
       # Loads the api version if it was specified in the client
       client_api_version = if context.property_is_set?(:client)
-                             if context.client.is_a?(Hash)
-                               convert_keys(context.client, :to_sym)[:api_version]
-                             elsif context.client.is_a?(OneviewSDK::Client) # It works for both Image Streamer and OneView
-                               context.client.api_version
+                             if context.new_resource.client.is_a?(Hash)
+                               convert_keys(context.new_resource.client, :to_sym)[:api_version]
+                             elsif context.new_resource.client.is_a?(OneviewSDK::Client) # It works for both Image Streamer and OneView
+                               context.new_resource.client.api_version
                              end
                            end
       # Loads the api version giving preference: property > client > node default
       api_version = context_api_version || client_api_version || context.node['oneview']['api_version']
       api_module = get_api_module(api_version, base_module)
-      api_variant = context.property_is_set?(:api_variant) ? context.api_variant : context.node['oneview']['api_variant']
+      api_variant = context.property_is_set?(:api_variant) ? context.new_resource.api_variant : context.node['oneview']['api_variant']
       api_module.provider_named(resource_type, api_variant)
     end
 
     # Get the API module given an api_version
-    # @param [Fixnum, String] api_version
+    # @param [Integer, String] api_version
     # @param [Module] base_module The base API module supported. e.g. OneviewCookbook::ImageStreamer
     # @return [Module] Resource module
     def self.get_api_module(api_version, base_module = OneviewCookbook)

--- a/libraries/oneview_resource_base.rb
+++ b/libraries/oneview_resource_base.rb
@@ -17,15 +17,18 @@ module OneviewCookbook
       context.property :client
       context.property :name, [String, Symbol], required: true
       context.property :data, Hash, default: {}
-      context.property :save_resource_info, [TrueClass, FalseClass, Array], default: context.node['oneview']['save_resource_info']
-      context.property :api_version, Integer, default: context.node['oneview']['api_version']
-      context.property :api_variant, [String, Symbol], default: context.node['oneview']['api_variant']
+      context.property :save_resource_info, [TrueClass, FalseClass, Array], default: self.safe_dup(context.node['oneview']['save_resource_info'])
+      context.property :api_version, Integer, default: self.safe_dup(context.node['oneview']['api_version'])
+      context.property :api_variant, [String, Symbol], default: self.safe_dup(context.node['oneview']['api_variant'])
       context.property :api_header_version, Integer    # Overrides X-API-Version headers in API requests
       context.property :operation, String              # To be used with :patch action
       context.property :path, String                   # To be used with :patch action
       context.property :value, [String, Array]         # To be used with :patch action
+    end
 
-      require_relative 'resource_provider'
+    def self.safe_dup(object)
+      return object if object.nil? || object === TrueClass || object === FalseClass
+      object.dup
     end
   end
 end

--- a/libraries/oneview_resource_base.rb
+++ b/libraries/oneview_resource_base.rb
@@ -17,9 +17,9 @@ module OneviewCookbook
       context.property :client
       context.property :name, [String, Symbol], required: true
       context.property :data, Hash, default: {}
-      context.property :save_resource_info, [TrueClass, FalseClass, Array], default: self.safe_dup(context.node['oneview']['save_resource_info'])
-      context.property :api_version, Integer, default: self.safe_dup(context.node['oneview']['api_version'])
-      context.property :api_variant, [String, Symbol], default: self.safe_dup(context.node['oneview']['api_variant'])
+      context.property :save_resource_info, [TrueClass, FalseClass, Array], default: safe_dup(context.node['oneview']['save_resource_info'])
+      context.property :api_version, Integer, default: safe_dup(context.node['oneview']['api_version'])
+      context.property :api_variant, [String, Symbol], default: safe_dup(context.node['oneview']['api_variant'])
       context.property :api_header_version, Integer    # Overrides X-API-Version headers in API requests
       context.property :operation, String              # To be used with :patch action
       context.property :path, String                   # To be used with :patch action
@@ -27,7 +27,7 @@ module OneviewCookbook
     end
 
     def self.safe_dup(object)
-      return object if object.nil? || object === TrueClass || object === FalseClass
+      return object if object.class <= Integer || object.class <= TrueClass || object.class <= FalseClass
       object.dup
     end
   end

--- a/libraries/oneview_resource_base.rb
+++ b/libraries/oneview_resource_base.rb
@@ -24,6 +24,8 @@ module OneviewCookbook
       context.property :operation, String              # To be used with :patch action
       context.property :path, String                   # To be used with :patch action
       context.property :value, [String, Array]         # To be used with :patch action
+
+      require_relative 'resource_provider'
     end
   end
 end

--- a/libraries/resource_providers/api200/connection_template_provider.rb
+++ b/libraries/resource_providers/api200/connection_template_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # ConnectionTemplate API200 provider

--- a/libraries/resource_providers/api200/connection_template_provider.rb
+++ b/libraries/resource_providers/api200/connection_template_provider.rb
@@ -20,13 +20,13 @@ module OneviewCookbook
       end
 
       def load_connection_templates
-        resources_set = [@context.associated_ethernet_network, @context.associated_fcoe_network, @context.associated_fc_network,
-                         @context.associated_network_set].compact.size
+        resources_set = [@new_resource.associated_ethernet_network, @new_resource.associated_fcoe_network, @new_resource.associated_fc_network,
+                         @new_resource.associated_network_set].compact.size
         raise 'A single associated resource field must be specified for this action.' if resources_set > 1
-        load_template_from_resource(:EthernetNetwork, @context.associated_ethernet_network)
-        load_template_from_resource(:FCoENetwork, @context.associated_fcoe_network)
-        load_template_from_resource(:FCNetwork, @context.associated_fc_network)
-        load_template_from_resource(:NetworkSet, @context.associated_network_set)
+        load_template_from_resource(:EthernetNetwork, @new_resource.associated_ethernet_network)
+        load_template_from_resource(:FCoENetwork, @new_resource.associated_fcoe_network)
+        load_template_from_resource(:FCNetwork, @new_resource.associated_fc_network)
+        load_template_from_resource(:NetworkSet, @new_resource.associated_network_set)
       end
 
       def create_or_update

--- a/libraries/resource_providers/api200/datacenter_provider.rb
+++ b/libraries/resource_providers/api200/datacenter_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # Datacenter API200 provider

--- a/libraries/resource_providers/api200/datacenter_provider.rb
+++ b/libraries/resource_providers/api200/datacenter_provider.rb
@@ -14,7 +14,7 @@ module OneviewCookbook
     # Datacenter API200 provider
     class DatacenterProvider < ResourceProvider
       def add_racks
-        @context.racks.each do |rack_name, rack_position|
+        @new_resource.racks.each do |rack_name, rack_position|
           rack = load_resource(:Rack, rack_name.to_s)
           rp = convert_keys(rack_position, :to_sym)
           x = rp[:x] || 0

--- a/libraries/resource_providers/api200/enclosure_group_provider.rb
+++ b/libraries/resource_providers/api200/enclosure_group_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # EnclosureGroup API200 provider

--- a/libraries/resource_providers/api200/enclosure_group_provider.rb
+++ b/libraries/resource_providers/api200/enclosure_group_provider.rb
@@ -14,18 +14,18 @@ module OneviewCookbook
     # EnclosureGroup API200 provider
     class EnclosureGroupProvider < ResourceProvider
       def load_lig # Deprecated property: logical_interconnect_group
-        return unless @context.logical_interconnect_group
+        return unless @new_resource.logical_interconnect_group
         lig_klass = resource_named(:LogicalInterconnectGroup)
         dep_warn = "The 'logical_interconnect_group' property (string) is deprecated!"
         Chef::Log.warn("#{dep_warn} Please use 'logical_interconnect_groups' property (array) instead")
-        @item.add_logical_interconnect_group(lig_klass.new(@item.client, name: @context.logical_interconnect_group))
+        @item.add_logical_interconnect_group(lig_klass.new(@item.client, name: @new_resource.logical_interconnect_group))
       end
 
       def load_ligs
         load_lig # Deprecated method
-        return unless @context.logical_interconnect_groups
+        return unless @new_resource.logical_interconnect_groups
         lig_klass = resource_named(:LogicalInterconnectGroup)
-        @context.logical_interconnect_groups.each do |lig|
+        @new_resource.logical_interconnect_groups.each do |lig|
           lig_name = lig.class == Hash ? convert_keys(lig, :to_s)['name'] : lig
           @item.add_logical_interconnect_group(lig_klass.new(@item.client, name: lig_name))
         end
@@ -43,10 +43,10 @@ module OneviewCookbook
 
       def set_script
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-        return Chef::Log.info("#{@resource_name} '#{@name}' script is up to date") if @item.get_script.eql?(@context.script)
+        return Chef::Log.info("#{@resource_name} '#{@name}' script is up to date") if @item.get_script.eql?(@new_resource.script)
         Chef::Log.debug "#{@resource_name} '#{@name}' Chef resource differs from OneView resource."
         @context.converge_by "Updated script for #{@resource_name} '#{@name}'" do
-          @item.set_script(@context.script)
+          @item.set_script(@new_resource.script)
         end
       end
     end

--- a/libraries/resource_providers/api200/enclosure_provider.rb
+++ b/libraries/resource_providers/api200/enclosure_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # Enclosure API200 provider

--- a/libraries/resource_providers/api200/enclosure_provider.rb
+++ b/libraries/resource_providers/api200/enclosure_provider.rb
@@ -14,8 +14,8 @@ module OneviewCookbook
     # Enclosure API200 provider
     class EnclosureProvider < ResourceProvider
       def add_or_edit
-        if @context.enclosure_group
-          eg = resource_named(:EnclosureGroup).new(@item.client, name: @context.enclosure_group)
+        if @new_resource.enclosure_group
+          eg = resource_named(:EnclosureGroup).new(@item.client, name: @new_resource.enclosure_group)
           @item.set_enclosure_group(eg)
         end
         super
@@ -37,7 +37,7 @@ module OneviewCookbook
         refresh_ready = ['RefreshFailed', 'NotRefreshing', ''].include? @item['refreshState']
         return Chef::Log.info("#{@resource_name} '#{@name}' refresh is already running. State: #{@item['refreshState']}") unless refresh_ready
         @context.converge_by "#{@resource_name} '#{@name}' was refreshed." do
-          @item.set_refresh_state(@context.refresh_state, @context.options)
+          @item.set_refresh_state(@new_resource.refresh_state, @new_resource.options)
         end
       end
     end

--- a/libraries/resource_providers/api200/ethernet_network_provider.rb
+++ b/libraries/resource_providers/api200/ethernet_network_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # EthernetNetworkProvider

--- a/libraries/resource_providers/api200/event_provider.rb
+++ b/libraries/resource_providers/api200/event_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # EventProvider API200 provider

--- a/libraries/resource_providers/api200/fc_network_provider.rb
+++ b/libraries/resource_providers/api200/fc_network_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # FC Network Provider resource methods

--- a/libraries/resource_providers/api200/fcoe_network_provider.rb
+++ b/libraries/resource_providers/api200/fcoe_network_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # FCoENetwork API200 provider

--- a/libraries/resource_providers/api200/firmware_driver_provider.rb
+++ b/libraries/resource_providers/api200/firmware_driver_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # Firmware API200 provider

--- a/libraries/resource_providers/api200/firmware_driver_provider.rb
+++ b/libraries/resource_providers/api200/firmware_driver_provider.rb
@@ -32,10 +32,10 @@ module OneviewCookbook
       end
 
       def create_custom_spp
-        hotfix_present = @context.hotfixes_names || @context.hotfixes_files
+        hotfix_present = @new_resource.hotfixes_names || @new_resource.hotfixes_files
         raise "Unspecified property: 'hotfixes_names' or 'hotfixes_files'. Please set it before attempting this action." unless hotfix_present
 
-        spp_present = @context.spp_name || @context.spp_file
+        spp_present = @new_resource.spp_name || @new_resource.spp_file
         raise "Unspecified property: 'spp_name' or 'spp_file'. Please set it before attempting this action." unless spp_present
 
         return Chef::Log.info "#{@resource_name} '#{@name}' is already up to date." if @item.exists?
@@ -54,10 +54,10 @@ module OneviewCookbook
       # Verifies and loads the SPP
       def load_spp
         spp = nil
-        if @context.spp_name
-          spp = load_resource(:FirmwareDriver, @context.spp_name)
-        elsif @context.spp_file
-          spp = load_firmware(@context.spp_file)
+        if @new_resource.spp_name
+          spp = load_resource(:FirmwareDriver, @new_resource.spp_name)
+        elsif @new_resource.spp_file
+          spp = load_firmware(@new_resource.spp_file)
         else
           raise "InvalidProperties: The property 'spp_name' or 'spp_file' must be specified."
         end
@@ -67,10 +67,10 @@ module OneviewCookbook
       # Verifies and loads Hotfixes
       def load_hotfixes
         @item['hotfixUris'] = []
-        if @context.hotfixes_names
-          @context.hotfixes_names.each { |hotfix| @item['hotfixUris'] << load_resource(:FirmwareDriver, hotfix, 'uri') }
-        elsif @context.hotfixes_files
-          @context.hotfixes_files.each do |hotfix|
+        if @new_resource.hotfixes_names
+          @new_resource.hotfixes_names.each { |hotfix| @item['hotfixUris'] << load_resource(:FirmwareDriver, hotfix, 'uri') }
+        elsif @new_resource.hotfixes_files
+          @new_resource.hotfixes_files.each do |hotfix|
             temp = load_firmware(hotfix)
             @item['hotfixUris'] << temp['uri'] if temp['uri']
           end

--- a/libraries/resource_providers/api200/generic_resource_provider.rb
+++ b/libraries/resource_providers/api200/generic_resource_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # Generic Resource Provider methods

--- a/libraries/resource_providers/api200/generic_resource_provider.rb
+++ b/libraries/resource_providers/api200/generic_resource_provider.rb
@@ -15,11 +15,12 @@ module OneviewCookbook
     class GenericResourceProvider < ResourceProvider
       def initialize(context)
         @context = context
-        @resource_name = context.resource_name
-        @name = context.name
+        @new_resource = context.new_resource
+        @resource_name = @new_resource.resource_name
+        @name = @new_resource.name
         name_arr = self.class.to_s.split('::')
         name_arr.pop
-        @sdk_resource_type = context.type # e.g., EthernetNetwork
+        @sdk_resource_type = @new_resource.type # e.g., EthernetNetwork
         case name_arr.size
         when 1 # No variant or api version specified. (OneviewCookbook)
           # This case should really only be used for testing
@@ -36,10 +37,10 @@ module OneviewCookbook
         end
         klass ||= OneviewSDK.resource_named(@sdk_resource_type, @sdk_api_version, @sdk_variant)
         raise "Type '#{@sdk_resource_type}' not found. Please use a valid type defined in the oneview-sdk" unless klass
-        c = OneviewCookbook::Helper.build_client(context.client)
-        new_data = JSON.parse(context.data.to_json) rescue context.data
-        @item = context.property_is_set?(:api_header_version) ? klass.new(c, new_data, context.api_header_version) : klass.new(c, new_data)
-        @item['name'] ||= context.name
+        c = OneviewCookbook::Helper.build_client(@new_resource.client)
+        new_data = JSON.parse(@new_resource.data.to_json) rescue @new_resource.data
+        @item = @new_resource.property_is_set?(:api_header_version) ? klass.new(c, new_data, @new_resource.api_header_version) : klass.new(c, new_data)
+        @item['name'] ||= @name
       end
     end
   end

--- a/libraries/resource_providers/api200/id_pool_provider.rb
+++ b/libraries/resource_providers/api200/id_pool_provider.rb
@@ -14,32 +14,32 @@ module OneviewCookbook
     # IDPool API200 provider
     class IDPoolProvider < ResourceProvider
       def create_or_update
-        @item.get_pool(@context.pool_type)
+        @item.get_pool(@new_resource.pool_type)
         Chef::Log.info "Updating #{@resource_name} '#{@name}'"
         @context.converge_by "#{@resource_name} '#{@name}' was updated." do
-          @item.update(enabled: @context.enabled)
+          @item.update(enabled: @new_resource.enabled)
         end
       end
 
       def allocate_list
-        raise 'The IDs Pools list is not valid.' unless @item.validate_id_list(@context.pool_type, @context.id_list)
-        Chef::Log.info "Allocating the IDs #{@context.id_list} #{@resource_name} '#{@name}'"
-        @context.converge_by "The IDs #{@context.id_list} #{@resource_name} '#{@name}' were allocated." do
-          @item.allocate_id_list(@context.pool_type, @context.id_list)
+        raise 'The IDs Pools list is not valid.' unless @item.validate_id_list(@new_resource.pool_type, @new_resource.id_list)
+        Chef::Log.info "Allocating the IDs #{@new_resource.id_list} #{@resource_name} '#{@name}'"
+        @context.converge_by "The IDs #{@new_resource.id_list} #{@resource_name} '#{@name}' were allocated." do
+          @item.allocate_id_list(@new_resource.pool_type, @new_resource.id_list)
         end
       end
 
       def allocate_count
-        Chef::Log.info "Allocating #{@context.count} ID(s) #{@resource_name} '#{@name}'"
-        @context.converge_by "#{@context.count} ID(s) #{@resource_name} '#{@name}' were allocated." do
-          @item.allocate_count(@context.pool_type, @context.count)
+        Chef::Log.info "Allocating #{@new_resource.count} ID(s) #{@resource_name} '#{@name}'"
+        @context.converge_by "#{@new_resource.count} ID(s) #{@resource_name} '#{@name}' were allocated." do
+          @item.allocate_count(@new_resource.pool_type, @new_resource.count)
         end
       end
 
       def collect_ids
-        Chef::Log.info "Removing the IDs #{@context.id_list} #{@resource_name} '#{@name}'"
-        @context.converge_by "The IDs #{@context.id_list} #{@resource_name} '#{@name}'were removed." do
-          @item.collect_ids(@context.pool_type, @context.id_list)
+        Chef::Log.info "Removing the IDs #{@new_resource.id_list} #{@resource_name} '#{@name}'"
+        @context.converge_by "The IDs #{@new_resource.id_list} #{@resource_name} '#{@name}'were removed." do
+          @item.collect_ids(@new_resource.pool_type, @new_resource.id_list)
         end
       end
     end

--- a/libraries/resource_providers/api200/id_pool_provider.rb
+++ b/libraries/resource_providers/api200/id_pool_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # IDPool API200 provider

--- a/libraries/resource_providers/api200/interconnect_provider.rb
+++ b/libraries/resource_providers/api200/interconnect_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # Interconnect API200 provider

--- a/libraries/resource_providers/api200/interconnect_provider.rb
+++ b/libraries/resource_providers/api200/interconnect_provider.rb
@@ -14,23 +14,23 @@ module OneviewCookbook
     # Interconnect API200 provider
     class InterconnectProvider < ResourceProvider
       def set_uid_light
-        raise "Unspecified property: 'uid_light_state'. Please set it before attempting this action." unless @context.uid_light_state
+        raise "Unspecified property: 'uid_light_state'. Please set it before attempting this action." unless @new_resource.uid_light_state
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         # Impossible to verify this value programatically
-        @context.converge_by "Set #{@resource_name} '#{@name}' UID light to #{@context.uid_light_state.upcase}" do
-          @item.patch('replace', '/uidState', @context.uid_light_state.capitalize)
+        @context.converge_by "Set #{@resource_name} '#{@name}' UID light to #{@new_resource.uid_light_state.upcase}" do
+          @item.patch('replace', '/uidState', @new_resource.uid_light_state.capitalize)
         end
       end
 
       def set_power_state
-        raise "Unspecified property: 'power_state'. Please set it before attempting this action." unless @context.power_state
+        raise "Unspecified property: 'power_state'. Please set it before attempting this action." unless @new_resource.power_state
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-        if @item['powerState'] != @context.power_state
-          @context.converge_by "Power #{@resource_name} '#{@name}' #{@context.power_state.upcase}" do
-            @item.patch('replace', '/powerState', @context.power_state.capitalize)
+        if @item['powerState'] != @new_resource.power_state
+          @context.converge_by "Power #{@resource_name} '#{@name}' #{@new_resource.power_state.upcase}" do
+            @item.patch('replace', '/powerState', @new_resource.power_state.capitalize)
           end
         else
-          Chef::Log.info("#{@resource_name} '#{@name}' is already powered #{@context.power_state.upcase}")
+          Chef::Log.info("#{@resource_name} '#{@name}' is already powered #{@new_resource.power_state.upcase}")
         end
       end
 
@@ -51,8 +51,8 @@ module OneviewCookbook
       end
 
       def update_port
-        raise "Unspecified property: 'port_options'. Please set it before attempting this action." unless @context.port_options
-        parsed_port_options = convert_keys(@context.port_options, :to_s)
+        raise "Unspecified property: 'port_options'. Please set it before attempting this action." unless @new_resource.port_options
+        parsed_port_options = convert_keys(@new_resource.port_options, :to_s)
         raise "Required value \"name\" for 'port_options' not specified" unless parsed_port_options['name']
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         target_port = (@item['ports'].select { |port| port['name'] == parsed_port_options['name'] }).first

--- a/libraries/resource_providers/api200/logical_enclosure_provider.rb
+++ b/libraries/resource_providers/api200/logical_enclosure_provider.rb
@@ -15,10 +15,10 @@ module OneviewCookbook
     class LogicalEnclosureProvider < ResourceProvider
       # Load the enclosure_group & enclosures properties
       def load_logical_enclosure
-        @item['enclosureGroupUri'] = load_resource(:EnclosureGroup, @context.enclosure_group, 'uri') if @context.enclosure_group
+        @item['enclosureGroupUri'] = load_resource(:EnclosureGroup, @new_resource.enclosure_group, 'uri') if @new_resource.enclosure_group
         @item['enclosureUris'] ||= []
-        return unless @context.enclosures
-        @context.enclosures.each do |e|
+        return unless @new_resource.enclosures
+        @new_resource.enclosures.each do |e|
           data = { name: e, serialNumber: e, activeOaPreferredIP: e, standbyOaPreferredIP: e }
           @item['enclosureUris'].push(load_resource(:Enclosure, data, 'uri'))
         end
@@ -58,13 +58,13 @@ module OneviewCookbook
 
       def set_script
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-        if @item.get_script.eql? @context.script
+        if @item.get_script.eql? @new_resource.script
           Chef::Log.info("#{@resource_name} '#{@name}' script is up to date")
         else
           Chef::Log.info "Updating #{@resource_name} '#{@name}'"
           Chef::Log.debug "#{@resource_name} '#{@name}' Chef resource differs from OneView resource."
           @context.converge_by "Updated script for #{@resource_name} '#{@name}'" do
-            @item.set_script(@context.script)
+            @item.set_script(@new_resource.script)
           end
         end
       end

--- a/libraries/resource_providers/api200/logical_enclosure_provider.rb
+++ b/libraries/resource_providers/api200/logical_enclosure_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # LogicalEnclosure API200 provider

--- a/libraries/resource_providers/api200/logical_interconnect_group_provider.rb
+++ b/libraries/resource_providers/api200/logical_interconnect_group_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # LogicalInterconnectGroup API200 provider

--- a/libraries/resource_providers/api200/logical_interconnect_group_provider.rb
+++ b/libraries/resource_providers/api200/logical_interconnect_group_provider.rb
@@ -14,14 +14,14 @@ module OneviewCookbook
     # LogicalInterconnectGroup API200 provider
     class LogicalInterconnectGroupProvider < ResourceProvider
       def load_interconnects
-        @context.interconnects.each do |location|
+        @new_resource.interconnects.each do |location|
           parsed_location = convert_keys(location, :to_sym)
           @item.add_interconnect(parsed_location[:bay], parsed_location[:type])
         end
       end
 
       def load_uplink_sets
-        @context.uplink_sets.each do |uplink_info|
+        @new_resource.uplink_sets.each do |uplink_info|
           parsed_uplink_info = convert_keys(uplink_info, :to_sym)
           up = resource_named(:LIGUplinkSet).new(@item.client, parsed_uplink_info[:data])
           parsed_uplink_info[:networks].each do |network_name|

--- a/libraries/resource_providers/api200/logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api200/logical_interconnect_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # LogicalInterconnect API200 provider

--- a/libraries/resource_providers/api200/logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api200/logical_interconnect_provider.rb
@@ -14,10 +14,10 @@ module OneviewCookbook
     # LogicalInterconnect API200 provider
     class LogicalInterconnectProvider < ResourceProvider
       def interconnect_handler(present_block, absent_block)
-        raise "Unspecified property: 'bay_number'. Please set it before attempting this action." unless @context.bay_number
-        raise "Unspecified property: 'enclosure'. Please set it before attempting this action." unless @context.enclosure
+        raise "Unspecified property: 'bay_number'. Please set it before attempting this action." unless @new_resource.bay_number
+        raise "Unspecified property: 'enclosure'. Please set it before attempting this action." unless @new_resource.enclosure
         interconnect_list = resource_named(:Interconnect).get_all(@item.client)
-        enclosure_item = load_resource(:Enclosure, @context.enclosure)
+        enclosure_item = load_resource(:Enclosure, @new_resource.enclosure)
         # Procedure to get (bay, enclosure) pairs and interconnect state
         listed_pairs = {}
         interconnect_list.each do |inter|
@@ -26,12 +26,12 @@ module OneviewCookbook
           listed_pairs[[bayn, encn]] = inter['state']
         end
         # Desired (bay, enclosure) interconnect location
-        pair = [@context.bay_number.to_s, enclosure_item['uri']]
+        pair = [@new_resource.bay_number.to_s, enclosure_item['uri']]
         # If an interconnect exists in the location, and its state is not 'Absent', so it is present
         if listed_pairs.keys.include?(pair) && listed_pairs[pair] != 'Absent'
-          present_block.call(@context.bay_number, enclosure_item)
+          present_block.call(@new_resource.bay_number, enclosure_item)
         else
-          absent_block.call(@context.bay_number, enclosure_item)
+          absent_block.call(@new_resource.bay_number, enclosure_item)
         end
       end
 
@@ -65,29 +65,29 @@ module OneviewCookbook
       def firmware_handler(action)
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         current_firmware = @item.get_firmware
-        @context.firmware_data['command'] = action
-        dif_values = @context.firmware_data.reject { |k, v| current_firmware[k] == v }
-        fw_defined = @context.firmware || @context.firmware_data['sppName']
+        @new_resource.firmware_data['command'] = action
+        dif_values = @new_resource.firmware_data.reject { |k, v| current_firmware[k] == v }
+        fw_defined = @new_resource.firmware || @new_resource.firmware_data['sppName']
         raise "Unspecified property: 'firmware'. Please set it before attempting this action." unless fw_defined
-        return Chef::Log.info("Firmware #{@context.firmware} from logical interconnect '#{@name}' is up to date") if dif_values.empty?
-        fd = load_resource(:FirmwareDriver, @context.firmware)
-        raise "Resource not found: Firmware action '#{action}' cannot be performed since the firmware '#{@context.firmware}' was not found." unless fd
-        diff = get_diff(current_firmware, @context.firmware_data)
+        return Chef::Log.info("Firmware #{@new_resource.firmware} from logical interconnect '#{@name}' is up to date") if dif_values.empty?
+        fd = load_resource(:FirmwareDriver, @new_resource.firmware)
+        raise "Resource not found: Action '#{action}' cannot be performed since the firmware '#{@new_resource.firmware}' was not found." unless fd
+        diff = get_diff(current_firmware, @new_resource.firmware_data)
         Chef::Log.info "#{action.to_s.capitalize.tr('_', ' ')} #{@resource_name} '#{@name}'#{diff}"
         Chef::Log.debug "#{@resource_name} '#{@name}' Chef resource firmware options differs from OneView resource."
         Chef::Log.debug "Current state: #{JSON.pretty_generate(current_firmware)}"
-        Chef::Log.debug "Desired state: #{JSON.pretty_generate(@context.firmware_data)}"
-        @context.converge_by "#{action.capitalize} firmware '#{@context.firmware}' from logical interconnect '#{@name}'" do
-          @item.firmware_update(action, fd, @context.firmware_data)
+        Chef::Log.debug "Desired state: #{JSON.pretty_generate(@new_resource.firmware_data)}"
+        @context.converge_by "#{action.capitalize} firmware '#{@new_resource.firmware}' from logical interconnect '#{@name}'" do
+          @item.firmware_update(action, fd, @new_resource.firmware_data)
         end
       end
 
       def add_interconnect
         noaction = proc do
-          Chef::Log.info("Interconnect already created in #{@context.enclosure} at bay #{@context.bay_number}")
+          Chef::Log.info("Interconnect already created in #{@new_resource.enclosure} at bay #{@new_resource.bay_number}")
         end
         do_add = proc do |bay, enc|
-          @context.converge_by "Add interconnect in #{@context.enclosure} at bay #{@context.bay_number}" do
+          @context.converge_by "Add interconnect in #{@new_resource.enclosure} at bay #{@new_resource.bay_number}" do
             @item.create(bay, enc)
           end
         end
@@ -96,26 +96,26 @@ module OneviewCookbook
 
       def remove_interconnect
         do_remove = proc do |bay, enc|
-          @context.converge_by "Remove interconnect in #{@context.enclosure} at bay #{@context.bay_number}" do
+          @context.converge_by "Remove interconnect in #{@new_resource.enclosure} at bay #{@new_resource.bay_number}" do
             @item.delete(bay, enc)
           end
         end
         noaction = proc do
-          Chef::Log.info("Interconnect not present in #{@context.enclosure} at bay #{@context.bay_number}")
+          Chef::Log.info("Interconnect not present in #{@new_resource.enclosure} at bay #{@new_resource.bay_number}")
         end
         interconnect_handler(do_remove, noaction)
       end
 
       def update_internal_networks
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-        @context.internal_networks.collect! { |n| load_resource(:EthernetNetwork, n) }
-        if @item['internalNetworkUris'].sort == @context.internal_networks.collect { |x| x['uri'] }.sort
+        @new_resource.internal_networks.collect! { |n| load_resource(:EthernetNetwork, n) }
+        if @item['internalNetworkUris'].sort == @new_resource.internal_networks.collect { |x| x['uri'] }.sort
           Chef::Log.info("Internal networks for #{@resource_name} #{@name} are up to date")
         else
-          diff = get_diff(@item, 'internalNetworkUris' => @context.internal_networks)
+          diff = get_diff(@item, 'internalNetworkUris' => @new_resource.internal_networks)
           Chef::Log.info "Updating internal networks for #{@resource_name} '#{@name}'#{diff}"
           @context.converge_by("Update internal networks for #{@resource_name} '#{@name}'") do
-            @item.update_internal_networks(*@context.internal_networks)
+            @item.update_internal_networks(*@new_resource.internal_networks)
           end
         end
       end
@@ -141,7 +141,7 @@ module OneviewCookbook
       end
 
       def update_snmp_configuration
-        traps = convert_keys(@context.trap_destinations, :to_s)
+        traps = convert_keys(@new_resource.trap_destinations, :to_s)
         unless @item['snmpConfiguration']['trapDestinations']
           @item['snmpConfiguration']['trapDestinations'] = []
         end

--- a/libraries/resource_providers/api200/logical_switch_group_provider.rb
+++ b/libraries/resource_providers/api200/logical_switch_group_provider.rb
@@ -16,9 +16,9 @@ module OneviewCookbook
       def load_logical_switch_group
         # This will avoid overriding the 'switchMapTemplate' if already specified in data
         return unless @item['switchMapTemplate'].empty?
-        raise "Unspecified property: 'switch_number'. Please set it before attempting this action." unless @context.switch_number
-        raise "Unspecified property: 'switch_type'. Please set it before attempting this action." unless @context.switch_type
-        @item.set_grouping_parameters(@context.switch_number, @context.switch_type)
+        raise "Unspecified property: 'switch_number'. Please set it before attempting this action." unless @new_resource.switch_number
+        raise "Unspecified property: 'switch_type'. Please set it before attempting this action." unless @new_resource.switch_type
+        @item.set_grouping_parameters(@new_resource.switch_number, @new_resource.switch_type)
       end
 
       def create_or_update

--- a/libraries/resource_providers/api200/logical_switch_group_provider.rb
+++ b/libraries/resource_providers/api200/logical_switch_group_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # LogicalSwitchGroup API200 provider

--- a/libraries/resource_providers/api200/logical_switch_provider.rb
+++ b/libraries/resource_providers/api200/logical_switch_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # LogicalSwitch API200 provider

--- a/libraries/resource_providers/api200/logical_switch_provider.rb
+++ b/libraries/resource_providers/api200/logical_switch_provider.rb
@@ -14,17 +14,17 @@ module OneviewCookbook
     # LogicalSwitch API200 provider
     class LogicalSwitchProvider < ResourceProvider
       def load_logical_switch
-        lsg_defined = @context.logical_switch_group || @item['LogicalSwitchGroupUri']
+        lsg_defined = @new_resource.logical_switch_group || @item['LogicalSwitchGroupUri']
         raise "Undefined Property: 'logical_switch_group'. Please set it before attempting this action" unless lsg_defined
         unless @item['LogicalSwitchGroupUri']
-          @item.set_logical_switch_group(load_resource(:LogicalSwitchGroup, @context.logical_switch_group))
+          @item.set_logical_switch_group(load_resource(:LogicalSwitchGroup, @new_resource.logical_switch_group))
         end
         # This will avoid overriding the 'logicalSwitchCredentials' if already specified in data
         return if @item['logicalSwitchCredentials']
         # Check if the credential properties are set
-        raise "Undefined Property: 'credentials'. Please set it before attempting this action" unless @context.credentials
+        raise "Undefined Property: 'credentials'. Please set it before attempting this action" unless @new_resource.credentials
         # Iterate through all the credentials
-        @context.credentials.each do |credential|
+        @new_resource.credentials.each do |credential|
           parsed_credential = convert_keys(credential, :to_sym)
           # Building the SSH Credential
           # This will create the Struct and then associate the pairs in the order required by it

--- a/libraries/resource_providers/api200/managed_san_provider.rb
+++ b/libraries/resource_providers/api200/managed_san_provider.rb
@@ -18,7 +18,7 @@ module OneviewCookbook
         refresh_ready = ['RefreshFailed', 'NotRefreshing', ''].include? @item['refreshState']
         return Chef::Log.info("#{@resource_name} '#{@name}' refresh is already running. State: #{@item['refreshState']}") unless refresh_ready
         @context.converge_by "#{@resource_name} '#{@name}' was refreshed." do
-          @item.set_refresh_state(@context.refresh_state)
+          @item.set_refresh_state(@new_resource.refresh_state)
         end
       end
 

--- a/libraries/resource_providers/api200/managed_san_provider.rb
+++ b/libraries/resource_providers/api200/managed_san_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # ManagedSAN API200 provider

--- a/libraries/resource_providers/api200/network_set_provider.rb
+++ b/libraries/resource_providers/api200/network_set_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # NetworkSet API200 provider

--- a/libraries/resource_providers/api200/network_set_provider.rb
+++ b/libraries/resource_providers/api200/network_set_provider.rb
@@ -14,9 +14,9 @@ module OneviewCookbook
     # NetworkSet API200 provider
     class NetworkSetProvider < ResourceProvider
       def load_resource_with_properties
-        @item.set_native_network(load_resource(:EthernetNetwork, @context.native_network)) if @context.native_network
-        return unless @context.ethernet_network_list
-        @context.ethernet_network_list.each { |net_name| @item.add_ethernet_network(load_resource(:EthernetNetwork, net_name)) }
+        @item.set_native_network(load_resource(:EthernetNetwork, @new_resource.native_network)) if @new_resource.native_network
+        return unless @new_resource.ethernet_network_list
+        @new_resource.ethernet_network_list.each { |net_name| @item.add_ethernet_network(load_resource(:EthernetNetwork, net_name)) }
       end
 
       # It should compare the networkUris regardless of how they are sorted in the array.

--- a/libraries/resource_providers/api200/power_device_provider.rb
+++ b/libraries/resource_providers/api200/power_device_provider.rb
@@ -19,7 +19,7 @@ module OneviewCookbook
         return Chef::Log.info("#{@resource_name} '#{@name}' is up to date") unless power_devices_list.empty?
         Chef::Log.info "Discovering #{@resource_name} '#{@name}'"
         @context.converge_by "Discovered #{@resource_name} '#{@name}'" do
-          pd_klass.discover(@item.client, hostname: @name, username: @context.username, password: @context.password)
+          pd_klass.discover(@item.client, hostname: @name, username: @new_resource.username, password: @new_resource.password)
         end
       end
 

--- a/libraries/resource_providers/api200/power_device_provider.rb
+++ b/libraries/resource_providers/api200/power_device_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # PowerDevice API200 provider

--- a/libraries/resource_providers/api200/rack_provider.rb
+++ b/libraries/resource_providers/api200/rack_provider.rb
@@ -14,22 +14,22 @@ module OneviewCookbook
     # Rack API200 provider
     class RackProvider < ResourceProvider
       def load_mount_item
-        options = convert_keys(@context.mount_options, :to_s)
+        options = convert_keys(@new_resource.mount_options, :to_s)
         load_resource(options['type'], options['name'])
       end
 
       def add_or_edit
         # Prevent the default initialization of the rackMounts property
-        @item.data.delete('rackMounts') if @context.data['rackMounts'].nil? && @item['rackMounts'] == []
+        @item.data.delete('rackMounts') if @new_resource.data['rackMounts'].nil? && @item['rackMounts'] == []
         super
       end
 
       def add_to_rack
-        raise "Unspecified property: 'mount_options'. Please set it before attempting this action." unless @context.mount_options
+        raise "Unspecified property: 'mount_options'. Please set it before attempting this action." unless @new_resource.mount_options
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         mount_item = load_mount_item
         rack_uris = @item['rackMounts'].collect { |i| i['mountUri'] }
-        options = convert_keys(@context.mount_options, :to_s).reject! { |i| ['type', 'name'].include?(i) }
+        options = convert_keys(@new_resource.mount_options, :to_s).reject! { |i| ['type', 'name'].include?(i) }
         if rack_uris.include? mount_item['uri']
           mounted_resource = @item['rackMounts'].find { |i| i['mountUri'] == mount_item['uri'] }
           return Chef::Log.info("Item '#{mount_item['name']}' in '#{@name}' is up to date") unless options.any? { |k, v| v != mounted_resource[k] }
@@ -48,7 +48,7 @@ module OneviewCookbook
       end
 
       def remove_from_rack
-        raise "Unspecified property: 'mount_options'. Please set it before attempting this action." unless @context.mount_options
+        raise "Unspecified property: 'mount_options'. Please set it before attempting this action." unless @new_resource.mount_options
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         mount_item = load_mount_item
         rack_uris = @item['rackMounts'].collect { |i| i['mountUri'] }

--- a/libraries/resource_providers/api200/rack_provider.rb
+++ b/libraries/resource_providers/api200/rack_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # Rack API200 provider

--- a/libraries/resource_providers/api200/san_manager_provider.rb
+++ b/libraries/resource_providers/api200/san_manager_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # SANManager API200 provider

--- a/libraries/resource_providers/api200/server_hardware_provider.rb
+++ b/libraries/resource_providers/api200/server_hardware_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # ServerHardware API200 provider

--- a/libraries/resource_providers/api200/server_hardware_provider.rb
+++ b/libraries/resource_providers/api200/server_hardware_provider.rb
@@ -21,8 +21,8 @@ module OneviewCookbook
       end
 
       def set_power_state
-        raise "Unspecified property: 'power_state'. Please set it before attempting this action." unless @context.power_state
-        ps = @context.power_state.to_s.downcase
+        raise "Unspecified property: 'power_state'. Please set it before attempting this action." unless @new_resource.power_state
+        ps = @new_resource.power_state.to_s.downcase
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         if @item['powerState'].casecmp(ps).zero?
           Chef::Log.info("#{@resource_name} '#{@name}' is already powered #{ps}")
@@ -38,7 +38,7 @@ module OneviewCookbook
         refresh_ready = ['RefreshFailed', 'NotRefreshing', ''].include? @item['refreshState']
         return Chef::Log.info("#{@resource_name} '#{@name}' refresh is already running.") unless refresh_ready
         @context.converge_by "Refresh #{@resource_name} '#{@name}'." do
-          @item.set_refresh_state('RefreshPending', @context.refresh_options)
+          @item.set_refresh_state('RefreshPending', @new_resource.refresh_options)
         end
       end
     end

--- a/libraries/resource_providers/api200/server_hardware_type_provider.rb
+++ b/libraries/resource_providers/api200/server_hardware_type_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # ServerHardwareType API200 provider

--- a/libraries/resource_providers/api200/server_profile_provider.rb
+++ b/libraries/resource_providers/api200/server_profile_provider.rb
@@ -42,21 +42,21 @@ module OneviewCookbook
       include ServerProfileProviderHelpers
       # Loads the Server profile with all the external resources (if needed)
       def load_with_properties
-        set_resource(:ServerHardware, @context.server_hardware, :set_server_hardware)
-        set_resource(:ServerHardwareType, @context.server_hardware_type, :set_server_hardware_type)
-        set_resource(:EnclosureGroup, @context.enclosure_group, :set_enclosure_group)
-        set_resource(:Enclosure, @context.enclosure, :set_enclosure)
-        set_resource(:FirmwareDriver, @context.firmware_driver, :set_firmware_driver)
-        set_connections(:EthernetNetwork, @context.ethernet_network_connections)
-        set_connections(:FCNetwork, @context.fc_network_connections)
-        set_connections(:NetworkSet, @context.network_set_connections)
+        set_resource(:ServerHardware, @new_resource.server_hardware, :set_server_hardware)
+        set_resource(:ServerHardwareType, @new_resource.server_hardware_type, :set_server_hardware_type)
+        set_resource(:EnclosureGroup, @new_resource.enclosure_group, :set_enclosure_group)
+        set_resource(:Enclosure, @new_resource.enclosure, :set_enclosure)
+        set_resource(:FirmwareDriver, @new_resource.firmware_driver, :set_firmware_driver)
+        set_connections(:EthernetNetwork, @new_resource.ethernet_network_connections)
+        set_connections(:FCNetwork, @new_resource.fc_network_connections)
+        set_connections(:NetworkSet, @new_resource.network_set_connections)
       end
 
       # Override create method to allow creation from a template
       def create(method)
-        if @context.server_profile_template
-          template = load_resource(:ServerProfileTemplate, @context.server_profile_template)
-          Chef::Log.info "Using template '#{@context.server_profile_template}' to #{method} #{@resource_name} '#{@name}'"
+        if @new_resource.server_profile_template
+          template = load_resource(:ServerProfileTemplate, @new_resource.server_profile_template)
+          Chef::Log.info "Using template '#{@new_resource.server_profile_template}' to #{method} #{@resource_name} '#{@name}'"
           new_profile_data = template.new_profile(@item['name']).data
           @item.data = new_profile_data.merge(@item.data)
         end

--- a/libraries/resource_providers/api200/server_profile_provider.rb
+++ b/libraries/resource_providers/api200/server_profile_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # Helper module for

--- a/libraries/resource_providers/api200/server_profile_template_provider.rb
+++ b/libraries/resource_providers/api200/server_profile_template_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative 'server_profile_provider' # For the ServerProfileProviderHelpers
-
 module OneviewCookbook
   module API200
     # ServerProfileTemplate API200 provider

--- a/libraries/resource_providers/api200/server_profile_template_provider.rb
+++ b/libraries/resource_providers/api200/server_profile_template_provider.rb
@@ -16,12 +16,12 @@ module OneviewCookbook
       include ServerProfileProviderHelpers
 
       def load_with_properties
-        set_resource(:ServerHardwareType, @context.server_hardware_type, :set_server_hardware_type)
-        set_resource(:EnclosureGroup, @context.enclosure_group, :set_enclosure_group)
-        set_resource(:FirmwareDriver, @context.firmware_driver, :set_firmware_driver)
-        set_connections(:EthernetNetwork, @context.ethernet_network_connections)
-        set_connections(:FCNetwork, @context.fc_network_connections)
-        set_connections(:NetworkSet, @context.network_set_connections)
+        set_resource(:ServerHardwareType, @new_resource.server_hardware_type, :set_server_hardware_type)
+        set_resource(:EnclosureGroup, @new_resource.enclosure_group, :set_enclosure_group)
+        set_resource(:FirmwareDriver, @new_resource.firmware_driver, :set_firmware_driver)
+        set_connections(:EthernetNetwork, @new_resource.ethernet_network_connections)
+        set_connections(:FCNetwork, @new_resource.fc_network_connections)
+        set_connections(:NetworkSet, @new_resource.network_set_connections)
       end
 
       def create_or_update
@@ -35,9 +35,9 @@ module OneviewCookbook
       end
 
       def new_profile
-        raise "Unspecified property: 'profile_name'. Please set it before attempting this action." unless @context.profile_name
+        raise "Unspecified property: 'profile_name'. Please set it before attempting this action." unless @new_resource.profile_name
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-        @item = @item.new_profile(@context.profile_name)
+        @item = @item.new_profile(@new_resource.profile_name)
         create_if_missing
       end
     end

--- a/libraries/resource_providers/api200/storage_pool_provider.rb
+++ b/libraries/resource_providers/api200/storage_pool_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # StoragePool API200 provider

--- a/libraries/resource_providers/api200/storage_pool_provider.rb
+++ b/libraries/resource_providers/api200/storage_pool_provider.rb
@@ -14,11 +14,11 @@ module OneviewCookbook
     # StoragePool API200 provider
     class StoragePoolProvider < ResourceProvider
       def add_if_missing
-        raise "Unspecified property: 'storage_system'. Please set it before attempting this action." unless @context.storage_system
+        raise "Unspecified property: 'storage_system'. Please set it before attempting this action." unless @new_resource.storage_system
         @item['poolName'] ||= @name
         data = {
-          credentials: { ip_hostname: @context.storage_system },
-          name: @context.storage_system
+          credentials: { ip_hostname: @new_resource.storage_system },
+          name: @new_resource.storage_system
         }
         @item.set_storage_system(load_resource(:StorageSystem, data))
         super

--- a/libraries/resource_providers/api200/storage_system_provider.rb
+++ b/libraries/resource_providers/api200/storage_system_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # StorageSystem API200 provider

--- a/libraries/resource_providers/api200/switch_provider.rb
+++ b/libraries/resource_providers/api200/switch_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # Switch API200 provider

--- a/libraries/resource_providers/api200/unmanaged_device_provider.rb
+++ b/libraries/resource_providers/api200/unmanaged_device_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # UnmanagedDevice API200 provider

--- a/libraries/resource_providers/api200/uplink_set_provider.rb
+++ b/libraries/resource_providers/api200/uplink_set_provider.rb
@@ -15,7 +15,7 @@ module OneviewCookbook
     class UplinkSetProvider < ResourceProvider
       # Checks for external resources to be loaded within the @item
       def load_native_network
-        return @item['nativeNetworkUri'] = nil unless @context.native_network
+        return @item['nativeNetworkUri'] = nil unless @new_resource.native_network
         # Retrieves the uplink set type based on the declared networkType parameter
         # Takes either Ethernet (default) or FibreChannel
         network_type = @item['networkType'] == 'Ethernet' ? 'EthernetNetwork' : 'FCNetwork'
@@ -52,10 +52,10 @@ module OneviewCookbook
       # Broken-down method calls
       def load_resource_with_properties
         load_native_network
-        load_networks(@context.networks, :EthernetNetwork)
-        load_networks(@context.fc_networks, :FCNetwork)
-        load_networks(@context.fcoe_networks, :FCoENetwork)
-        @item.set_logical_interconnect(load_resource(:LogicalInterconnect, @context.logical_interconnect)) if @context.logical_interconnect
+        load_networks(@new_resource.networks, :EthernetNetwork)
+        load_networks(@new_resource.fc_networks, :FCNetwork)
+        load_networks(@new_resource.fcoe_networks, :FCoENetwork)
+        @item.set_logical_interconnect(load_resource(:LogicalInterconnect, @new_resource.logical_interconnect)) if @new_resource.logical_interconnect
         load_enclosure
       end
 

--- a/libraries/resource_providers/api200/uplink_set_provider.rb
+++ b/libraries/resource_providers/api200/uplink_set_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # UplinkSet API200 provider

--- a/libraries/resource_providers/api200/user_provider.rb
+++ b/libraries/resource_providers/api200/user_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # User API200 provider

--- a/libraries/resource_providers/api200/volume_provider.rb
+++ b/libraries/resource_providers/api200/volume_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # Volume API200 provider

--- a/libraries/resource_providers/api200/volume_template_provider.rb
+++ b/libraries/resource_providers/api200/volume_template_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../resource_provider'
-
 module OneviewCookbook
   module API200
     # VolumeTemplate API200 provider

--- a/libraries/resource_providers/api200/volume_template_provider.rb
+++ b/libraries/resource_providers/api200/volume_template_provider.rb
@@ -15,14 +15,14 @@ module OneviewCookbook
     class VolumeTemplateProvider < ResourceProvider
       # Loads the VolumeTemplate with all the external resources (if needed)
       def load_resource_with_associated_resources
-        raise "Unspecified property: 'storage_system'. Please set it before attempting this action." unless @context.storage_system
-        raise "Unspecified property: 'storage_pool'. Please set it before attempting this action." unless @context.storage_pool
+        raise "Unspecified property: 'storage_system'. Please set it before attempting this action." unless @new_resource.storage_system
+        raise "Unspecified property: 'storage_pool'. Please set it before attempting this action." unless @new_resource.storage_pool
         @item['provisioning']['capacity'] = @item['provisioning']['capacity'].to_s if @item['provisioning'] && @item['provisioning']['capacity']
         load_storage_system
-        sp = resource_named(:StoragePool).find_by(@item.client, name: @context.storage_pool, storageSystemUri: @item['storageSystemUri']).first
-        raise "Storage Pool '#{@context.storage_pool}' not found for Storage System '#{@context.storage_system}'" unless sp
+        sp = resource_named(:StoragePool).find_by(@item.client, name: @new_resource.storage_pool, storageSystemUri: @item['storageSystemUri']).first
+        raise "Storage Pool '#{@new_resource.storage_pool}' not found for Storage System '#{@new_resource.storage_system}'" unless sp
         @item['provisioning']['storagePoolUri'] = sp['uri']
-        @item.set_snapshot_pool(resource_named(:StoragePool).new(@item.client, name: @context.snapshot_pool)) if @context.snapshot_pool
+        @item.set_snapshot_pool(resource_named(:StoragePool).new(@item.client, name: @new_resource.snapshot_pool)) if @new_resource.snapshot_pool
       end
 
       # Loads Storage System in the given VolumeTemplate resource.
@@ -31,8 +31,8 @@ module OneviewCookbook
       # @return [resource_named(:VolumeTemplate)] VolumeTemplate with Storage System parameters updated
       def load_storage_system
         data = {
-          credentials: { ip_hostname: @context.storage_system },
-          name: @context.storage_system
+          credentials: { ip_hostname: @new_resource.storage_system },
+          name: @new_resource.storage_system
         }
         @item.set_storage_system(load_resource(:StorageSystem, data))
       end

--- a/libraries/resource_providers/api300.rb
+++ b/libraries/resource_providers/api300.rb
@@ -9,6 +9,8 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+require_relative 'api200'
+
 module OneviewCookbook
   # Module for Oneview API 300 Resources
   module API300

--- a/libraries/resource_providers/api300/c7000/connection_template_provider.rb
+++ b/libraries/resource_providers/api300/c7000/connection_template_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/connection_template_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/datacenter_provider.rb
+++ b/libraries/resource_providers/api300/c7000/datacenter_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/datacenter_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/enclosure_group_provider.rb
+++ b/libraries/resource_providers/api300/c7000/enclosure_group_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/enclosure_group_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/enclosure_group_provider.rb
+++ b/libraries/resource_providers/api300/c7000/enclosure_group_provider.rb
@@ -16,9 +16,9 @@ module OneviewCookbook
       class EnclosureGroupProvider < API200::EnclosureGroupProvider
         def load_ligs
           load_lig # Deprecated method
-          return unless @context.logical_interconnect_groups
+          return unless @new_resource.logical_interconnect_groups
           lig_klass = resource_named(:LogicalInterconnectGroup)
-          @context.logical_interconnect_groups.each do |lig|
+          @new_resource.logical_interconnect_groups.each do |lig|
             lig_name = lig.class == Hash ? convert_keys(lig, :to_s)['name'] : lig
             index = lig.class == Hash ? convert_keys(lig, :to_s)['enclosureIndex'] : nil
             @item.add_logical_interconnect_group(lig_klass.new(@item.client, name: lig_name), index)

--- a/libraries/resource_providers/api300/c7000/enclosure_provider.rb
+++ b/libraries/resource_providers/api300/c7000/enclosure_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/enclosure_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/ethernet_network_provider.rb
+++ b/libraries/resource_providers/api300/c7000/ethernet_network_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/ethernet_network_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/event_provider.rb
+++ b/libraries/resource_providers/api300/c7000/event_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/event_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/fc_network_provider.rb
+++ b/libraries/resource_providers/api300/c7000/fc_network_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/fc_network_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/fcoe_network_provider.rb
+++ b/libraries/resource_providers/api300/c7000/fcoe_network_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/fcoe_network_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/firmware_driver_provider.rb
+++ b/libraries/resource_providers/api300/c7000/firmware_driver_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/firmware_driver_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/generic_resource_provider.rb
+++ b/libraries/resource_providers/api300/c7000/generic_resource_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/generic_resource_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/id_pool_provider.rb
+++ b/libraries/resource_providers/api300/c7000/id_pool_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/id_pool_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/interconnect_provider.rb
+++ b/libraries/resource_providers/api300/c7000/interconnect_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/interconnect_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/logical_enclosure_provider.rb
+++ b/libraries/resource_providers/api300/c7000/logical_enclosure_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/logical_enclosure_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/logical_interconnect_group_provider.rb
+++ b/libraries/resource_providers/api300/c7000/logical_interconnect_group_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/logical_interconnect_group_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api300/c7000/logical_interconnect_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/logical_interconnect_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/logical_switch_group_provider.rb
+++ b/libraries/resource_providers/api300/c7000/logical_switch_group_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/logical_switch_group_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/logical_switch_provider.rb
+++ b/libraries/resource_providers/api300/c7000/logical_switch_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/logical_switch_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/managed_san_provider.rb
+++ b/libraries/resource_providers/api300/c7000/managed_san_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/managed_san_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/network_set_provider.rb
+++ b/libraries/resource_providers/api300/c7000/network_set_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/network_set_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/power_device_provider.rb
+++ b/libraries/resource_providers/api300/c7000/power_device_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/power_device_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/rack_provider.rb
+++ b/libraries/resource_providers/api300/c7000/rack_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/rack_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/san_manager_provider.rb
+++ b/libraries/resource_providers/api300/c7000/san_manager_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/san_manager_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/scope_provider.rb
+++ b/libraries/resource_providers/api300/c7000/scope_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../../resource_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/scope_provider.rb
+++ b/libraries/resource_providers/api300/c7000/scope_provider.rb
@@ -17,7 +17,7 @@ module OneviewCookbook
         # Adds or removes resources to a specified scope
         # @note Calls the build_resource_list method to retrieve the resources
         def change_resource_assignments
-          add_or_remove = @context.add.any? || @context.remove.any?
+          add_or_remove = @new_resource.add.any? || @new_resource.remove.any?
           raise "Unspecified properties: 'add' and 'remove'. Please set at least one before attempting this action." unless add_or_remove
           @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
           values_to_add = build_resource_list
@@ -36,7 +36,7 @@ module OneviewCookbook
         # @return [Array] containing the instances of all resources to be added or removed
         def build_resource_list(op = :add)
           retrieved_resources = []
-          context = op == :add ? @context.add : @context.remove
+          context = op == :add ? @new_resource.add : @new_resource.remove
           context.each do |resource_name, values|
             values.each do |value|
               retrieved_resource = load_resource(resource_name, value)

--- a/libraries/resource_providers/api300/c7000/server_hardware_provider.rb
+++ b/libraries/resource_providers/api300/c7000/server_hardware_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/server_hardware_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/server_hardware_type_provider.rb
+++ b/libraries/resource_providers/api300/c7000/server_hardware_type_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/server_hardware_type_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/server_profile_provider.rb
+++ b/libraries/resource_providers/api300/c7000/server_profile_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/server_profile_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/server_profile_template_provider.rb
+++ b/libraries/resource_providers/api300/c7000/server_profile_template_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/server_profile_template_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/storage_pool_provider.rb
+++ b/libraries/resource_providers/api300/c7000/storage_pool_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/storage_pool_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/storage_system_provider.rb
+++ b/libraries/resource_providers/api300/c7000/storage_system_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/storage_system_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/switch_provider.rb
+++ b/libraries/resource_providers/api300/c7000/switch_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/switch_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/switch_provider.rb
+++ b/libraries/resource_providers/api300/c7000/switch_provider.rb
@@ -19,15 +19,15 @@ module OneviewCookbook
         # Change the scopeUris of the server   |  replace    |  /scopeUris  |  a list of scopeUris
         # Remove one scopeUri from the server  |  remove     |  /scopeUris/[0-#index_of_scopes_on_current_server]
         def patch
-          invalid_param = @context.operation.nil? || @context.path.nil?
+          invalid_param = @new_resource.operation.nil? || @new_resource.path.nil?
           raise "InvalidParameters: Parameters 'operation' and 'path' must be set for patch" if invalid_param
           # TODO: Add support to Scopes (Currently not supported by oneview-sdk gem 3.1.0)
           @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-          @context.converge_by "Performing '#{@context.operation}' at #{@context.path} with #{@context.value} in #{@resource_name} '#{@name}'" do
-            body = if @context.value
-                     { op: @context.operation, path: @context.path, value: @context.value }
+          @context.converge_by "Performing '#{@new_resource.operation}' at #{@new_resource.path} with #{@new_resource.value} in #{@resource_name} '#{@name}'" do
+            body = if @new_resource.value
+                     { op: @new_resource.operation, path: @new_resource.path, value: @new_resource.value }
                    else
-                     { op: @context.operation, path: @context.path }
+                     { op: @new_resource.operation, path: @new_resource.path }
                    end
             response = @item.client.rest_patch(@item['uri'], { 'body' => [body] }, @sdk_api_version)
             @item.client.response_handler(response)

--- a/libraries/resource_providers/api300/c7000/unmanaged_device_provider.rb
+++ b/libraries/resource_providers/api300/c7000/unmanaged_device_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/unmanaged_device_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/uplink_set_provider.rb
+++ b/libraries/resource_providers/api300/c7000/uplink_set_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/uplink_set_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/user_provider.rb
+++ b/libraries/resource_providers/api300/c7000/user_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/user_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/volume_provider.rb
+++ b/libraries/resource_providers/api300/c7000/volume_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/volume_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/c7000/volume_template_provider.rb
+++ b/libraries/resource_providers/api300/c7000/volume_template_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/volume_template_provider'
-
 module OneviewCookbook
   module API300
     module C7000

--- a/libraries/resource_providers/api300/synergy.rb
+++ b/libraries/resource_providers/api300/synergy.rb
@@ -9,6 +9,8 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+require_relative 'c7000'
+
 module OneviewCookbook
   module API300
     # Module for API300 Synergy

--- a/libraries/resource_providers/api300/synergy/connection_template_provider.rb
+++ b/libraries/resource_providers/api300/synergy/connection_template_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/connection_template_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/datacenter_provider.rb
+++ b/libraries/resource_providers/api300/synergy/datacenter_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/datacenter_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/drive_enclosure_provider.rb
+++ b/libraries/resource_providers/api300/synergy/drive_enclosure_provider.rb
@@ -9,6 +9,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+# Improve it with a Mixin
 require_relative 'sas_interconnect_provider'
 
 module OneviewCookbook

--- a/libraries/resource_providers/api300/synergy/enclosure_group_provider.rb
+++ b/libraries/resource_providers/api300/synergy/enclosure_group_provider.rb
@@ -16,10 +16,10 @@ module OneviewCookbook
       class EnclosureGroupProvider < API200::EnclosureGroupProvider
         def load_ligs
           load_lig # Deprecated method
-          return unless @context.logical_interconnect_groups
+          return unless @new_resource.logical_interconnect_groups
           lig_klass = resource_named(:LogicalInterconnectGroup)
           sas_lig_klass = resource_named(:SASLogicalInterconnectGroup)
-          @context.logical_interconnect_groups.each do |lig|
+          @new_resource.logical_interconnect_groups.each do |lig|
             lig_name = lig.class == Hash ? convert_keys(lig, :to_s)['name'] : lig
             index = lig.class == Hash ? convert_keys(lig, :to_s)['enclosureIndex'] : nil
             begin

--- a/libraries/resource_providers/api300/synergy/enclosure_group_provider.rb
+++ b/libraries/resource_providers/api300/synergy/enclosure_group_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/enclosure_group_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/enclosure_provider.rb
+++ b/libraries/resource_providers/api300/synergy/enclosure_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/enclosure_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/ethernet_network_provider.rb
+++ b/libraries/resource_providers/api300/synergy/ethernet_network_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/ethernet_network_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/event_provider.rb
+++ b/libraries/resource_providers/api300/synergy/event_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/event_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/fabric_provider.rb
+++ b/libraries/resource_providers/api300/synergy/fabric_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../../resource_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/fabric_provider.rb
+++ b/libraries/resource_providers/api300/synergy/fabric_provider.rb
@@ -16,7 +16,7 @@ module OneviewCookbook
       class FabricProvider < ResourceProvider
         def set_reserved_vlan_range
           @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-          options = { 'reservedVlanRange' => convert_keys(@context.reserved_vlan_range, :to_s) }
+          options = { 'reservedVlanRange' => convert_keys(@new_resource.reserved_vlan_range, :to_s) }
           options['reservedVlanRange']['type'] ||= 'vlan-pool'
           if @item.like? options
             Chef::Log.info("#{resource_name} '#{name}' reserved Vlan range is up to date")

--- a/libraries/resource_providers/api300/synergy/fc_network_provider.rb
+++ b/libraries/resource_providers/api300/synergy/fc_network_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/fc_network_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/fcoe_network_provider.rb
+++ b/libraries/resource_providers/api300/synergy/fcoe_network_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/fcoe_network_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/firmware_driver_provider.rb
+++ b/libraries/resource_providers/api300/synergy/firmware_driver_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/firmware_driver_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/generic_resource_provider.rb
+++ b/libraries/resource_providers/api300/synergy/generic_resource_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/generic_resource_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/id_pool_provider.rb
+++ b/libraries/resource_providers/api300/synergy/id_pool_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/id_pool_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/interconnect_provider.rb
+++ b/libraries/resource_providers/api300/synergy/interconnect_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/interconnect_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/logical_enclosure_provider.rb
+++ b/libraries/resource_providers/api300/synergy/logical_enclosure_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/logical_enclosure_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/logical_interconnect_group_provider.rb
+++ b/libraries/resource_providers/api300/synergy/logical_interconnect_group_provider.rb
@@ -15,7 +15,7 @@ module OneviewCookbook
       # LogicalInterconnectGroup API300 Synergy resource provider methods
       class LogicalInterconnectGroupProvider < API200::LogicalInterconnectGroupProvider
         def load_interconnects
-          @context.interconnects.each do |location|
+          @new_resource.interconnects.each do |location|
             parsed_location = convert_keys(location, :to_sym)
             @item.add_interconnect(
               parsed_location[:bay],

--- a/libraries/resource_providers/api300/synergy/logical_interconnect_group_provider.rb
+++ b/libraries/resource_providers/api300/synergy/logical_interconnect_group_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/logical_interconnect_group_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api300/synergy/logical_interconnect_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/logical_interconnect_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/managed_san_provider.rb
+++ b/libraries/resource_providers/api300/synergy/managed_san_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/managed_san_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/network_set_provider.rb
+++ b/libraries/resource_providers/api300/synergy/network_set_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/network_set_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/power_device_provider.rb
+++ b/libraries/resource_providers/api300/synergy/power_device_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/power_device_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/rack_provider.rb
+++ b/libraries/resource_providers/api300/synergy/rack_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/rack_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/san_manager_provider.rb
+++ b/libraries/resource_providers/api300/synergy/san_manager_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/san_manager_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/sas_interconnect_provider.rb
+++ b/libraries/resource_providers/api300/synergy/sas_interconnect_provider.rb
@@ -29,7 +29,7 @@ module OneviewCookbook
           refresh_ready = ['RefreshFailed', 'NotRefreshing', ''].include? @item['refreshState']
           return Chef::Log.info("#{@resource_name} '#{@name}' refresh is already running. State: #{@item['refreshState']}") unless refresh_ready
           @context.converge_by "#{@resource_name} '#{@name}' was refreshed." do
-            @item.set_refresh_state(@context.refresh_state)
+            @item.set_refresh_state(@new_resource.refresh_state)
           end
         end
 

--- a/libraries/resource_providers/api300/synergy/sas_interconnect_provider.rb
+++ b/libraries/resource_providers/api300/synergy/sas_interconnect_provider.rb
@@ -9,7 +9,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative 'Interconnect_provider'
+require_relative 'interconnect_provider'
 
 module OneviewCookbook
   module API300

--- a/libraries/resource_providers/api300/synergy/sas_interconnect_provider.rb
+++ b/libraries/resource_providers/api300/synergy/sas_interconnect_provider.rb
@@ -9,7 +9,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative 'interconnect_provider'
+require_relative 'Interconnect_provider'
 
 module OneviewCookbook
   module API300

--- a/libraries/resource_providers/api300/synergy/sas_logical_interconnect_group_provider.rb
+++ b/libraries/resource_providers/api300/synergy/sas_logical_interconnect_group_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/logical_interconnect_group_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/sas_logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api300/synergy/sas_logical_interconnect_provider.rb
@@ -24,9 +24,9 @@ module OneviewCookbook
         end
 
         def replace_drive_enclosure
-          old_sn = @item.data.delete('oldSerialNumber') || get_serial_number(@context.old_drive_enclosure)
+          old_sn = @item.data.delete('oldSerialNumber') || get_serial_number(@new_resource.old_drive_enclosure)
           raise 'InvalidParameters: Old drive enclosure name or serial number must be set and should be valid' unless old_sn
-          new_sn = @item.data.delete('newSerialNumber') || get_serial_number(@context.new_drive_enclosure)
+          new_sn = @item.data.delete('newSerialNumber') || get_serial_number(@new_resource.new_drive_enclosure)
           raise 'InvalidParameters: New drive enclosure name or serial number must be set and should be valid' unless new_sn
           @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
           @context.converge_by "Replacing drive enclosure '#{old_sn}' by '#{new_sn}'" do

--- a/libraries/resource_providers/api300/synergy/sas_logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api300/synergy/sas_logical_interconnect_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/logical_interconnect_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/scope_provider.rb
+++ b/libraries/resource_providers/api300/synergy/scope_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../c7000/scope_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/server_hardware_provider.rb
+++ b/libraries/resource_providers/api300/synergy/server_hardware_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../c7000/server_hardware_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/server_hardware_type_provider.rb
+++ b/libraries/resource_providers/api300/synergy/server_hardware_type_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/server_hardware_type_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/server_profile_provider.rb
+++ b/libraries/resource_providers/api300/synergy/server_profile_provider.rb
@@ -23,7 +23,7 @@ module OneviewCookbook
 
         def load_os_deployment_plan
           # Return if the property is not defined
-          return unless @context.os_deployment_plan
+          return unless @new_resource.os_deployment_plan
           @item['osDeploymentSettings'] ||= {}
           # Return if the value is already defined in data
           if @item['osDeploymentSettings']['osDeploymentPlanUri']
@@ -33,7 +33,7 @@ module OneviewCookbook
           # Get the user specified custom attributes
           custom = @item['osDeploymentSettings']['customAttributes'] || @item['osDeploymentSettings']['osCustomAttributes']
           # Loads the OS deployment plan and gets the default custom attributes
-          plan = load_resource(:OSDeploymentPlan, @context.os_deployment_plan)
+          plan = load_resource(:OSDeploymentPlan, @new_resource.os_deployment_plan)
           plan_defaults = plan['additionalParameters']
           # Merge both user defined and default custom attributes
           custom = custom_merge(plan_defaults, custom)

--- a/libraries/resource_providers/api300/synergy/server_profile_provider.rb
+++ b/libraries/resource_providers/api300/synergy/server_profile_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/server_profile_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/server_profile_template_provider.rb
+++ b/libraries/resource_providers/api300/synergy/server_profile_template_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/server_profile_template_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/storage_pool_provider.rb
+++ b/libraries/resource_providers/api300/synergy/storage_pool_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/storage_pool_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/storage_system_provider.rb
+++ b/libraries/resource_providers/api300/synergy/storage_system_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/storage_system_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/unmanaged_device_provider.rb
+++ b/libraries/resource_providers/api300/synergy/unmanaged_device_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/unmanaged_device_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/uplink_set_provider.rb
+++ b/libraries/resource_providers/api300/synergy/uplink_set_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/uplink_set_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/user_provider.rb
+++ b/libraries/resource_providers/api300/synergy/user_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/user_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/volume_provider.rb
+++ b/libraries/resource_providers/api300/synergy/volume_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/volume_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api300/synergy/volume_template_provider.rb
+++ b/libraries/resource_providers/api300/synergy/volume_template_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api200/volume_template_provider'
-
 module OneviewCookbook
   module API300
     module Synergy

--- a/libraries/resource_providers/api500.rb
+++ b/libraries/resource_providers/api500.rb
@@ -9,6 +9,8 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+require_relative 'api300'
+
 module OneviewCookbook
   # Module for Oneview API 500 Resources
   module API500

--- a/libraries/resource_providers/api500/c7000/datacenter_provider.rb
+++ b/libraries/resource_providers/api500/c7000/datacenter_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/c7000/datacenter_provider'
-
 module OneviewCookbook
   module API500
     module C7000

--- a/libraries/resource_providers/api500/c7000/rack_provider.rb
+++ b/libraries/resource_providers/api500/c7000/rack_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/c7000/rack_provider'
-
 module OneviewCookbook
   module API500
     module C7000

--- a/libraries/resource_providers/api500/c7000/san_manager_provider.rb
+++ b/libraries/resource_providers/api500/c7000/san_manager_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/c7000/san_manager_provider'
-
 module OneviewCookbook
   module API500
     module C7000

--- a/libraries/resource_providers/api500/c7000/scope_provider.rb
+++ b/libraries/resource_providers/api500/c7000/scope_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/c7000/scope_provider'
-
 module OneviewCookbook
   module API500
     module C7000

--- a/libraries/resource_providers/api500/c7000/unmanaged_device_provider.rb
+++ b/libraries/resource_providers/api500/c7000/unmanaged_device_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/c7000/unmanaged_device_provider'
-
 module OneviewCookbook
   module API500
     module C7000

--- a/libraries/resource_providers/api500/synergy.rb
+++ b/libraries/resource_providers/api500/synergy.rb
@@ -9,6 +9,8 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+require_relative 'c7000'
+
 module OneviewCookbook
   module API500
     # Module for API500 Synergy

--- a/libraries/resource_providers/api500/synergy/datacenter_provider.rb
+++ b/libraries/resource_providers/api500/synergy/datacenter_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/synergy/datacenter_provider'
-
 module OneviewCookbook
   module API500
     module Synergy

--- a/libraries/resource_providers/api500/synergy/rack_provider.rb
+++ b/libraries/resource_providers/api500/synergy/rack_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/synergy/rack_provider'
-
 module OneviewCookbook
   module API500
     module Synergy

--- a/libraries/resource_providers/api500/synergy/san_manager_provider.rb
+++ b/libraries/resource_providers/api500/synergy/san_manager_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/synergy/san_manager_provider'
-
 module OneviewCookbook
   module API500
     module Synergy

--- a/libraries/resource_providers/api500/synergy/scope_provider.rb
+++ b/libraries/resource_providers/api500/synergy/scope_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/synergy/scope_provider'
-
 module OneviewCookbook
   module API500
     module Synergy

--- a/libraries/resource_providers/api500/synergy/unmanaged_device_provider.rb
+++ b/libraries/resource_providers/api500/synergy/unmanaged_device_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/synergy/unmanaged_device_provider'
-
 module OneviewCookbook
   module API500
     module Synergy

--- a/libraries/resource_providers/image_streamer/api300/artifact_bundle_provider.rb
+++ b/libraries/resource_providers/image_streamer/api300/artifact_bundle_provider.rb
@@ -28,39 +28,39 @@ module OneviewCookbook
         end
 
         def create_if_missing
-          load_expected_resources(:BuildPlan, @context.os_build_plans)
-          load_expected_resources(:DeploymentPlan, @context.deployment_plans)
-          load_expected_resources(:GoldenImage, @context.golden_images)
-          load_expected_resources(:PlanScript, @context.plan_scripts)
+          load_expected_resources(:BuildPlan, @new_resource.os_build_plans)
+          load_expected_resources(:DeploymentPlan, @new_resource.deployment_plans)
+          load_expected_resources(:GoldenImage, @new_resource.golden_images)
+          load_expected_resources(:PlanScript, @new_resource.plan_scripts)
           super
         end
 
         def update_name
-          raise 'This action requires the new_name field to be specified.' unless @context.new_name
+          raise 'This action requires the new_name field to be specified.' unless @new_resource.new_name
           @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-          return Chef::Log.info("#{@resource_name} '#{@name}' is up to date") if @item['name'] == @context.new_name
-          new_name_in_use = resource_named(:ArtifactBundle).new(@item.client, name: @context.new_name).exists?
-          raise "ArtifactBundle name '#{@context.new_name}' is already in use." if new_name_in_use
-          Chef::Log.debug "New name #{@context.new_name} differs from current name'#{@name}' for resource."
-          @context.converge_by "Update #{@resource_name}'s name from '#{@name}' to #{@context.new_name} completed successfully" do
-            @item.update_name(@context.new_name)
+          return Chef::Log.info("#{@resource_name} '#{@name}' is up to date") if @item['name'] == @new_resource.new_name
+          new_name_in_use = resource_named(:ArtifactBundle).new(@item.client, name: @new_resource.new_name).exists?
+          raise "ArtifactBundle name '#{@new_resource.new_name}' is already in use." if new_name_in_use
+          Chef::Log.debug "New name #{@new_resource.new_name} differs from current name'#{@name}' for resource."
+          @context.converge_by "Update #{@resource_name}'s name from '#{@name}' to #{@new_resource.new_name} completed successfully" do
+            @item.update_name(@new_resource.new_name)
           end
         end
 
         def download
-          raise "#{@resource_name} #{@context.file_path} must be specified for this action" unless @context.file_path
+          raise "#{@resource_name} #{@new_resource.file_path} must be specified for this action" unless @new_resource.file_path
           @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-          return Chef::Log.info("#{@resource_name} '#{@name}' file already exists in specified location.") if File.file?(@context.file_path)
-          @context.converge_by "Download #{@resource_name}'s '#{@name}' to #{@context.file_path} completed successfully" do
-            @item.download(@context.file_path)
+          return Chef::Log.info("#{@resource_name} '#{@name}' file already exists in specified location.") if File.file?(@new_resource.file_path)
+          @context.converge_by "Download #{@resource_name}'s '#{@name}' to #{@new_resource.file_path} completed successfully" do
+            @item.download(@new_resource.file_path)
           end
         end
 
         def upload
-          raise "'#{@context.file_path}' file does not exist." unless File.file?(@context.file_path)
+          raise "'#{@new_resource.file_path}' file does not exist." unless File.file?(@new_resource.file_path)
           return Chef::Log.info("#{@resource_name} #{@name} already exists in the appliance.") if @item.exists?
           @context.converge_by "Upload of #{@resource_name}'s '#{@name}' completed successfully" do
-            @item.class.create_from_file(@item.client, @context.file_path, @name)
+            @item.class.create_from_file(@item.client, @new_resource.file_path, @name)
           end
         end
 
@@ -80,24 +80,24 @@ module OneviewCookbook
         end
 
         def backup_from_file
-          raise "#{@resource_name} #{@context.file_path} must be specified for this action" unless @context.file_path
-          raise "'#{@context.file_path}' file does not exist." unless File.file?(@context.file_path)
-          raise 'A deployment_group field is required for this action.' unless @context.deployment_group
-          deployment_group = load_resource(:DeploymentGroup, @context.deployment_group)
-          Chef::Log.info("Starting upload of backup file #{@context.file_path}...")
-          @context.converge_by "Upload of backup file '#{@context.file_path}' completed successfully" do
-            return @item.class.create_backup_from_file!(@item.client, deployment_group, @context.file_path, @name) unless @context.timeout
-            return @item.class.create_backup_from_file!(@item.client, deployment_group, @context.file_path, @name, @context.timeout)
+          raise "#{@resource_name} #{@new_resource.file_path} must be specified for this action" unless @new_resource.file_path
+          raise "'#{@new_resource.file_path}' file does not exist." unless File.file?(@new_resource.file_path)
+          raise 'A deployment_group field is required for this action.' unless @new_resource.deployment_group
+          deployment_group = load_resource(:DeploymentGroup, @new_resource.deployment_group)
+          Chef::Log.info("Starting upload of backup file #{@new_resource.file_path}...")
+          @context.converge_by "Upload of backup file '#{@new_resource.file_path}' completed successfully" do
+            return @item.class.create_backup_from_file!(@item.client, deployment_group, @new_resource.file_path, @name) unless @new_resource.timeout
+            return @item.class.create_backup_from_file!(@item.client, deployment_group, @new_resource.file_path, @name, @new_resource.timeout)
           end
         end
 
         def download_backup
-          raise "#{@resource_name} #{@context.file_path} must be specified for this action" unless @context.file_path
-          return Chef::Log.info("File '#{@context.file_path}' already exists in specified location.") if File.file?(@context.file_path)
+          raise "#{@resource_name} #{@new_resource.file_path} must be specified for this action" unless @new_resource.file_path
+          return Chef::Log.info("File '#{@new_resource.file_path}' already exists in specified location.") if File.file?(@new_resource.file_path)
           backup = @item.class.get_backups(@item.client).first
           raise 'There are no backups present in the appliance. Cannot run download_backup action.' unless backup
-          @context.converge_by "Downloading appliance backup image to '#{@context.file_path}' completed successfully" do
-            @item.class.download_backup(@item.client, @context.file_path, backup)
+          @context.converge_by "Downloading appliance backup image to '#{@new_resource.file_path}' completed successfully" do
+            @item.class.download_backup(@item.client, @new_resource.file_path, backup)
           end
         end
 

--- a/libraries/resource_providers/image_streamer/api300/artifact_bundle_provider.rb
+++ b/libraries/resource_providers/image_streamer/api300/artifact_bundle_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../../resource_provider'
-
 module OneviewCookbook
   module ImageStreamer
     module API300

--- a/libraries/resource_providers/image_streamer/api300/deployment_plan_provider.rb
+++ b/libraries/resource_providers/image_streamer/api300/deployment_plan_provider.rb
@@ -15,14 +15,14 @@ module OneviewCookbook
       # DeploymentPlan Provider resource methods
       class DeploymentPlanProvider < ResourceProvider
         def create_or_update
-          @item['goldenImageURI'] ||= load_resource(:GoldenImage, @context.golden_image, :uri)
-          @item['oeBuildPlanURI'] ||= load_resource(:BuildPlan, @context.os_build_plan, :uri)
+          @item['goldenImageURI'] ||= load_resource(:GoldenImage, @new_resource.golden_image, :uri)
+          @item['oeBuildPlanURI'] ||= load_resource(:BuildPlan, @new_resource.os_build_plan, :uri)
           super
         end
 
         def create_if_missing
-          @item['goldenImageURI'] ||= load_resource(:GoldenImage, @context.golden_image, :uri)
-          @item['oeBuildPlanURI'] ||= load_resource(:BuildPlan, @context.os_build_plan, :uri)
+          @item['goldenImageURI'] ||= load_resource(:GoldenImage, @new_resource.golden_image, :uri)
+          @item['oeBuildPlanURI'] ||= load_resource(:BuildPlan, @new_resource.os_build_plan, :uri)
           super
         end
       end

--- a/libraries/resource_providers/image_streamer/api300/deployment_plan_provider.rb
+++ b/libraries/resource_providers/image_streamer/api300/deployment_plan_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../../resource_provider'
-
 module OneviewCookbook
   module ImageStreamer
     module API300

--- a/libraries/resource_providers/image_streamer/api300/golden_image_provider.rb
+++ b/libraries/resource_providers/image_streamer/api300/golden_image_provider.rb
@@ -15,8 +15,8 @@ module OneviewCookbook
       # PlanScript Provider resource methods
       class GoldenImageProvider < ResourceProvider
         def load_resources
-          @item.set_os_volume(resource_named(:OSVolume).new(@item.client, name: @context.os_volume)) if @context.os_volume
-          @item.set_build_plan(resource_named(:BuildPlan).new(@item.client, name: @context.os_build_plan)) if @context.os_build_plan
+          @item.set_os_volume(resource_named(:OSVolume).new(@item.client, name: @new_resource.os_volume)) if @new_resource.os_volume
+          @item.set_build_plan(resource_named(:BuildPlan).new(@item.client, name: @new_resource.os_build_plan)) if @new_resource.os_build_plan
         end
 
         def create_or_update
@@ -30,36 +30,36 @@ module OneviewCookbook
         end
 
         def upload_if_missing
-          raise 'InvalidFilePath: The file_path was not specified. Please set it and try again' unless @context.file_path
-          raise "InvalidFilePath: Could not find the file '#{@context.file_path}'" unless File.exist?(@context.file_path)
+          raise 'InvalidFilePath: The file_path was not specified. Please set it and try again' unless @new_resource.file_path
+          raise "InvalidFilePath: Could not find the file '#{@new_resource.file_path}'" unless File.exist?(@new_resource.file_path)
           return Chef::Log.info("#{@resource_type} '#{@name}' already exist") if @item.exists?
-          connection_timeout = @context.timeout || resource_named(:GoldenImage)::READ_TIMEOUT
-          Chef::Log.info("Uploading #{@resource_type} '#{@name}' from '#{@context.file_path}'. Timeout is #{connection_timeout} seconds")
-          @context.converge_by("Upload #{@resource_type} '#{@name}' from '#{@context.file_path}'") do
-            resource_named(:GoldenImage).add(@item.client, @context.file_path, @item.data, connection_timeout)
+          connection_timeout = @new_resource.timeout || resource_named(:GoldenImage)::READ_TIMEOUT
+          Chef::Log.info("Uploading #{@resource_type} '#{@name}' from '#{@new_resource.file_path}'. Timeout is #{connection_timeout} seconds")
+          @context.converge_by("Upload #{@resource_type} '#{@name}' from '#{@new_resource.file_path}'") do
+            resource_named(:GoldenImage).add(@item.client, @new_resource.file_path, @item.data, connection_timeout)
           end
         end
 
         def download_validation
-          raise 'InvalidFilePath: The file_path was not specified. Please set it and try again' unless @context.file_path
-          return Chef::Log.info("#{@resource_type} '#{@name}' file '#{@context.file_path}' already exist") if File.exist?(@context.file_path)
+          raise 'InvalidFilePath: The file_path was not specified. Please set it and try again' unless @new_resource.file_path
+          return Chef::Log.info("#{@resource_type} '#{@name}' file '#{@new_resource.file_path}' already exist") if File.exist?(@new_resource.file_path)
           @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         end
 
         def download
           download_validation
-          connection_timeout = @context.timeout || resource_named(:GoldenImage)::READ_TIMEOUT
-          Chef::Log.info("Downloading #{@resource_type} '#{@name}' to '#{@context.file_path}'. Timeout is #{connection_timeout} seconds")
-          @context.converge_by("Download #{@resource_type} '#{@name}' to '#{@context.file_path}'") do
-            @item.download(@context.file_path, connection_timeout)
+          connection_timeout = @new_resource.timeout || resource_named(:GoldenImage)::READ_TIMEOUT
+          Chef::Log.info("Downloading #{@resource_type} '#{@name}' to '#{@new_resource.file_path}'. Timeout is #{connection_timeout} seconds")
+          @context.converge_by("Download #{@resource_type} '#{@name}' to '#{@new_resource.file_path}'") do
+            @item.download(@new_resource.file_path, connection_timeout)
           end
         end
 
         def download_details_archive
           download_validation
-          Chef::Log.info("Downloading' #{@resource_type} '#{@name}' details to '#{@context.file_path}'")
-          @context.converge_by("Download' #{@resource_type} '#{@name}' details to '#{@context.file_path}'") do
-            @item.download_details_archive(@context.file_path)
+          Chef::Log.info("Downloading' #{@resource_type} '#{@name}' details to '#{@new_resource.file_path}'")
+          @context.converge_by("Download' #{@resource_type} '#{@name}' details to '#{@new_resource.file_path}'") do
+            @item.download_details_archive(@new_resource.file_path)
           end
         end
       end

--- a/libraries/resource_providers/image_streamer/api300/golden_image_provider.rb
+++ b/libraries/resource_providers/image_streamer/api300/golden_image_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../../resource_provider'
-
 module OneviewCookbook
   module ImageStreamer
     module API300

--- a/libraries/resource_providers/image_streamer/api300/os_build_plan_provider.rb
+++ b/libraries/resource_providers/image_streamer/api300/os_build_plan_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../../resource_provider'
-
 module OneviewCookbook
   module ImageStreamer
     module API300

--- a/libraries/resource_providers/image_streamer/api300/plan_script_provider.rb
+++ b/libraries/resource_providers/image_streamer/api300/plan_script_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../../resource_provider'
-
 module OneviewCookbook
   module ImageStreamer
     module API300

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ license          'Apache-2.0'
 description      'Provides HPE OneView & Image Streamer resources'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version          '2.3.0'
+version          '3.0.0'
 
 source_url       'https://github.com/HewlettPackard/oneview-chef' if respond_to?(:source_url)
 issues_url       'https://github.com/HewlettPackard/oneview-chef/issues' if respond_to?(:issues_url)

--- a/spec/fixtures/fake_resource.rb
+++ b/spec/fixtures/fake_resource.rb
@@ -5,6 +5,7 @@ require 'chef/node'
 class FakeResource
   attr_accessor \
     :resource_name,
+    :new_resource,
     :api_version,
     :api_variant,
     :api_header_version,
@@ -25,6 +26,7 @@ class FakeResource
     @client = opts[:client] if opts[:client]
     @data = opts[:data] || {}
     @save_resource_info = opts[:save_resource_info] || ['uri']
+    @new_resource = self
   end
 
   def property_is_set?(property)


### PR DESCRIPTION
### Description
Supports new Chef 13, removing deprecations and warnings.

It also fixes some bugs that were found with different platforms and newer ruby versions (Since Chef 13 requires ruby 2.4+)

### Issues Resolved
Fixes #247
Fixes #284 
Fixes #287

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [ ] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
