### PR TITLE
Enhancement/shared examples to scope actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Enhancements:
 - [#247](https://github.com/HewlettPackard/oneview-chef/issues/247) Remove deprecation and warnings for Chef 13
 - [#225](https://github.com/HewlettPackard/oneview-chef/issues/225) Support additional uplink port types in the LogicalInterconnectGroupProvider
 - [#304](https://github.com/HewlettPackard/oneview-chef/issues/304) Add refresh actions to oneview_storage_system
+- [#306](https://github.com/HewlettPackard/oneview-chef/issues/306) Create shared examples to unit tests that using scope actions
 
 Bug fixes:
 - [#284](https://github.com/HewlettPackard/oneview-chef/issues/284) Nested and cyclic requires are causing the first resource to be skipped

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ require 'oneview-sdk'
 require 'chef/log'
 require 'chefspec'
 require 'chefspec/berkshelf'
+Dir[File.expand_path('./unit/shared_examples/*.rb', File.dirname(__FILE__))].each { |file| require file }
 ChefSpec::Coverage.start!
 
 RSpec.configure do |config|

--- a/spec/unit/resources/ethernet_network/add_to_scopes_spec.rb
+++ b/spec/unit/resources/ethernet_network/add_to_scopes_spec.rb
@@ -4,34 +4,8 @@ describe 'oneview_test_api300_synergy::ethernet_network_add_to_scopes' do
   let(:resource_name) { 'ethernet_network' }
   include_context 'chef context'
 
-  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
-  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
-
-  before do
-    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
-    allow(scope1).to receive(:retrieve!).and_return(true)
-    allow(scope2).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:[]).and_call_original
-  end
-
-  it 'adds all scopes when are not added' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:[]).with('scopeUris').and_return([])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:add_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:add_scope).with(scope2)
-    expect(real_chef_run).to add_oneview_ethernet_network_to_scopes('EthernetNetwork1')
-  end
-
-  it 'adds only the scope that is not added' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).not_to receive(:add_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:add_scope).with(scope2)
-    expect(real_chef_run).to add_oneview_ethernet_network_to_scopes('EthernetNetwork1')
-  end
-
-  it 'does nothing when scopes are already added' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).not_to receive(:add_scope)
-    expect(real_chef_run).to add_oneview_ethernet_network_to_scopes('EthernetNetwork1')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::EthernetNetwork }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:add_oneview_ethernet_network_to_scopes, 'EthernetNetwork1'] }
+  it_behaves_like 'action :add_to_scopes'
 end

--- a/spec/unit/resources/ethernet_network/patch_spec.rb
+++ b/spec/unit/resources/ethernet_network/patch_spec.rb
@@ -4,9 +4,7 @@ describe 'oneview_test_api300_synergy::ethernet_network_patch' do
   let(:resource_name) { 'ethernet_network' }
   include_context 'chef context'
 
-  it 'performs patch operation' do
-    expect_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:retrieve!).and_return(true)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:patch).with('test', 'test/', 'TestMessage').and_return(true)
-    expect(real_chef_run).to patch_oneview_ethernet_network('EthernetNetwork1')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::EthernetNetwork }
+  let(:target_match_method) { [:patch_oneview_ethernet_network, 'EthernetNetwork1'] }
+  it_behaves_like 'action :patch'
 end

--- a/spec/unit/resources/ethernet_network/remove_from_scopes_spec.rb
+++ b/spec/unit/resources/ethernet_network/remove_from_scopes_spec.rb
@@ -4,34 +4,8 @@ describe 'oneview_test_api300_synergy::ethernet_network_remove_from_scopes' do
   let(:resource_name) { 'ethernet_network' }
   include_context 'chef context'
 
-  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
-  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
-
-  before do
-    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
-    allow(scope1).to receive(:retrieve!).and_return(true)
-    allow(scope2).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:[]).and_call_original
-  end
-
-  it 'removes all scopes when are not removed' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:remove_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:remove_scope).with(scope2)
-    expect(real_chef_run).to remove_oneview_ethernet_network_from_scopes('EthernetNetwork1')
-  end
-
-  it 'removes only the one scope that is not removed' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:remove_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).not_to receive(:remove_scope).with(scope2)
-    expect(real_chef_run).to remove_oneview_ethernet_network_from_scopes('EthernetNetwork1')
-  end
-
-  it 'does nothing when scope is already removed' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/other-scope'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).not_to receive(:remove_scope)
-    expect(real_chef_run).to remove_oneview_ethernet_network_from_scopes('EthernetNetwork1')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::EthernetNetwork }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:remove_oneview_ethernet_network_from_scopes, 'EthernetNetwork1'] }
+  it_behaves_like 'action :remove_from_scopes'
 end

--- a/spec/unit/resources/ethernet_network/replace_scopes_spec.rb
+++ b/spec/unit/resources/ethernet_network/replace_scopes_spec.rb
@@ -4,32 +4,8 @@ describe 'oneview_test_api300_synergy::ethernet_network_replace_scopes' do
   let(:resource_name) { 'ethernet_network' }
   include_context 'chef context'
 
-  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
-  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
-
-  before do
-    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
-    allow(scope1).to receive(:retrieve!).and_return(true)
-    allow(scope2).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:[]).and_call_original
-  end
-
-  it 'replace scopes' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:[]).with('scopeUris').and_return([])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:replace_scopes).with([scope1, scope2])
-    expect(real_chef_run).to replace_oneview_ethernet_network_scopes('EthernetNetwork1')
-  end
-
-  it 'replace scopes even when already one of scopes added' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:replace_scopes).with([scope1, scope2])
-    expect(real_chef_run).to replace_oneview_ethernet_network_scopes('EthernetNetwork1')
-  end
-
-  it 'does nothing when all scopes are already replaced' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/2', '/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::EthernetNetwork).not_to receive(:replace_scopes)
-    expect(real_chef_run).to replace_oneview_ethernet_network_scopes('EthernetNetwork1')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::EthernetNetwork }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:replace_oneview_ethernet_network_scopes, 'EthernetNetwork1'] }
+  it_behaves_like 'action :replace_scopes'
 end

--- a/spec/unit/resources/fc_network/add_to_scopes_spec.rb
+++ b/spec/unit/resources/fc_network/add_to_scopes_spec.rb
@@ -4,34 +4,8 @@ describe 'oneview_test_api300_synergy::fc_network_add_to_scopes' do
   let(:resource_name) { 'fc_network' }
   include_context 'chef context'
 
-  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
-  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
-
-  before do
-    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
-    allow(scope1).to receive(:retrieve!).and_return(true)
-    allow(scope2).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).and_call_original
-  end
-
-  it 'adds all scopes when are not added' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return([])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:add_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:add_scope).with(scope2)
-    expect(real_chef_run).to add_oneview_fc_network_to_scopes('FCNetwork1')
-  end
-
-  it 'adds only the scope that is not added' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).not_to receive(:add_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:add_scope).with(scope2)
-    expect(real_chef_run).to add_oneview_fc_network_to_scopes('FCNetwork1')
-  end
-
-  it 'does nothing when scopes are already added' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).not_to receive(:add_scope)
-    expect(real_chef_run).to add_oneview_fc_network_to_scopes('FCNetwork1')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::FCNetwork }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:add_oneview_fc_network_to_scopes, 'FCNetwork1'] }
+  it_behaves_like 'action :add_to_scopes'
 end

--- a/spec/unit/resources/fc_network/patch_spec.rb
+++ b/spec/unit/resources/fc_network/patch_spec.rb
@@ -4,9 +4,7 @@ describe 'oneview_test_api300_synergy::fc_network_patch' do
   let(:resource_name) { 'fc_network' }
   include_context 'chef context'
 
-  it 'performs patch operation' do
-    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:patch).with('test', 'test/', 'TestMessage').and_return(true)
-    expect(real_chef_run).to patch_oneview_fc_network('FCNetwork4')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::FCNetwork }
+  let(:target_match_method) { [:patch_oneview_fc_network, 'FCNetwork4'] }
+  it_behaves_like 'action :patch'
 end

--- a/spec/unit/resources/fc_network/remove_from_scopes_spec.rb
+++ b/spec/unit/resources/fc_network/remove_from_scopes_spec.rb
@@ -4,34 +4,8 @@ describe 'oneview_test_api300_synergy::fc_network_remove_from_scopes' do
   let(:resource_name) { 'fc_network' }
   include_context 'chef context'
 
-  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
-  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
-
-  before do
-    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
-    allow(scope1).to receive(:retrieve!).and_return(true)
-    allow(scope2).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).and_call_original
-  end
-
-  it 'removes all scopes when are not removed' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:remove_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:remove_scope).with(scope2)
-    expect(real_chef_run).to remove_oneview_fc_network_from_scopes('FCNetwork1')
-  end
-
-  it 'removes only the one scope that is not removed' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:remove_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).not_to receive(:remove_scope).with(scope2)
-    expect(real_chef_run).to remove_oneview_fc_network_from_scopes('FCNetwork1')
-  end
-
-  it 'does nothing when scope is already removed' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/other-scope'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).not_to receive(:remove_scope)
-    expect(real_chef_run).to remove_oneview_fc_network_from_scopes('FCNetwork1')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::FCNetwork }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:remove_oneview_fc_network_from_scopes, 'FCNetwork1'] }
+  it_behaves_like 'action :remove_from_scopes'
 end

--- a/spec/unit/resources/fc_network/replace_scopes_spec.rb
+++ b/spec/unit/resources/fc_network/replace_scopes_spec.rb
@@ -4,32 +4,8 @@ describe 'oneview_test_api300_synergy::fc_network_replace_scopes' do
   let(:resource_name) { 'fc_network' }
   include_context 'chef context'
 
-  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
-  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
-
-  before do
-    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
-    allow(scope1).to receive(:retrieve!).and_return(true)
-    allow(scope2).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).and_call_original
-  end
-
-  it 'replace scopes' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return([])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:replace_scopes).with([scope1, scope2])
-    expect(real_chef_run).to replace_oneview_fc_network_scopes('FCNetwork1')
-  end
-
-  it 'replace scopes even when already one of scopes added' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:replace_scopes).with([scope1, scope2])
-    expect(real_chef_run).to replace_oneview_fc_network_scopes('FCNetwork1')
-  end
-
-  it 'does nothing when all scopes are already replaced' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).to receive(:[]).with('scopeUris').and_return(['/rest/fake/2', '/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::FCNetwork).not_to receive(:replace_scopes)
-    expect(real_chef_run).to replace_oneview_fc_network_scopes('FCNetwork1')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::FCNetwork }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:replace_oneview_fc_network_scopes, 'FCNetwork1'] }
+  it_behaves_like 'action :replace_scopes'
 end

--- a/spec/unit/resources/logical_interconnect_group/add_to_scopes_spec.rb
+++ b/spec/unit/resources/logical_interconnect_group/add_to_scopes_spec.rb
@@ -4,35 +4,8 @@ describe 'oneview_test_api300_synergy::logical_interconnect_group_add_to_scopes'
   let(:resource_name) { 'logical_interconnect_group' }
   include_context 'chef context'
 
-  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
-  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
-
-  before do
-    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
-    allow(scope1).to receive(:retrieve!).and_return(true)
-    allow(scope2).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:[]).and_call_original
-  end
-
-  it 'adds all scopes when are not added' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:[]).with('scopeUris').and_return([])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:add_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:add_scope).with(scope2)
-    expect(real_chef_run).to add_oneview_logical_interconnect_group_to_scopes('LogicalInterconnectGroup1')
-  end
-
-  it 'adds only the scope that is not added' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).not_to receive(:add_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:add_scope).with(scope2)
-    expect(real_chef_run).to add_oneview_logical_interconnect_group_to_scopes('LogicalInterconnectGroup1')
-  end
-
-  it 'does nothing when scopes are already added' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:[])
-      .with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).not_to receive(:add_scope)
-    expect(real_chef_run).to add_oneview_logical_interconnect_group_to_scopes('LogicalInterconnectGroup1')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::LogicalInterconnectGroup }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:add_oneview_logical_interconnect_group_to_scopes, 'LogicalInterconnectGroup1'] }
+  it_behaves_like 'action :add_to_scopes'
 end

--- a/spec/unit/resources/logical_interconnect_group/patch_spec.rb
+++ b/spec/unit/resources/logical_interconnect_group/patch_spec.rb
@@ -4,11 +4,7 @@ describe 'oneview_test_api300_synergy::logical_interconnect_group_patch' do
   let(:resource_name) { 'logical_interconnect_group' }
   include_context 'chef context'
 
-  it 'performs patch operation' do
-    expect_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:retrieve!).and_return(true)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:patch)
-      .with('test', 'test/', 'TestMessage')
-      .and_return(true)
-    expect(real_chef_run).to patch_oneview_logical_interconnect_group('LogicalInterconnectGroup1')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::LogicalInterconnectGroup }
+  let(:target_match_method) { [:patch_oneview_logical_interconnect_group, 'LogicalInterconnectGroup1'] }
+  it_behaves_like 'action :patch'
 end

--- a/spec/unit/resources/logical_interconnect_group/remove_from_scopes_spec.rb
+++ b/spec/unit/resources/logical_interconnect_group/remove_from_scopes_spec.rb
@@ -4,34 +4,8 @@ describe 'oneview_test_api300_synergy::logical_interconnect_group_remove_from_sc
   let(:resource_name) { 'logical_interconnect_group' }
   include_context 'chef context'
 
-  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
-  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
-
-  before do
-    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
-    allow(scope1).to receive(:retrieve!).and_return(true)
-    allow(scope2).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:[]).and_call_original
-  end
-
-  it 'removes all scopes when are not removed' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:remove_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:remove_scope).with(scope2)
-    expect(real_chef_run).to remove_oneview_logical_interconnect_group_from_scopes('LogicalInterconnectGroup1')
-  end
-
-  it 'removes only the one scope that is not removed' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:remove_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).not_to receive(:remove_scope).with(scope2)
-    expect(real_chef_run).to remove_oneview_logical_interconnect_group_from_scopes('LogicalInterconnectGroup1')
-  end
-
-  it 'does nothing when scope is already removed' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:[]).with('scopeUris').and_return(['/rest/fake/other-scope'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).not_to receive(:remove_scope)
-    expect(real_chef_run).to remove_oneview_logical_interconnect_group_from_scopes('LogicalInterconnectGroup1')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::LogicalInterconnectGroup }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:remove_oneview_logical_interconnect_group_from_scopes, 'LogicalInterconnectGroup1'] }
+  it_behaves_like 'action :remove_from_scopes'
 end

--- a/spec/unit/resources/logical_interconnect_group/replace_scopes_spec.rb
+++ b/spec/unit/resources/logical_interconnect_group/replace_scopes_spec.rb
@@ -4,34 +4,8 @@ describe 'oneview_test_api300_synergy::logical_interconnect_group_replace_scopes
   let(:resource_name) { 'logical_interconnect_group' }
   include_context 'chef context'
 
-  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
-  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
-
-  before do
-    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
-    allow(scope1).to receive(:retrieve!).and_return(true)
-    allow(scope2).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:[]).and_call_original
-  end
-
-  it 'replace scopes' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:[]).with('scopeUris').and_return([])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:replace_scopes).with([scope1, scope2])
-    expect(real_chef_run).to replace_oneview_logical_interconnect_group_scopes('LogicalInterconnectGroup1')
-  end
-
-  it 'replace scopes even when already one of scopes added' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:replace_scopes).with([scope1, scope2])
-    expect(real_chef_run).to replace_oneview_logical_interconnect_group_scopes('LogicalInterconnectGroup1')
-  end
-
-  it 'does nothing when all scopes are already replaced' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).to receive(:[])
-      .with('scopeUris')
-      .and_return(['/rest/fake/2', '/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::LogicalInterconnectGroup).not_to receive(:replace_scopes)
-    expect(real_chef_run).to replace_oneview_logical_interconnect_group_scopes('LogicalInterconnectGroup1')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::LogicalInterconnectGroup }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:replace_oneview_logical_interconnect_group_scopes, 'LogicalInterconnectGroup1'] }
+  it_behaves_like 'action :replace_scopes'
 end

--- a/spec/unit/resources/network_set/add_to_scopes_spec.rb
+++ b/spec/unit/resources/network_set/add_to_scopes_spec.rb
@@ -4,34 +4,8 @@ describe 'oneview_test_api300_synergy::network_set_add_to_scopes' do
   let(:resource_name) { 'network_set' }
   include_context 'chef context'
 
-  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
-  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
-
-  before do
-    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
-    allow(scope1).to receive(:retrieve!).and_return(true)
-    allow(scope2).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).and_call_original
-  end
-
-  it 'adds all scopes when are not added' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return([])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:add_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:add_scope).with(scope2)
-    expect(real_chef_run).to add_oneview_network_set_to_scopes('NetworkSet1')
-  end
-
-  it 'adds only the scope that is not added' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).not_to receive(:add_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:add_scope).with(scope2)
-    expect(real_chef_run).to add_oneview_network_set_to_scopes('NetworkSet1')
-  end
-
-  it 'does nothing when scopes are already added' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).not_to receive(:add_scope)
-    expect(real_chef_run).to add_oneview_network_set_to_scopes('NetworkSet1')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::NetworkSet }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:add_oneview_network_set_to_scopes, 'NetworkSet1'] }
+  it_behaves_like 'action :add_to_scopes'
 end

--- a/spec/unit/resources/network_set/patch_spec.rb
+++ b/spec/unit/resources/network_set/patch_spec.rb
@@ -4,9 +4,7 @@ describe 'oneview_test_api300_synergy::network_set_patch' do
   let(:resource_name) { 'network_set' }
   include_context 'chef context'
 
-  it 'performs patch operation' do
-    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:patch).with('test', 'test/', 'TestMessage').and_return(true)
-    expect(real_chef_run).to patch_oneview_network_set('NetworkSet1')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::NetworkSet }
+  let(:target_match_method) { [:patch_oneview_network_set, 'NetworkSet1'] }
+  it_behaves_like 'action :patch'
 end

--- a/spec/unit/resources/network_set/remove_from_scopes_spec.rb
+++ b/spec/unit/resources/network_set/remove_from_scopes_spec.rb
@@ -4,34 +4,8 @@ describe 'oneview_test_api300_synergy::network_set_remove_from_scopes' do
   let(:resource_name) { 'network_set' }
   include_context 'chef context'
 
-  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
-  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
-
-  before do
-    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
-    allow(scope1).to receive(:retrieve!).and_return(true)
-    allow(scope2).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).and_call_original
-  end
-
-  it 'removes all scopes when are not removed' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:remove_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:remove_scope).with(scope2)
-    expect(real_chef_run).to remove_oneview_network_set_from_scopes('NetworkSet1')
-  end
-
-  it 'removes only the one scope that is not removed' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:remove_scope).with(scope1)
-    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).not_to receive(:remove_scope).with(scope2)
-    expect(real_chef_run).to remove_oneview_network_set_from_scopes('NetworkSet1')
-  end
-
-  it 'does nothing when scope is already removed' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return(['/rest/fake/other-scope'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).not_to receive(:remove_scope)
-    expect(real_chef_run).to remove_oneview_network_set_from_scopes('NetworkSet1')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::NetworkSet }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:remove_oneview_network_set_from_scopes, 'NetworkSet1'] }
+  it_behaves_like 'action :remove_from_scopes'
 end

--- a/spec/unit/resources/network_set/replace_scopes_spec.rb
+++ b/spec/unit/resources/network_set/replace_scopes_spec.rb
@@ -4,32 +4,8 @@ describe 'oneview_test_api300_synergy::network_set_replace_scopes' do
   let(:resource_name) { 'network_set' }
   include_context 'chef context'
 
-  let(:scope1) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope1', uri: '/rest/fake/1') }
-  let(:scope2) { OneviewSDK::API300::Synergy::Scope.new(client, name: 'Scope2', uri: '/rest/fake/2') }
-
-  before do
-    allow(OneviewSDK::API300::Synergy::Scope).to receive(:new).and_return(scope1, scope2)
-    allow(scope1).to receive(:retrieve!).and_return(true)
-    allow(scope2).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).and_call_original
-  end
-
-  it 'replace scopes' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return([])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:replace_scopes).with([scope1, scope2])
-    expect(real_chef_run).to replace_oneview_network_set_scopes('NetworkSet1')
-  end
-
-  it 'replace scopes even when already one of scopes added' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:replace_scopes).with([scope1, scope2])
-    expect(real_chef_run).to replace_oneview_network_set_scopes('NetworkSet1')
-  end
-
-  it 'does nothing when all scopes are already replaced' do
-    allow_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).to receive(:[]).with('scopeUris').and_return(['/rest/fake/2', '/rest/fake/1'])
-    expect_any_instance_of(OneviewSDK::API300::Synergy::NetworkSet).not_to receive(:replace_scopes)
-    expect(real_chef_run).to replace_oneview_network_set_scopes('NetworkSet1')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::NetworkSet }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:replace_oneview_network_set_scopes, 'NetworkSet1'] }
+  it_behaves_like 'action :replace_scopes'
 end

--- a/spec/unit/shared_examples/add_to_scopes.rb
+++ b/spec/unit/shared_examples/add_to_scopes.rb
@@ -1,0 +1,50 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# NOTE:
+# This shared examples needs of below variables:
+#  target_class - The full name of Oneview resource target of the test
+#  scope_class - The full name of Oneview Scope resource used in the test
+#  target_match_method - Array with name of match method called and with the argument of the match method,
+#    e.g: let(:target_match_method) { [:add_oneview_enclosure_to_scopes, 'EnclosureName'] }
+
+RSpec.shared_examples 'action :add_to_scopes' do
+  let(:scope1) { scope_class.new(client, name: 'Scope1', uri: '/rest/fake/1') }
+  let(:scope2) { scope_class.new(client, name: 'Scope2', uri: '/rest/fake/2') }
+
+  before do
+    allow(scope_class).to receive(:new).and_return(scope1, scope2)
+    allow(scope1).to receive(:retrieve!).and_return(true)
+    allow(scope2).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(target_class).to receive(:[]).and_call_original
+  end
+
+  it 'adds all scopes when are not added' do
+    allow_any_instance_of(target_class).to receive(:[]).with('scopeUris').and_return([])
+    expect_any_instance_of(target_class).to receive(:add_scope).with(scope1)
+    expect_any_instance_of(target_class).to receive(:add_scope).with(scope2)
+    expect(real_chef_run).to send(*target_match_method)
+  end
+
+  it 'adds only the scope that is not added' do
+    allow_any_instance_of(target_class).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
+    expect_any_instance_of(target_class).not_to receive(:add_scope).with(scope1)
+    expect_any_instance_of(target_class).to receive(:add_scope).with(scope2)
+    expect(real_chef_run).to send(*target_match_method)
+  end
+
+  it 'does nothing when scopes are already added' do
+    allow_any_instance_of(target_class).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
+    expect_any_instance_of(target_class).not_to receive(:add_scope)
+    expect(real_chef_run).to send(*target_match_method)
+  end
+end

--- a/spec/unit/shared_examples/pacth.rb
+++ b/spec/unit/shared_examples/pacth.rb
@@ -1,0 +1,24 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# NOTE:
+# This shared examples needs of below variables:
+#  target_class - The full name of Oneview resource target of the test
+#  target_match_method - Array with name of match method called and with the argument of the match method,
+#    e.g: let(:target_match_method) { [:add_oneview_enclosure_to_scopes, 'EnclosureName'] }
+
+RSpec.shared_examples 'action :patch' do
+  it 'performs patch operation' do
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:patch).with('test', 'test/', 'TestMessage').and_return(true)
+    expect(real_chef_run).to send(*target_match_method)
+  end
+end

--- a/spec/unit/shared_examples/remove_from_scopes.rb
+++ b/spec/unit/shared_examples/remove_from_scopes.rb
@@ -1,0 +1,50 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# NOTE:
+# This shared examples needs of below variables:
+#  target_class - The full name of Oneview resource target of the test
+#  scope_class - The full name of Oneview Scope resource used in the test
+#  target_match_method - Array with name of match method called and with the argument of the match method,
+#    e.g: let(:target_match_method) { [:add_oneview_enclosure_to_scopes, 'EnclosureName'] }
+
+RSpec.shared_examples 'action :remove_from_scopes' do
+  let(:scope1) { scope_class.new(client, name: 'Scope1', uri: '/rest/fake/1') }
+  let(:scope2) { scope_class.new(client, name: 'Scope2', uri: '/rest/fake/2') }
+
+  before do
+    allow(scope_class).to receive(:new).and_return(scope1, scope2)
+    allow(scope1).to receive(:retrieve!).and_return(true)
+    allow(scope2).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(target_class).to receive(:[]).and_call_original
+  end
+
+  it 'removes all scopes when are not removed' do
+    allow_any_instance_of(target_class).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1', '/rest/fake/2'])
+    expect_any_instance_of(target_class).to receive(:remove_scope).with(scope1)
+    expect_any_instance_of(target_class).to receive(:remove_scope).with(scope2)
+    expect(real_chef_run).to send(*target_match_method)
+  end
+
+  it 'removes only the one scope that is not removed' do
+    allow_any_instance_of(target_class).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
+    expect_any_instance_of(target_class).to receive(:remove_scope).with(scope1)
+    expect_any_instance_of(target_class).not_to receive(:remove_scope).with(scope2)
+    expect(real_chef_run).to send(*target_match_method)
+  end
+
+  it 'does nothing when scope is already removed' do
+    allow_any_instance_of(target_class).to receive(:[]).with('scopeUris').and_return(['/rest/fake/other-scope'])
+    expect_any_instance_of(target_class).not_to receive(:remove_scope)
+    expect(real_chef_run).to send(*target_match_method)
+  end
+end

--- a/spec/unit/shared_examples/replace_scopes.rb
+++ b/spec/unit/shared_examples/replace_scopes.rb
@@ -1,0 +1,48 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# NOTE:
+# This shared examples needs of below variables:
+#  target_class - The full name of Oneview resource target of the test
+#  scope_class - The full name of Oneview Scope resource used in the test
+#  target_match_method - Array with name of match method called and with the argument of the match method,
+#    e.g: let(:target_match_method) { [:add_oneview_enclosure_to_scopes, 'EnclosureName'] }
+
+RSpec.shared_examples 'action :replace_scopes' do
+  let(:scope1) { scope_class.new(client, name: 'Scope1', uri: '/rest/fake/1') }
+  let(:scope2) { scope_class.new(client, name: 'Scope2', uri: '/rest/fake/2') }
+
+  before do
+    allow(scope_class).to receive(:new).and_return(scope1, scope2)
+    allow(scope1).to receive(:retrieve!).and_return(true)
+    allow(scope2).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(target_class).to receive(:[]).and_call_original
+  end
+
+  it 'replace scopes' do
+    allow_any_instance_of(target_class).to receive(:[]).with('scopeUris').and_return([])
+    expect_any_instance_of(target_class).to receive(:replace_scopes).with([scope1, scope2])
+    expect(real_chef_run).to send(*target_match_method)
+  end
+
+  it 'replace scopes even when already one of scopes added' do
+    allow_any_instance_of(target_class).to receive(:[]).with('scopeUris').and_return(['/rest/fake/1'])
+    expect_any_instance_of(target_class).to receive(:replace_scopes).with([scope1, scope2])
+    expect(real_chef_run).to send(*target_match_method)
+  end
+
+  it 'does nothing when all scopes are already replaced' do
+    allow_any_instance_of(target_class).to receive(:[]).with('scopeUris').and_return(['/rest/fake/2', '/rest/fake/1'])
+    expect_any_instance_of(target_class).not_to receive(:replace_scopes)
+    expect(real_chef_run).to send(*target_match_method)
+  end
+end


### PR DESCRIPTION
### Description
- It was created shared examples to run tests related to scope actions: add_to_scopes, remove_from_scopes, replace_scopes, patch (even that is used with other actions).
- Specs related to scope actions were refactored to use shared examples.

### Issues Resolved
#306 

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
