### PR TITLE
API500 Support to oneview_connection_template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.4.0 (Unreleased)
 Adds API 500 support to the following HPE OneView resources:
+  - oneview_connection_template
   - oneview_datacenter
   - oneview_drive_enclosure
   - oneview_enclosure

--- a/libraries/resource_providers/api500/c7000/connection_template_provider.rb
+++ b/libraries/resource_providers/api500/c7000/connection_template_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module C7000
+      # ConnectionTemplate API500 C7000 provider
+      class ConnectionTemplateProvider < API300::C7000::ConnectionTemplateProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api500/synergy/connection_template_provider.rb
+++ b/libraries/resource_providers/api500/synergy/connection_template_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module Synergy
+      # ConnectionTemplate API500 Synergy provider
+      class ConnectionTemplateProvider < API300::Synergy::ConnectionTemplateProvider
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description
API500 Support to oneview_connection_template

### Environment Details
 - **oneview Cookbook:** Version: 2.3.0
 - **OneView Version:** 3.10
 - **chef-client Version:** 12.0+
 - **platform:** Any

### Steps to Reproduce
Try to use the oneview_connection_templateon the API 500.

### Expected Result
This resource supports API 500.

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
