### PR TITLE
Adding SAS Logical Interconnect Group API500 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Adds API 500 support to the following HPE OneView resources:
   - oneview_managed_san
   - oneview_rack
   - oneview_san_manager
+  - oneview_sas_logical_interconnect_group
   - oneview_scope
   - oneview_unmanaged_device
   - oneview_user

--- a/examples/sas_logical_interconnect_group.rb
+++ b/examples/sas_logical_interconnect_group.rb
@@ -15,10 +15,10 @@ my_client = {
   password: ENV['ONEVIEWSDK_PASSWORD']
 }
 
-# This resource is only available for Synergy and API 300 and onwards, so we need
-# to set these attributes to ensure it loads the correct resource_provider module.
-# You can also set the api_version and api_variant properties on each resource
-# definition below (see the README).
+# This resource is only available for Synergy on API 300 onwards, and these attributes
+# must be set to ensure the correct resource_provider module is loaded.
+# The api_version and api_variant properties can also be set on each resource definition
+# bellow (see the README).
 node.default['oneview']['api_version'] = 300
 node.default['oneview']['api_variant'] = 'Synergy'
 

--- a/examples/sas_logical_interconnect_group.rb
+++ b/examples/sas_logical_interconnect_group.rb
@@ -15,15 +15,16 @@ my_client = {
   password: ENV['ONEVIEWSDK_PASSWORD']
 }
 
-# This resource is only available for API300::Synergy, so we need to set these attributes
-# to ensure it loads the correct resource_provider module. You can also set the api_version
-# and api_variant properties on each resource definition below (see the README).
+# This resource is only available for Synergy and API 300 and onwards, so we need
+# to set these attributes to ensure it loads the correct resource_provider module.
+# You can also set the api_version and api_variant properties on each resource
+# definition below (see the README).
 node.default['oneview']['api_version'] = 300
 node.default['oneview']['api_variant'] = 'Synergy'
 
 # Example: Create a SAS LIG with interconnects
 oneview_sas_logical_interconnect_group 'SAS LIG' do
-  my_client
+  client my_client
   interconnects([
     { bay: 4, type: 'Synergy 12Gb SAS Connection Module' },
     { bay: 1, type: 'Synergy 12Gb SAS Connection Module' }
@@ -31,7 +32,7 @@ oneview_sas_logical_interconnect_group 'SAS LIG' do
 end
 
 # Example: Delete a SAS LIG
-oneview_logical_interconnect_group 'SAS LIG' do
+oneview_sas_logical_interconnect_group 'SAS LIG' do
   client my_client
   action :delete
 end

--- a/libraries/resource_providers/api500/synergy/sas_logical_interconnect_group_provider.rb
+++ b/libraries/resource_providers/api500/synergy/sas_logical_interconnect_group_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module Synergy
+      # SASLogicalInterconnectGroup API500 Synergy provider
+      class SASLogicalInterconnectGroupProvider < API300::Synergy::SASLogicalInterconnectGroupProvider
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description
Adding SAS Logical Interconnect Group for HPE OneView API500 support.

### Issues Resolved
#295  

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
