### PR TITLE
Storage System support to API500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Adds API 500 support to the following HPE OneView resources:
   - oneview_sas_logical_interconnect_group
   - oneview_scope
   - oneview_server_hardware_type
+  - oneview_storage_system
   - oneview_unmanaged_device
   - oneview_user
 
@@ -20,6 +21,7 @@ Enhancements:
 - [#246](https://github.com/HewlettPackard/oneview-chef/issues/246) Upgrade oneview-sdk gem to version 5.0.0
 - [#247](https://github.com/HewlettPackard/oneview-chef/issues/247) Remove deprecation and warnings for Chef 13
 - [#225](https://github.com/HewlettPackard/oneview-chef/issues/225) Support additional uplink port types in the LogicalInterconnectGroupProvider
+- [#304](https://github.com/HewlettPackard/oneview-chef/issues/304) Add refresh actions to oneview_storage_system
 
 Bug fixes:
 - [#284](https://github.com/HewlettPackard/oneview-chef/issues/284) Nested and cyclic requires are causing the first resource to be skipped

--- a/README.md
+++ b/README.md
@@ -600,34 +600,13 @@ end
 ```
 
 ### [oneview_storage_system](examples/storage_system.rb)
-Note: If you add ip_hostname to credentials you don't need to specify a name to handle storage systems
+Note: If you add `ip_hostname` to credentials (prior to API500) or `hostname` (API500 onwards) you don't need to specify a name to handle storage systems
 
 ```ruby
-storage_system_credentials = {
-  'ip_hostname' => '<ip_hostname>',
-  'username' => 'user',
-  'password' => 'password'
-}
-
-oneview_storage_system 'ThreePAR7200-8147' do
+oneview_storage_system 'StorageSystem1' do
   client <my_client>
-  data(
-    credentials: storage_system_credentials,
-    managedDomain: 'TestDomain'
-  )
-  action [:add, :add_if_missing, :remove]
-end
-```
-
-```ruby
-oneview_storage_system 'ThreePAR7200-81471' do
-  client my_client
-  data(
-    ip_hostname: '127.0.0.1',
-    username: 'username',
-    password: 'password'
-  )
-  action :edit_credentials
+  data <storage_system_data>
+  action [:add, :add_if_missing, :remove, :refresh]
 end
 ```
 

--- a/examples/storage_system.rb
+++ b/examples/storage_system.rb
@@ -53,6 +53,12 @@ oneview_storage_system 'StorageSystem1' do
   action :edit_credentials
 end
 
+# Example: refresh storage system
+oneview_storage_system 'StorageSystem1' do
+  client my_client
+  action :refresh
+end
+
 # Example: remove storage system
 oneview_storage_system 'StorageSystem1' do
   client my_client

--- a/examples/storage_system_store_serv.rb
+++ b/examples/storage_system_store_serv.rb
@@ -1,0 +1,52 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+node.default['oneview']['api_version'] = 500
+
+my_client = {
+  url: ENV['ONEVIEWSDK_URL'],
+  user: ENV['ONEVIEWSDK_USER'],
+  password: ENV['ONEVIEWSDK_PASSWORD'],
+  api_version: 500
+}
+
+# Example: add storage system or update if it already exists
+oneview_storage_system 'ThreePAR-1' do
+  client my_client
+  data(
+    credentials: {
+      username: @storage_system_username,
+      password: @storage_system_password
+    },
+    hostname: @storage_system_ip,
+    family: 'StoreServ',
+    deviceSpecificAttributes: {
+      managedDomain: 'TestDomain'
+    }
+  )
+  action :add
+end
+
+# Example: Refresh storage system using its hostname
+oneview_storage_system 'ThreePAR-1' do
+  client my_client
+  data(
+    hostname: '172.18.11.11'
+  )
+  action :refresh
+end
+
+
+# Example: remove storage system
+oneview_storage_system 'ThreePAR-1' do
+  client my_client
+  action :remove
+end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -56,7 +56,7 @@ if defined?(ChefSpec)
     oneview_server_profile_template:    standard_actions + [:new_profile],
     oneview_server_profile:             standard_actions + [:update_from_template],
     oneview_storage_pool:               %i[add_if_missing remove],
-    oneview_storage_system:             %i[add remove edit_credentials add_if_missing],
+    oneview_storage_system:             %i[add remove edit_credentials add_if_missing refresh],
     oneview_switch:                     %i[remove none patch],
     oneview_unmanaged_device:           %i[add remove add_if_missing],
     oneview_uplink_set:                 standard_actions,

--- a/libraries/resource_providers/api500/c7000/storage_system_provider.rb
+++ b/libraries/resource_providers/api500/c7000/storage_system_provider.rb
@@ -1,0 +1,26 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module C7000
+      # StorageSystem API500 C7000 provider
+      class StorageSystemProvider < API300::C7000::StorageSystemProvider
+        def refresh
+          @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
+          @context.converge_by "#{@resource_name} '#{@name}' was refreshed." do
+            @item.request_refresh
+          end
+        end
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api500/synergy/storage_system_provider.rb
+++ b/libraries/resource_providers/api500/synergy/storage_system_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module Synergy
+      # StorageSystem API500 Synergy provider
+      class StorageSystemProvider < API500::C7000::StorageSystemProvider
+      end
+    end
+  end
+end

--- a/resources/storage_system.rb
+++ b/resources/storage_system.rb
@@ -28,3 +28,7 @@ end
 action :remove do
   OneviewCookbook::Helper.do_resource_action(self, :StorageSystem, :remove)
 end
+
+action :refresh do
+  OneviewCookbook::Helper.do_resource_action(self, :StorageSystem, :refresh)
+end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/storage_system_refresh.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/storage_system_refresh.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: oneview_test
 # Recipe:: storage_system_refresh
 #
-# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/fixtures/cookbooks/oneview_test/recipes/storage_system_refresh.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/storage_system_refresh.rb
@@ -1,3 +1,7 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: storage_system_refresh
+#
 # (c) Copyright 2016 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -8,13 +12,9 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+#
 
-source 'https://supermarket.chef.io'
-metadata
-
-group :test do
-  cookbook 'oneview_test', path: './spec/fixtures/cookbooks/oneview_test'
-  cookbook 'oneview_test_api300_synergy', path: './spec/fixtures/cookbooks/oneview_test_api300_synergy'
-  cookbook 'oneview_test_api500_synergy', path: './spec/fixtures/cookbooks/oneview_test_api500_synergy'
-  cookbook 'image_streamer_test_api300', path: './spec/fixtures/cookbooks/image_streamer_test_api300'
+oneview_storage_system 'StorageSystem1' do
+  client node['oneview_test']['client']
+  action :refresh
 end

--- a/spec/fixtures/cookbooks/oneview_test_api500_synergy/attributes/default.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api500_synergy/attributes/default.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: oneview_test_api300_synergy
+# Cookbook Name:: oneview_test_api500_synergy
 # Attributes:: default
 #
-# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/fixtures/cookbooks/oneview_test_api500_synergy/attributes/default.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api500_synergy/attributes/default.rb
@@ -1,3 +1,7 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Attributes:: default
+#
 # (c) Copyright 2016 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -8,13 +12,9 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+#
 
-source 'https://supermarket.chef.io'
-metadata
+default['oneview']['api_version'] = 500
+default['oneview']['api_variant'] = 'Synergy'
 
-group :test do
-  cookbook 'oneview_test', path: './spec/fixtures/cookbooks/oneview_test'
-  cookbook 'oneview_test_api300_synergy', path: './spec/fixtures/cookbooks/oneview_test_api300_synergy'
-  cookbook 'oneview_test_api500_synergy', path: './spec/fixtures/cookbooks/oneview_test_api500_synergy'
-  cookbook 'image_streamer_test_api300', path: './spec/fixtures/cookbooks/image_streamer_test_api300'
-end
+default['oneview_test']['client'] = { url: 'https://oneview.example.com', user: 'Administrator', password: 'secret123', api_version: 500 }

--- a/spec/fixtures/cookbooks/oneview_test_api500_synergy/metadata.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api500_synergy/metadata.rb
@@ -1,0 +1,7 @@
+name             'oneview_test_api500_synergy'
+maintainer       'none'
+license          'All rights reserved'
+description      'A test cookbook for the oneview cookbook API500::Synergy module'
+version          '0.1.0'
+
+depends          'oneview'

--- a/spec/fixtures/cookbooks/oneview_test_api500_synergy/recipes/storage_system_refresh.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api500_synergy/recipes/storage_system_refresh.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: oneview_test_api500_synergy
 # Recipe:: storage_system_refresh
 #
-# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/fixtures/cookbooks/oneview_test_api500_synergy/recipes/storage_system_refresh.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api500_synergy/recipes/storage_system_refresh.rb
@@ -1,3 +1,7 @@
+#
+# Cookbook Name:: oneview_test_api500_synergy
+# Recipe:: storage_system_refresh
+#
 # (c) Copyright 2016 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -8,13 +12,9 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+#
 
-source 'https://supermarket.chef.io'
-metadata
-
-group :test do
-  cookbook 'oneview_test', path: './spec/fixtures/cookbooks/oneview_test'
-  cookbook 'oneview_test_api300_synergy', path: './spec/fixtures/cookbooks/oneview_test_api300_synergy'
-  cookbook 'oneview_test_api500_synergy', path: './spec/fixtures/cookbooks/oneview_test_api500_synergy'
-  cookbook 'image_streamer_test_api300', path: './spec/fixtures/cookbooks/image_streamer_test_api300'
+oneview_storage_system 'StorageSystem1' do
+  client node['oneview_test']['client']
+  action :refresh
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ RSpec.configure do |config|
 
   config.before(:each) do
     # Mock appliance version and login api requests, as well as loading trusted certs
-    allow_any_instance_of(OneviewSDK::Client).to receive(:appliance_api_version).and_return(300)
+    allow_any_instance_of(OneviewSDK::Client).to receive(:appliance_api_version).and_return(500)
     allow_any_instance_of(OneviewSDK::Client).to receive(:login).and_return('secretToken')
     allow(OneviewSDK::SSLHelper).to receive(:load_trusted_certs).and_return(nil)
 

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -212,6 +212,7 @@ describe 'oneview_test::default' do
     expect(chef_run).to_not add_oneview_storage_system('')
     expect(chef_run).to_not add_oneview_storage_system_if_missing('')
     expect(chef_run).to_not edit_oneview_storage_system_credentials('')
+    expect(chef_run).to_not refresh_oneview_storage_system('')
     expect(chef_run).to_not remove_oneview_storage_system('')
 
     # oneview_switch

--- a/spec/unit/resources/storage_system/refresh_spec.rb
+++ b/spec/unit/resources/storage_system/refresh_spec.rb
@@ -1,0 +1,41 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test::storage_system_refresh' do
+  let(:resource_name) { 'storage_system' }
+  include_context 'chef context'
+
+  let(:base_sdk) { OneviewSDK::API200 }
+
+  it 'refreshes it when it exists' do
+    allow_any_instance_of(base_sdk::StorageSystem).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(base_sdk::StorageSystem).to receive(:[]).and_call_original
+    allow_any_instance_of(base_sdk::StorageSystem).to receive(:[]).with('refreshState').and_return('')
+    expect_any_instance_of(base_sdk::StorageSystem).to receive(:set_refresh_state).with('RefreshPending').and_return(true)
+    expect(real_chef_run).to refresh_oneview_storage_system('StorageSystem1')
+  end
+
+  it 'raises an error when it does not exist' do
+    allow_any_instance_of(base_sdk::StorageSystem).to receive(:retrieve!).and_return(false)
+    expect_any_instance_of(base_sdk::StorageSystem).to_not receive(:set_refresh_state)
+    expect { real_chef_run }.to raise_error(StandardError, /not found/)
+  end
+end
+
+describe 'oneview_test_api500_synergy::storage_system_refresh' do
+  let(:resource_name) { 'storage_system' }
+  include_context 'chef context'
+
+  let(:base_sdk) { OneviewSDK::API500::Synergy }
+
+  it 'refreshes it when it exists' do
+    allow_any_instance_of(base_sdk::StorageSystem).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(base_sdk::StorageSystem).to receive(:request_refresh).and_return(true)
+    expect(real_chef_run).to refresh_oneview_storage_system('StorageSystem1')
+  end
+
+  it 'raises an error when it does not exist' do
+    allow_any_instance_of(base_sdk::StorageSystem).to receive(:retrieve!).and_return(false)
+    expect_any_instance_of(base_sdk::StorageSystem).to_not receive(:request_refresh)
+    expect { real_chef_run }.to raise_error(StandardError, /not found/)
+  end
+end


### PR DESCRIPTION
### Description
Adds support to refresh in previous versions of Storage System
Adds support to Storage System in API500:
 - Changes refresh  behavior in API500
 - Adds unit test cookbook for API500
 - Adds new example showing StoreServ storage system

### Issues Resolved
Fixes #304

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [ ] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
