### PR TITLE
API 500 Support for Server Hardware Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Adds API 500 support to the following HPE OneView resources:
   - oneview_san_manager
   - oneview_sas_logical_interconnect_group
   - oneview_scope
+  - oneview_server_hardware_type
   - oneview_unmanaged_device
   - oneview_user
 

--- a/libraries/resource_providers/api500/c7000/server_hardware_type_provider.rb
+++ b/libraries/resource_providers/api500/c7000/server_hardware_type_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module C7000
+      # ServerHardwareType API500 C7000 provider
+      class ServerHardwareTypeProvider < API300::C7000::ServerHardwareTypeProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api500/synergy/server_hardware_type_provider.rb
+++ b/libraries/resource_providers/api500/synergy/server_hardware_type_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module Synergy
+      # ServerHardwareType API500 Synergy provider
+      class ServerHardwareTypeProvider < API300::Synergy::ServerHardwareTypeProvider
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description
Adding Server Hardware Type for HPE OneView API500 support.

### Issues Resolved
#302 

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
