### PR TITLE
Server Profile API500 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Adds API 500 support to the following HPE OneView resources:
   - oneview_sas_logical_interconnect_group
   - oneview_scope
   - oneview_server_hardware_type
+  - oneview_server_profile
   - oneview_storage_system
   - oneview_unmanaged_device
   - oneview_user

--- a/README.md
+++ b/README.md
@@ -767,6 +767,7 @@ oneview_server_profile 'ServerProfile1' do
   firmware_driver <firmware_driver_name>
   ethernet_network_connections <ethernet_network_connections_data>
   fc_network_connections <fc_network_connections_data>
+  fcoe_network_connections <fcoe_network_connections_data>
   network_set_connections <network_set_connections_data>
   os_deployment_plan <os_deployment_plan_name>
   action [:create, :create_if_missing, :delete]

--- a/examples/server_profile.rb
+++ b/examples/server_profile.rb
@@ -71,6 +71,13 @@ oneview_server_profile 'ServerProfile3' do
       'portId' => 'Auto'
     }
   )
+  fcoe_network_connections(
+    'fcoe1' => {
+      'name' => 'c1',
+      'functionType' => 'FibreChannel',
+      'portId' => 'Auto'
+    }
+  )
   action :create_if_missing
 end
 

--- a/examples/server_profile.rb
+++ b/examples/server_profile.rb
@@ -15,11 +15,16 @@ my_client = {
   password: ENV['ONEVIEWSDK_PASSWORD']
 }
 
+my_server_profile_template = 'spt1'
+my_server_hardware_type = 'SY 480 Gen9 2'
+my_server_hardware = '0000A66101, bay 5'
+my_enclosure_group = 'eg1'
+
 # Creates a server profile with the desired Enclosure group and Server hardware type
 oneview_server_profile 'ServerProfile1' do
   client my_client
-  enclosure_group 'EnclosureGroup1'
-  server_hardware_type 'BL460c Gen8'
+  enclosure_group my_enclosure_group
+  server_hardware_type my_server_hardware_type
 end
 
 # Creates a server profile using a template
@@ -32,12 +37,12 @@ oneview_server_profile 'ServerProfile2' do
   data(
     description: 'Override Description',
     boot: {
-      'order' => [],
-      'manageBoot' => false
+      order: [],
+      manageBoot: false
     }
   )
-  server_profile_template 'Web Server Template'
-  server_hardware 'Enclosure1, bay 3'
+  server_profile_template my_server_profile_template
+  server_hardware my_server_hardware
 end
 
 # If a profile does get in an inconsistent state, you can update it from it's template. Note that this action
@@ -53,29 +58,29 @@ end
 # Creates a server profile with the desired Enclosure group and Server hardware type and some connections
 oneview_server_profile 'ServerProfile3' do
   client my_client
-  enclosure_group 'EnclosureGroup2'
-  server_hardware_type 'BL460c Gen8'
+  enclosure_group my_enclosure_group
+  server_hardware_type my_server_hardware_type
   data(
-    'macType' => 'Virtual',
-    'wwnType' => 'Virtual'
+    macType: 'Virtual',
+    wwnType: 'Virtual'
   )
   ethernet_network_connections(
-    'EthernetNetwork1' => {
-      'name' => 'Connection1'
+    EthernetNetwork1: {
+      name: 'Connection1'
     }
   )
   fc_network_connections(
-    'FCNetwork1' => {
-      'name' => 'Connection2',
-      'functionType' => 'FibreChannel',
-      'portId' => 'Auto'
+    FCNetwork1: {
+      name: 'Connection2',
+      functionType: 'FibreChannel',
+      portId: 'Auto'
     }
   )
   fcoe_network_connections(
-    'fcoe1' => {
-      'name' => 'c1',
-      'functionType' => 'FibreChannel',
-      'portId' => 'Auto'
+    fcoe1: {
+      name: 'c1',
+      functionType: 'FibreChannel',
+      portId: 'Auto'
     }
   )
   action :create_if_missing
@@ -84,31 +89,31 @@ end
 # Creates or updates ServerProfile3 with multiple boot connections in the same network
 oneview_server_profile 'ServerProfile3' do
   client my_client
-  enclosure_group 'EnclosureGroup2'
-  server_hardware_type 'BL460c Gen8'
+  enclosure_group my_enclosure_group
+  server_hardware_type my_server_hardware_type
   data(
-    "bootMode" => {
-      'manageMode' => true,
-      'mode' => 'BIOS'
+    bootMode: {
+      manageMode: true,
+      mode: 'BIOS'
     },
-    'boot' => {
-      'manageBoot' => true
+  boot: {
+      manageBoot: true
     }
   )
   ethernet_network_connections [
     {
-      'EthernetNetwork1' => {
-        'name' => 'PrimaryBoot',
-        "boot": {
-          "priority": "Primary"
+      EthernetNetwork1: {
+        name: 'PrimaryBoot',
+        boot: {
+          priority: "Primary"
         }
       }
     },
     {
-      'EthernetNetwork1' => {
-        'name' => 'SecondaryBoot',
-        "boot": {
-          "priority": "Secondary"
+      EthernetNetwork1: {
+        name: 'SecondaryBoot',
+        boot: {
+          priority: "Secondary"
         }
       }
     }

--- a/libraries/resource_providers/api200/server_profile_provider.rb
+++ b/libraries/resource_providers/api200/server_profile_provider.rb
@@ -49,6 +49,7 @@ module OneviewCookbook
         set_resource(:FirmwareDriver, @new_resource.firmware_driver, :set_firmware_driver)
         set_connections(:EthernetNetwork, @new_resource.ethernet_network_connections)
         set_connections(:FCNetwork, @new_resource.fc_network_connections)
+        set_connections(:FCoENetwork, @new_resource.fcoe_network_connections)
         set_connections(:NetworkSet, @new_resource.network_set_connections)
       end
 

--- a/libraries/resource_providers/api200/server_profile_template_provider.rb
+++ b/libraries/resource_providers/api200/server_profile_template_provider.rb
@@ -9,6 +9,8 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+require_relative 'server_profile_provider'
+
 module OneviewCookbook
   module API200
     # ServerProfileTemplate API200 provider

--- a/libraries/resource_providers/api500/c7000/server_profile_provider.rb
+++ b/libraries/resource_providers/api500/c7000/server_profile_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module C7000
+      # Server Profile API500 C7000 provider
+      class ServerProfileProvider < API300::C7000::ServerProfileProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api500/synergy/server_profile_provider.rb
+++ b/libraries/resource_providers/api500/synergy/server_profile_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module Synergy
+      # Server Profile API500 Synergy provider
+      class ServerProfileProvider < API300::Synergy::ServerProfileProvider
+      end
+    end
+  end
+end

--- a/resources/server_profile.rb
+++ b/resources/server_profile.rb
@@ -18,6 +18,7 @@ property :enclosure, String
 property :firmware_driver, String
 property :ethernet_network_connections, Object
 property :fc_network_connections, Object
+property :fcoe_network_connections, Object
 property :network_set_connections, Object
 property :server_profile_template, String
 property :os_deployment_plan, String


### PR DESCRIPTION
### Description
Allowed FCoE Networks on connections and validated against API500
- New property fcoe_network_connections added
- Validated against API500
- Docs updated

### Check List
  - [X] All tests pass (`$ rake test`).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [X] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
