### PR TITLE
Adds safe_dup to operate with Chef 13 ImmutableArrays

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,8 +6,15 @@ AllCops:
     - 'examples/*'
     - 'bin/*'
 
+######### RUBY 2.4 ###########
+
+Style/SafeNavigation:
+  Enabled: false
+
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+##############################
 
 Layout/EndOfLine:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ Enhancements:
 - [#247](https://github.com/HewlettPackard/oneview-chef/issues/247) Remove deprecation and warnings for Chef 13
 
 Bug fixes:
-- [#284](https://github.com/HewlettPackard/oneview-chef/issues/284) Nested and cyclic requires are causing the first resource to be skipped.
-- [#287](https://github.com/HewlettPackard/oneview-chef/issues/287) Disable FrozenString magic comment cop from Rubocop until the support is done.
+- [#284](https://github.com/HewlettPackard/oneview-chef/issues/284) Nested and cyclic requires are causing the first resource to be skipped
+- [#287](https://github.com/HewlettPackard/oneview-chef/issues/287) Disable FrozenString magic comment cop from Rubocop until the support is done
+- [#243](https://github.com/HewlettPackard/oneview-chef/issues/243) Chef-client 13.2.20 does not allow modification of property :save_resource_info
 
 ## 2.3.0
 Adds support to the following HPE OneView resources:

--- a/libraries/oneview_resource_base.rb
+++ b/libraries/oneview_resource_base.rb
@@ -27,8 +27,9 @@ module OneviewCookbook
     end
 
     def self.safe_dup(object)
-      return object if object.class <= Integer || object.class <= TrueClass || object.class <= FalseClass
       object.dup
+    rescue TypeError
+      object
     end
   end
 end

--- a/spec/unit/libraries/oneview_resource_base_spec.rb
+++ b/spec/unit/libraries/oneview_resource_base_spec.rb
@@ -68,4 +68,16 @@ RSpec.describe OneviewCookbook::ResourceBaseProperties do
       described_class.load(@context)
     end
   end
+
+  describe 'self.safe_dup' do
+    it 'dups a dupable object correctly' do
+      dupable = "dupable".freeze
+      expect(described_class.safe_dup(dupable)).to_not be dupable
+    end
+
+    it 'returns the same object if not dupable' do
+      not_dupable = 1
+      expect(described_class.safe_dup(not_dupable)).to be not_dupable
+    end
+  end
 end

--- a/spec/unit/libraries/oneview_resource_base_spec.rb
+++ b/spec/unit/libraries/oneview_resource_base_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe OneviewCookbook::ResourceBaseProperties do
 
   describe 'self.safe_dup' do
     it 'dups a dupable object correctly' do
-      dupable = "dupable".freeze
+      dupable = 'dupable'.freeze
       expect(described_class.safe_dup(dupable)).to_not be dupable
     end
 


### PR DESCRIPTION
### Description
Improves safe_dup method and add tests

### Issues Resolved
#243 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
