### PR TITLE
Removed unnecessary imports from fcoe_network_provider

### DIFF
--- a/libraries/resource_providers/api500/c7000/fcoe_network_provider.rb
+++ b/libraries/resource_providers/api500/c7000/fcoe_network_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/c7000/fcoe_network_provider'
-
 module OneviewCookbook
   module API500
     module C7000

--- a/libraries/resource_providers/api500/synergy/fcoe_network_provider.rb
+++ b/libraries/resource_providers/api500/synergy/fcoe_network_provider.rb
@@ -9,8 +9,6 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative '../../api300/synergy/fcoe_network_provider'
-
 module OneviewCookbook
   module API500
     module Synergy


### PR DESCRIPTION
### Description
The unnecessary imports were removed from fc_network_provider of api500.