### PR TITLE
API500 Support to Power Device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Adds API 500 support to the following HPE OneView resources:
   - oneview_logical_switch_group
   - oneview_managed_san
   - oneview_network_set
+  - oneview_power_device
   - oneview_rack
   - oneview_san_manager
   - oneview_sas_interconnect

--- a/README.md
+++ b/README.md
@@ -675,7 +675,10 @@ oneview_power_device 'PowerDevice1' do
   data(
     ratedCapacity: 40
   )
-  action [:add, :add_if_missing, :remove]
+  power_state [:on, :off]    # Only used with the :set_power_state action
+  uid_state [:on, :off]      # Only used with the :set_uid_state action
+  refresh_options <options>  # Optional <Hash> - Used in :refresh action. It defaults to { refreshState: 'RefreshPending' }.
+  action [:add, :add_if_missing, :remove, :refresh, :set_power_state, :set_uid_state]
 end
 ```
 

--- a/examples/power_device.rb
+++ b/examples/power_device.rb
@@ -35,9 +35,29 @@ end
 # Discovers an iPDU
 oneview_power_device '127.0.0.1' do
   client my_client
-  username 'usernmae'
+  username 'username'
   password 'password'
   action :discover
+end
+
+# Refreshes an iPDU
+oneview_power_device '127.0.0.1' do
+  client my_client
+  action :refresh
+end
+
+# Sets UID state of an iPDU (use a power device that accept change the uid state)
+oneview_power_device '127.0.0.1' do
+  client my_client
+  uid_state 'off'
+  action :set_uid_state
+end
+
+# Sets the power state of an iPDU (use a power device that accept change the power state)
+oneview_power_device '127.0.0.1' do
+  client my_client
+  power_state 'off'
+  action :set_power_state
 end
 
 # Removes a power delivery device

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -43,7 +43,7 @@ if defined?(ChefSpec)
     oneview_logical_switch:             standard_actions + scope_actions + %i[refresh],
     oneview_managed_san:                %i[refresh set_policy set_public_attributes],
     oneview_network_set:                standard_actions + scope_actions + %i[reset_connection_template],
-    oneview_power_device:               %i[add add_if_missing discover remove],
+    oneview_power_device:               %i[add add_if_missing discover remove refresh set_uid_state set_power_state],
     oneview_rack:                       %i[add remove add_if_missing add_to_rack remove_from_rack],
     oneview_san_manager:                %i[add add_if_missing remove],
     oneview_sas_logical_interconnect:   %i[none update_firmware stage_firmware activate_firmware update_from_group reapply_configuration

--- a/libraries/resource_providers/api200/power_device_provider.rb
+++ b/libraries/resource_providers/api200/power_device_provider.rb
@@ -23,13 +23,52 @@ module OneviewCookbook
         end
       end
 
+      def load_power_device
+        return @item if @item.retrieve!
+        power_devices_list = resource_named(:PowerDevice).get_ipdu_devices(@item.client, @name)
+        power_devices_list.first
+      end
+
       def remove
         # First try to remove by name, if it does not work it consider the power device is an iPDU
         return true if super
-        power_devices_list = resource_named(:PowerDevice).get_ipdu_devices(@item.client, @name)
-        return false if power_devices_list.empty?
-        @item = power_devices_list.first
+        item = load_power_device
+        return false if item.nil?
+        @item = item
         super
+      end
+
+      def refresh
+        @item = load_power_device || raise("#{@resource_name} '#{@name}' not found!")
+        raise "Unspecified property: 'refresh_options'. Please set it before attempting this action." unless @new_resource.refresh_options
+        refresh_ready = ['RefreshFailed', 'NotRefreshing', ''].include? @item['refreshState']
+        return Chef::Log.info("#{@resource_name} '#{@name}' refresh is already running. State: #{@item['refreshState']}") unless refresh_ready
+        @context.converge_by "#{@resource_name} '#{@name}' was refreshed." do
+          @item.set_refresh_state(@new_resource.refresh_options)
+        end
+      end
+
+      def set_uid_state
+        execute_action_to_set_property(:uid_state)
+      end
+
+      def set_power_state
+        execute_action_to_set_property(:power_state)
+      end
+
+      private
+
+      # method to help to set property power_state or uid_state, applying the DRY concept
+      def execute_action_to_set_property(property_name)
+        @item = load_power_device || raise("#{@resource_name} '#{@name}' not found!")
+        raise "Unspecified property: '#{property_name}'. Please set it before attempting this action." unless @new_resource.send(property_name)
+        property_name = property_name.to_s
+        current_state = @item.public_send('get_' + property_name)
+        desired_value = @new_resource.public_send(property_name).capitalize
+        return Chef::Log.info("The #{property_name} of #{@resource_name} '#{@name}' is already #{desired_value}") if current_state == desired_value
+        @context.converge_by "#{@resource_name} '#{@name}' #{property_name} set to #{desired_value}" do
+          @item.public_send('set_' + property_name, desired_value)
+        end
       end
     end
   end

--- a/libraries/resource_providers/api200/power_device_provider.rb
+++ b/libraries/resource_providers/api200/power_device_provider.rb
@@ -64,7 +64,7 @@ module OneviewCookbook
         raise "Unspecified property: '#{property_name}'. Please set it before attempting this action." unless @new_resource.send(property_name)
         property_name = property_name.to_s
         current_state = @item.public_send('get_' + property_name)
-        desired_value = @new_resource.public_send(property_name).capitalize
+        desired_value = @new_resource.public_send(property_name).to_s.capitalize
         return Chef::Log.info("The #{property_name} of #{@resource_name} '#{@name}' is already #{desired_value}") if current_state == desired_value
         @context.converge_by "#{@resource_name} '#{@name}' #{property_name} set to #{desired_value}" do
           @item.public_send('set_' + property_name, desired_value)

--- a/libraries/resource_providers/api300/synergy/power_device_provider.rb
+++ b/libraries/resource_providers/api300/synergy/power_device_provider.rb
@@ -12,7 +12,7 @@
 module OneviewCookbook
   module API300
     module Synergy
-      # PowerDevice API300 Synergy resource provider methods
+      # PowerDevice API300 Synergy provider
       class PowerDeviceProvider < API200::PowerDeviceProvider
       end
     end

--- a/libraries/resource_providers/api500/c7000/power_device_provider.rb
+++ b/libraries/resource_providers/api500/c7000/power_device_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module C7000
+      # PowerDevice API500 C7000 provider
+      class PowerDeviceProvider < API300::C7000::PowerDeviceProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api500/synergy/power_device_provider.rb
+++ b/libraries/resource_providers/api500/synergy/power_device_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module Synergy
+      # PowerDevice API500 Synergy provider
+      class PowerDeviceProvider < API300::Synergy::PowerDeviceProvider
+      end
+    end
+  end
+end

--- a/resources/power_device.rb
+++ b/resources/power_device.rb
@@ -14,7 +14,7 @@ OneviewCookbook::ResourceBaseProperties.load(self)
 property :username, String
 property :password, String
 property :uid_state, [String, Symbol], regex: /^(on|off)$/i                   # Used in :set_power_state action only
-property :power_state, [String, Symbol], regex: /^(on|off)$/i                 # Used in :set_power_state action only
+property :power_state, [String, Symbol], regex: /^(on|off)$/i                 # Used in :set_uid_state action only
 property :refresh_options, Hash, default: { refreshState: 'RefreshPending' }  # Used in :refresh action only
 
 default_action :add

--- a/resources/power_device.rb
+++ b/resources/power_device.rb
@@ -13,6 +13,9 @@ OneviewCookbook::ResourceBaseProperties.load(self)
 
 property :username, String
 property :password, String
+property :uid_state, [String, Symbol], regex: /^(on|off)$/i                   # Used in :set_power_state action only
+property :power_state, [String, Symbol], regex: /^(on|off)$/i                 # Used in :set_power_state action only
+property :refresh_options, Hash, default: { refreshState: 'RefreshPending' }  # Used in :refresh action only
 
 default_action :add
 
@@ -30,4 +33,16 @@ end
 
 action :remove do
   OneviewCookbook::Helper.do_resource_action(self, :PowerDevice, :remove)
+end
+
+action :refresh do
+  OneviewCookbook::Helper.do_resource_action(self, :PowerDevice, :refresh)
+end
+
+action :set_uid_state do
+  OneviewCookbook::Helper.do_resource_action(self, :PowerDevice, :set_uid_state)
+end
+
+action :set_power_state do
+  OneviewCookbook::Helper.do_resource_action(self, :PowerDevice, :set_power_state)
 end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/power_device_refresh.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/power_device_refresh.rb
@@ -1,0 +1,20 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: power_device_refresh
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_power_device 'PowerDevice1' do
+  client node['oneview_test']['client']
+  action :refresh
+end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/power_device_set_power_state_off.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/power_device_set_power_state_off.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: power_device_set_power_state_off
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_power_device 'PowerDevicePowerStateOff' do
+  client node['oneview_test']['client']
+  power_state 'off'
+  action :set_power_state
+end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/power_device_set_power_state_on.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/power_device_set_power_state_on.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: power_device_set_power_state_on
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_power_device 'PowerDevicePowerStateOn' do
+  client node['oneview_test']['client']
+  power_state 'on'
+  action :set_power_state
+end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/power_device_set_uid_state_off.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/power_device_set_uid_state_off.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: power_device_set_uid_state_off
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_power_device 'PowerDeviceUidStateOff' do
+  client node['oneview_test']['client']
+  uid_state 'off'
+  action :set_uid_state
+end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/power_device_set_uid_state_on.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/power_device_set_uid_state_on.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: power_device_set_uid_state_on
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_power_device 'PowerDeviceUidStateOn' do
+  client node['oneview_test']['client']
+  uid_state 'on'
+  action :set_uid_state
+end

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -171,6 +171,9 @@ describe 'oneview_test::default' do
     expect(chef_run).to_not add_oneview_power_device_if_missing('')
     expect(chef_run).to_not discover_oneview_power_device('')
     expect(chef_run).to_not remove_oneview_power_device('')
+    expect(chef_run).to_not refresh_oneview_power_device('')
+    expect(chef_run).to_not set_oneview_power_device_power_state('')
+    expect(chef_run).to_not set_oneview_power_device_uid_state('')
 
     # oneview_rack
     expect(chef_run).to_not add_oneview_rack('')

--- a/spec/unit/resources/power_device/add_if_missing_spec.rb
+++ b/spec/unit/resources/power_device/add_if_missing_spec.rb
@@ -4,16 +4,18 @@ describe 'oneview_test::power_device_add_if_missing' do
   let(:resource_name) { 'power_device' }
   include_context 'chef context'
 
+  let(:target_class) { OneviewSDK::API200::PowerDevice }
+
   it 'adds it when it does not exist' do
-    expect_any_instance_of(OneviewSDK::PowerDevice).to receive(:exists?).and_return(false)
-    expect_any_instance_of(OneviewSDK::PowerDevice).to receive(:add).and_return(true)
+    expect_any_instance_of(target_class).to receive(:exists?).and_return(false)
+    expect_any_instance_of(target_class).to receive(:add).and_return(true)
     expect(real_chef_run).to add_oneview_power_device_if_missing('PowerDevice1')
   end
 
   it 'does nothing when it exists' do
-    expect_any_instance_of(OneviewSDK::PowerDevice).to receive(:exists?).and_return(true)
-    expect_any_instance_of(OneviewSDK::PowerDevice).to receive(:retrieve!).and_return(true)
-    expect_any_instance_of(OneviewSDK::PowerDevice).to_not receive(:add)
+    expect_any_instance_of(target_class).to receive(:exists?).and_return(true)
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to_not receive(:add)
     expect(real_chef_run).to add_oneview_power_device_if_missing('PowerDevice1')
   end
 end

--- a/spec/unit/resources/power_device/add_spec.rb
+++ b/spec/unit/resources/power_device/add_spec.rb
@@ -4,26 +4,28 @@ describe 'oneview_test::power_device_add' do
   let(:resource_name) { 'power_device' }
   include_context 'chef context'
 
+  let(:target_class) { OneviewSDK::API200::PowerDevice }
+
   it 'adds it when it does not exist' do
-    expect_any_instance_of(OneviewSDK::PowerDevice).to receive(:exists?).and_return(false)
-    expect_any_instance_of(OneviewSDK::PowerDevice).to receive(:add).and_return(true)
+    expect_any_instance_of(target_class).to receive(:exists?).and_return(false)
+    expect_any_instance_of(target_class).to receive(:add).and_return(true)
     expect(real_chef_run).to add_oneview_power_device('PowerDevice1')
   end
 
   it 'updates it when it exists but not alike' do
-    expect_any_instance_of(OneviewSDK::PowerDevice).to receive(:exists?).and_return(true)
-    expect_any_instance_of(OneviewSDK::PowerDevice).to receive(:retrieve!).and_return(true)
-    expect_any_instance_of(OneviewSDK::PowerDevice).to receive(:like?).and_return(false)
-    expect_any_instance_of(OneviewSDK::PowerDevice).to receive(:update).and_return(true)
+    expect_any_instance_of(target_class).to receive(:exists?).and_return(true)
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:like?).and_return(false)
+    expect_any_instance_of(target_class).to receive(:update).and_return(true)
     expect(real_chef_run).to add_oneview_power_device('PowerDevice1')
   end
 
   it 'does nothing when it exists and is alike' do
-    expect_any_instance_of(OneviewSDK::PowerDevice).to receive(:exists?).and_return(true)
-    expect_any_instance_of(OneviewSDK::PowerDevice).to receive(:retrieve!).and_return(true)
-    expect_any_instance_of(OneviewSDK::PowerDevice).to receive(:like?).and_return(true)
-    expect_any_instance_of(OneviewSDK::PowerDevice).to_not receive(:update)
-    expect_any_instance_of(OneviewSDK::PowerDevice).to_not receive(:add)
+    expect_any_instance_of(target_class).to receive(:exists?).and_return(true)
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:like?).and_return(true)
+    expect_any_instance_of(target_class).to_not receive(:update)
+    expect_any_instance_of(target_class).to_not receive(:add)
     expect(real_chef_run).to add_oneview_power_device('PowerDevice1')
   end
 end

--- a/spec/unit/resources/power_device/discover_spec.rb
+++ b/spec/unit/resources/power_device/discover_spec.rb
@@ -4,9 +4,11 @@ describe 'oneview_test::power_device_discover' do
   let(:resource_name) { 'power_device' }
   include_context 'chef context'
 
+  let(:target_class) { OneviewSDK::API200::PowerDevice }
+
   it 'discovers an ipdu that does not exists' do
-    allow(OneviewSDK::PowerDevice).to receive(:get_ipdu_devices).and_return([])
-    expect(OneviewSDK::PowerDevice).to receive(:discover)
+    allow(target_class).to receive(:get_ipdu_devices).and_return([])
+    expect(target_class).to receive(:discover)
       .with(
         kind_of(OneviewSDK::Client),
         hostname: '127.0.0.1',
@@ -17,12 +19,12 @@ describe 'oneview_test::power_device_discover' do
   end
 
   it 'discovers an ipdu that already exists' do
-    allow(OneviewSDK::PowerDevice).to receive(:get_ipdu_devices).and_return(
+    allow(target_class).to receive(:get_ipdu_devices).and_return(
       [
-        OneviewSDK::PowerDevice.new(client, managedBy: { name: '127.0.0.1' })
+        target_class.new(client, managedBy: { name: '127.0.0.1' })
       ]
     )
-    expect(OneviewSDK::PowerDevice).to_not receive(:discover)
+    expect(target_class).to_not receive(:discover)
     expect(real_chef_run).to discover_oneview_power_device('127.0.0.1')
   end
 end

--- a/spec/unit/resources/power_device/refresh_spec.rb
+++ b/spec/unit/resources/power_device/refresh_spec.rb
@@ -39,6 +39,7 @@ describe 'oneview_test::power_device_refresh' do
 
   it 'raises an error when it does not exist' do
     allow_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
+    allow(target_class).to receive(:get_ipdu_devices).and_return([])
     expect_any_instance_of(target_class).to_not receive(:set_refresh_state)
     expect { real_chef_run }.to raise_error(StandardError, /not found/)
   end

--- a/spec/unit/resources/power_device/refresh_spec.rb
+++ b/spec/unit/resources/power_device/refresh_spec.rb
@@ -1,0 +1,45 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test::power_device_refresh' do
+  let(:resource_name) { 'power_device' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API200::PowerDevice }
+
+  context 'when Oneview resource can be retrieved' do
+    before do
+      allow_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+      allow_any_instance_of(target_class).to receive(:[]).with('name').and_call_original
+    end
+
+    it 'refreshes it when it current state is ""' do
+      allow_any_instance_of(target_class).to receive(:[]).with('refreshState').and_return('')
+      expect_any_instance_of(target_class).to receive(:set_refresh_state).with(refreshState: 'RefreshPending')
+      expect(real_chef_run).to refresh_oneview_power_device('PowerDevice1')
+    end
+
+    it 'refreshes it when it current state is RefreshFailed' do
+      allow_any_instance_of(target_class).to receive(:[]).with('refreshState').and_return('RefreshFailed')
+      expect_any_instance_of(target_class).to receive(:set_refresh_state).with(refreshState: 'RefreshPending')
+      expect(real_chef_run).to refresh_oneview_power_device('PowerDevice1')
+    end
+
+    it 'refreshes it when it current state is NotRefreshing' do
+      allow_any_instance_of(target_class).to receive(:[]).with('refreshState').and_return('NotRefreshing')
+      expect_any_instance_of(target_class).to receive(:set_refresh_state).with(refreshState: 'RefreshPending')
+      expect(real_chef_run).to refresh_oneview_power_device('PowerDevice1')
+    end
+
+    it 'does nothing when refresh state is RefreshPending' do
+      allow_any_instance_of(target_class).to receive(:[]).with('refreshState').and_return('RefreshPending')
+      expect_any_instance_of(target_class).not_to receive(:set_refresh_state)
+      expect(real_chef_run).to refresh_oneview_power_device('PowerDevice1')
+    end
+  end
+
+  it 'raises an error when it does not exist' do
+    allow_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
+    expect_any_instance_of(target_class).to_not receive(:set_refresh_state)
+    expect { real_chef_run }.to raise_error(StandardError, /not found/)
+  end
+end

--- a/spec/unit/resources/power_device/remove_spec.rb
+++ b/spec/unit/resources/power_device/remove_spec.rb
@@ -4,16 +4,18 @@ describe 'oneview_test::power_device_remove' do
   let(:resource_name) { 'power_device' }
   include_context 'chef context'
 
+  let(:target_class) { OneviewSDK::API200::PowerDevice }
+
   it 'removes it when it exists' do
-    allow_any_instance_of(OneviewSDK::PowerDevice).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::PowerDevice).to receive(:remove).and_return(true)
+    allow_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(target_class).to receive(:remove).and_return(true)
     expect(real_chef_run).to remove_oneview_power_device('PowerDevice1')
   end
 
   it 'does nothing when it does not exist' do
-    allow_any_instance_of(OneviewSDK::PowerDevice).to receive(:retrieve!).and_return(false)
-    allow(OneviewSDK::PowerDevice).to receive(:get_ipdu_devices).and_return([])
-    expect_any_instance_of(OneviewSDK::PowerDevice).to_not receive(:remove)
+    allow_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
+    allow(target_class).to receive(:get_ipdu_devices).and_return([])
+    expect_any_instance_of(target_class).to_not receive(:remove)
     expect(real_chef_run).to remove_oneview_power_device('PowerDevice1')
   end
 end
@@ -22,14 +24,16 @@ describe 'oneview_test::power_device_remove_ipdu' do
   let(:resource_name) { 'power_device' }
   include_context 'chef context'
 
+  let(:target_class) { OneviewSDK::API200::PowerDevice }
+
   it 'removes ipdu when it exists' do
-    allow_any_instance_of(OneviewSDK::PowerDevice).to receive(:retrieve!).and_return(false)
-    allow(OneviewSDK::PowerDevice).to receive(:get_ipdu_devices).and_return(
+    allow_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
+    allow(target_class).to receive(:get_ipdu_devices).and_return(
       [
-        OneviewSDK::PowerDevice.new(client, managedBy: { name: '127.0.0.1' })
+        target_class.new(client, managedBy: { name: '127.0.0.1' })
       ]
     )
-    expect_any_instance_of(OneviewSDK::PowerDevice).to_not receive(:remove)
+    expect_any_instance_of(target_class).to_not receive(:remove)
     expect(real_chef_run).to remove_oneview_power_device('127.0.0.1')
   end
 end

--- a/spec/unit/resources/power_device/set_power_state_spec.rb
+++ b/spec/unit/resources/power_device/set_power_state_spec.rb
@@ -1,0 +1,53 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test::power_device_set_power_state_on' do
+  let(:resource_name) { 'power_device' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API200::PowerDevice }
+
+  it 'sets the power state to On when power state original value is Off' do
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:get_power_state).and_return('Off')
+    expect_any_instance_of(target_class).to receive(:set_power_state).with('On')
+    expect(real_chef_run).to set_oneview_power_device_power_state('PowerDevicePowerStateOn')
+  end
+
+  it 'do nothing when power state original value is On' do
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:get_power_state).and_return('On')
+    expect_any_instance_of(target_class).not_to receive(:set_power_state)
+    expect(real_chef_run).to set_oneview_power_device_power_state('PowerDevicePowerStateOn')
+  end
+
+  it 'raise error when power device not found' do
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
+end
+
+describe 'oneview_test::power_device_set_power_state_off' do
+  let(:resource_name) { 'power_device' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API200::PowerDevice }
+
+  it 'sets the power state to Off when power state original value is On' do
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:get_power_state).and_return('On')
+    expect_any_instance_of(target_class).to receive(:set_power_state).with('Off')
+    expect(real_chef_run).to set_oneview_power_device_power_state('PowerDevicePowerStateOff')
+  end
+
+  it 'do nothing when power state original value is Off' do
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:get_power_state).and_return('Off')
+    expect_any_instance_of(target_class).not_to receive(:set_power_state)
+    expect(real_chef_run).to set_oneview_power_device_power_state('PowerDevicePowerStateOff')
+  end
+
+  it 'raise error when power device not found' do
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
+end

--- a/spec/unit/resources/power_device/set_power_state_spec.rb
+++ b/spec/unit/resources/power_device/set_power_state_spec.rb
@@ -22,6 +22,7 @@ describe 'oneview_test::power_device_set_power_state_on' do
 
   it 'raise error when power device not found' do
     expect_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
+    allow(target_class).to receive(:get_ipdu_devices).and_return([])
     expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 end
@@ -48,6 +49,7 @@ describe 'oneview_test::power_device_set_power_state_off' do
 
   it 'raise error when power device not found' do
     expect_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
+    allow(target_class).to receive(:get_ipdu_devices).and_return([])
     expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 end

--- a/spec/unit/resources/power_device/set_uid_state_spec.rb
+++ b/spec/unit/resources/power_device/set_uid_state_spec.rb
@@ -22,6 +22,7 @@ describe 'oneview_test::power_device_set_uid_state_on' do
 
   it 'raise error when power device not found' do
     expect_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
+    allow(target_class).to receive(:get_ipdu_devices).and_return([])
     expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 end
@@ -48,6 +49,7 @@ describe 'oneview_test::power_device_set_uid_state_off' do
 
   it 'raise error when power device not found' do
     expect_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
+    allow(target_class).to receive(:get_ipdu_devices).and_return([])
     expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 end

--- a/spec/unit/resources/power_device/set_uid_state_spec.rb
+++ b/spec/unit/resources/power_device/set_uid_state_spec.rb
@@ -1,0 +1,53 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test::power_device_set_uid_state_on' do
+  let(:resource_name) { 'power_device' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API200::PowerDevice }
+
+  it 'sets the uid state to On when uid state original value is Off' do
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:get_uid_state).and_return('Off')
+    expect_any_instance_of(target_class).to receive(:set_uid_state).with('On')
+    expect(real_chef_run).to set_oneview_power_device_uid_state('PowerDeviceUidStateOn')
+  end
+
+  it 'does nothing when uid state original value is On' do
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:get_uid_state).and_return('On')
+    expect_any_instance_of(target_class).not_to receive(:set_uid_state)
+    expect(real_chef_run).to set_oneview_power_device_uid_state('PowerDeviceUidStateOn')
+  end
+
+  it 'raise error when power device not found' do
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
+end
+
+describe 'oneview_test::power_device_set_uid_state_off' do
+  let(:resource_name) { 'power_device' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API200::PowerDevice }
+
+  it 'sets the uid state to Off when uid state original value is On' do
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:get_uid_state).and_return('On')
+    expect_any_instance_of(target_class).to receive(:set_uid_state).with('Off')
+    expect(real_chef_run).to set_oneview_power_device_uid_state('PowerDeviceUidStateOff')
+  end
+
+  it 'does nothing when uid state original value is Off' do
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:get_uid_state).and_return('Off')
+    expect_any_instance_of(target_class).not_to receive(:set_uid_state)
+    expect(real_chef_run).to set_oneview_power_device_uid_state('PowerDeviceUidStateOff')
+  end
+
+  it 'raise error when power device not found' do
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
+end


### PR DESCRIPTION
### Description
- API500 Support to Power Device
- Added new actions for oneview_power_device: `refresh`, `set_power_state`, `set_uid_state`.

### Environment Details
 - **oneview Cookbook:** Version: 2.3.0
 - **OneView Version:** 3.10
 - **chef-client Version:** 12.0+
 - **platform:** Any

### Steps to Reproduce
Try to use the oneview_power_deviceon the API 500.

### Expected Result
This resource supports API 500.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
