### PR TITLE
Enhancement: DriveEnclosure, SASInterconnect and Interconnect resource providers using mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Bug fixes:
 - [#284](https://github.com/HewlettPackard/oneview-chef/issues/284) Nested and cyclic requires are causing the first resource to be skipped
 - [#287](https://github.com/HewlettPackard/oneview-chef/issues/287) Disable FrozenString magic comment cop from Rubocop until the support is done
 - [#243](https://github.com/HewlettPackard/oneview-chef/issues/243) Chef-client 13.2.20 does not allow modification of property :save_resource_info
+- [#180](https://github.com/HewlettPackard/oneview-chef/issues/180) Create Mixins for the resource providers common methods
 
 ## 2.3.0
 Adds support to the following HPE OneView resources:

--- a/libraries/resource_providers/api200.rb
+++ b/libraries/resource_providers/api200.rb
@@ -24,5 +24,7 @@ module OneviewCookbook
   end
 end
 
+# Load the helper files:
+Dir[File.dirname(__FILE__) + '/helpers/*.rb'].each { |file| require file }
 # Load all API-specific resources:
 Dir[File.dirname(__FILE__) + '/api200/*.rb'].each { |file| require file }

--- a/libraries/resource_providers/api200/interconnect_provider.rb
+++ b/libraries/resource_providers/api200/interconnect_provider.rb
@@ -13,33 +13,11 @@ module OneviewCookbook
   module API200
     # Interconnect API200 provider
     class InterconnectProvider < ResourceProvider
-      def set_uid_light
-        raise "Unspecified property: 'uid_light_state'. Please set it before attempting this action." unless @new_resource.uid_light_state
-        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-        # Impossible to verify this value programatically
-        @context.converge_by "Set #{@resource_name} '#{@name}' UID light to #{@new_resource.uid_light_state.upcase}" do
-          @item.patch('replace', '/uidState', @new_resource.uid_light_state.capitalize)
-        end
-      end
-
-      def set_power_state
-        raise "Unspecified property: 'power_state'. Please set it before attempting this action." unless @new_resource.power_state
-        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-        if @item['powerState'] != @new_resource.power_state
-          @context.converge_by "Power #{@resource_name} '#{@name}' #{@new_resource.power_state.upcase}" do
-            @item.patch('replace', '/powerState', @new_resource.power_state.capitalize)
-          end
-        else
-          Chef::Log.info("#{@resource_name} '#{@name}' is already powered #{@new_resource.power_state.upcase}")
-        end
-      end
+      include OneviewCookbook::PatchOperations::OnOff
+      include OneviewCookbook::PatchOperations::Reset
 
       def reset
-        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-        # Nothing to verify
-        @context.converge_by "Reset #{@resource_name} '#{@name}'" do
-          @item.patch('replace', '/deviceResetState', 'Reset')
-        end
+        reset_handler('/deviceResetState')
       end
 
       def reset_port_protection

--- a/libraries/resource_providers/api200/storage_system_provider.rb
+++ b/libraries/resource_providers/api200/storage_system_provider.rb
@@ -13,6 +13,8 @@ module OneviewCookbook
   module API200
     # StorageSystem API200 provider
     class StorageSystemProvider < ResourceProvider
+      include OneviewCookbook::RefreshActions::SetRefreshState
+
       def add_or_edit
         temp = Marshal.load(Marshal.dump(@item.data))
         if @item.exists?
@@ -52,15 +54,6 @@ module OneviewCookbook
         Chef::Log.info "Updating #{@resource_name} '#{@name}' credentials"
         @context.converge_by "Updated #{@resource_name} '#{@name}' credentials" do
           @item.update(temp)
-        end
-      end
-
-      def refresh
-        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-        refresh_ready = ['RefreshFailed', 'NotRefreshing', ''].include? @item['refreshState']
-        return Chef::Log.info("#{@resource_name} '#{@name}' refresh is already running. State: #{@item['refreshState']}") unless refresh_ready
-        @context.converge_by "#{@resource_name} '#{@name}' was refreshed." do
-          @item.set_refresh_state('RefreshPending')
         end
       end
     end

--- a/libraries/resource_providers/api300/synergy/drive_enclosure_provider.rb
+++ b/libraries/resource_providers/api300/synergy/drive_enclosure_provider.rb
@@ -9,14 +9,14 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-# Improve it with a Mixin
-require_relative 'sas_interconnect_provider'
-
 module OneviewCookbook
   module API300
     module Synergy
       # Drive Enclosure API300 Synergy provider
-      class DriveEnclosureProvider < API300::Synergy::SASInterconnectProvider # Improve it with a Mixin
+      class DriveEnclosureProvider < ResourceProvider
+        include OneviewCookbook::PatchOperations::OnOff
+        include OneviewCookbook::PatchOperations::Reset
+        include OneviewCookbook::RefreshActions::SetRefreshState
       end
     end
   end

--- a/libraries/resource_providers/api300/synergy/sas_interconnect_provider.rb
+++ b/libraries/resource_providers/api300/synergy/sas_interconnect_provider.rb
@@ -9,49 +9,14 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-require_relative 'interconnect_provider'
-
 module OneviewCookbook
   module API300
     module Synergy
       # SAS Interconnect API300 Synergy provider
-      class SASInterconnectProvider < InterconnectProvider
-        def reset
-          reset_handler('/softResetState')
-        end
-
-        def hard_reset
-          reset_handler('/hardResetState')
-        end
-
-        def refresh
-          @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-          refresh_ready = ['RefreshFailed', 'NotRefreshing', ''].include? @item['refreshState']
-          return Chef::Log.info("#{@resource_name} '#{@name}' refresh is already running. State: #{@item['refreshState']}") unless refresh_ready
-          @context.converge_by "#{@resource_name} '#{@name}' was refreshed." do
-            @item.set_refresh_state(@new_resource.refresh_state)
-          end
-        end
-
-        protected
-
-        def reset_handler(path)
-          @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-          # Nothing to verify
-          @context.converge_by "#{path.delete('/').gsub(/([A-Z])/, ' \1').capitalize} #{@resource_name} '#{@name}'" do
-            @item.patch('replace', path, 'Reset')
-          end
-        end
-
-        private
-
-        def update_port
-          Chef::Log.error('InternalError: Method not supported by this resource')
-        end
-
-        def reset_port_protection
-          Chef::Log.error('InternalError: Method not supported by this resource')
-        end
+      class SASInterconnectProvider < ResourceProvider
+        include OneviewCookbook::PatchOperations::OnOff
+        include OneviewCookbook::PatchOperations::Reset
+        include OneviewCookbook::RefreshActions::SetRefreshState
       end
     end
   end

--- a/libraries/resource_providers/api500/c7000/storage_system_provider.rb
+++ b/libraries/resource_providers/api500/c7000/storage_system_provider.rb
@@ -14,12 +14,7 @@ module OneviewCookbook
     module C7000
       # StorageSystem API500 C7000 provider
       class StorageSystemProvider < API300::C7000::StorageSystemProvider
-        def refresh
-          @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-          @context.converge_by "#{@resource_name} '#{@name}' was refreshed." do
-            @item.request_refresh
-          end
-        end
+        include OneviewCookbook::RefreshActions::RequestRefresh
       end
     end
   end

--- a/libraries/resource_providers/helpers/patch_operations.rb
+++ b/libraries/resource_providers/helpers/patch_operations.rb
@@ -1,0 +1,58 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  # Module for Patch operations used by many resources
+  module PatchOperations
+    # module for patch operations that replace On/Off values
+    module OnOff
+      def on_off_handler(property_name, item_attribute_name, operation_path)
+        raise "Unspecified property: '#{property_name}'. Please set it before attempting this action." unless @new_resource.send(property_name)
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
+        op_value = @new_resource.send(property_name).capitalize
+        if @item[item_attribute_name] != @new_resource.send(property_name)
+          @context.converge_by "#{item_attribute_name} of #{@resource_name} '#{@name}' replaced to #{op_value}" do
+            @item.patch('replace', operation_path, op_value)
+          end
+        else
+          Chef::Log.info("'#{item_attribute_name}' of #{@resource_name} '#{@name}' is already #{op_value}")
+        end
+      end
+
+      def set_uid_light
+        on_off_handler(:uid_light_state, 'uidState', '/uidState')
+      end
+
+      def set_power_state
+        on_off_handler(:power_state, 'powerState', '/powerState')
+      end
+    end
+
+    # module for reset operations that replace Reset value
+    module Reset
+      def reset_handler(path)
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
+        # Nothing to verify
+        @context.converge_by "#{path.delete('/').gsub(/([A-Z])/, ' \1').capitalize} #{@resource_name} '#{@name}'" do
+          @item.patch('replace', path, 'Reset')
+        end
+      end
+
+      def reset
+        reset_handler('/softResetState')
+      end
+
+      def hard_reset
+        reset_handler('/hardResetState')
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/helpers/refresh_actions.rb
+++ b/libraries/resource_providers/helpers/refresh_actions.rb
@@ -1,0 +1,37 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  # module for actions related to refresh of resource
+  module RefreshActions
+    # module SetRefreshState with method to refresh calling set_refresh_state method of resource
+    module SetRefreshState
+      def refresh
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
+        refresh_ready = ['RefreshFailed', 'NotRefreshing', ''].include? @item['refreshState']
+        return Chef::Log.info("#{@resource_name} '#{@name}' refresh is already running. State: #{@item['refreshState']}") unless refresh_ready
+        @context.converge_by "#{@resource_name} '#{@name}' was refreshed." do
+          @item.set_refresh_state(@new_resource.refresh_state)
+        end
+      end
+    end
+
+    # module RequestRefresh with method to refresh calling request_refresh method of resource
+    module RequestRefresh
+      def refresh
+        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
+        @context.converge_by "#{@resource_name} '#{@name}' was refreshed." do
+          @item.request_refresh
+        end
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/helpers/refresh_actions.rb
+++ b/libraries/resource_providers/helpers/refresh_actions.rb
@@ -18,8 +18,10 @@ module OneviewCookbook
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         refresh_ready = ['RefreshFailed', 'NotRefreshing', ''].include? @item['refreshState']
         return Chef::Log.info("#{@resource_name} '#{@name}' refresh is already running. State: #{@item['refreshState']}") unless refresh_ready
+        state_value = @new_resource.refresh_state if @new_resource.respond_to?(:refresh_state)
+        state_value ||= 'RefreshPending'
         @context.converge_by "#{@resource_name} '#{@name}' was refreshed." do
-          @item.set_refresh_state(@new_resource.refresh_state)
+          @item.set_refresh_state(state_value)
         end
       end
     end


### PR DESCRIPTION
### Description
The methods `reset`, `set_power_state`, `set_uid_light`, `set_refresh_state` of DriveEnclosureProvider, SASInterconnectProvider and InterconnectProvider were changed to use common methods from mixin.

### Issues Resolved
#180 

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
