### PR TITLE
API 500 Support for Logical Interconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Adds API 500 support to the following HPE OneView resources:
   - oneview_id_pool
   - oneview_interconnect
   - oneview_logical_enclosure
+  - oneview_logical_interconnect
   - oneview_logical_interconnect_group
   - oneview_logical_switch
   - oneview_logical_switch_group

--- a/README.md
+++ b/README.md
@@ -283,16 +283,17 @@ Note: By default it performs the action `:none`.
 oneview_logical_interconnect 'LogicalInterconnect1' do
   client <my_client>
   data <resource_data>
-  firmware <firmware_name>           # String: Optional for actions like :<action>_firwmare (can be replaced by data attribute 'sppName')
-  firmware_data <firmware_data>      # Hash: Optional for actions like :<action>_firwmare
-  internal_networks <networks_names> # Array: Optional for :update_internal_networks
-  trap_destinations <trap_options>   # Hash: Optional for :update_snmp_configuration
-  enclosure <enclosure_name>         # String: Required for :add_interconnect and :remove_interconnect
-  bay_number <bay>                   # Integer: Required for :add_interconnect and :remove_interconnect
-  operation <op>                     # String. Used in patch action only. e.g., 'add'
-  path <path>                        # String. Used in patch option only. e.g., '/scopeUris/-'
-  value <val>                        # String. Used in patch option only. e.g., 'scope uri'
-  scopes <scope_names>               # Array - Optional. Array of scope names. Used in add_to_scopes, remove_from_scopes or replace_scopes options only. e.g., ['Scope1', 'Scope2']
+  firmware <firmware_name>            # String: Optional for actions like :<action>_firwmare (can be replaced by data attribute 'sppName')
+  firmware_data <firmware_data>       # Hash: Optional for actions like :<action>_firwmare
+  internal_networks <networks_names>  # Array: Optional for :update_internal_networks
+  trap_destinations <trap_options>    # Hash: Optional for :update_snmp_configuration
+  enclosure <enclosure_name>          # String: Required for :add_interconnect and :remove_interconnect
+  bay_number <bay>                    # Integer: Required for :add_interconnect and :remove_interconnect
+  port_monitor <port_monitor_options> # Hash: Optional for :update_port_monitor
+  operation <op>                      # String. Used in patch action only. e.g., 'add'
+  path <path>                         # String. Used in patch option only. e.g., '/scopeUris/-'
+  value <val>                         # String. Used in patch option only. e.g., 'scope uri'
+  scopes <scope_names>                # Array - Optional. Array of scope names. Used in add_to_scopes, remove_from_scopes or replace_scopes options only. e.g., ['Scope1', 'Scope2']
   action [:none, :add_interconnect, :remove_interconnect, :update_internal_networks,
           :update_settings,:update_ethernet_settings, :update_port_monitor, :update_qos_configuration,
           :update_telemetry_configuration, :update_snmp_configuration, :update_firmware, :stage_firmware,

--- a/README.md
+++ b/README.md
@@ -278,7 +278,8 @@ end
 Performs actions on logical interconnect and associated interconnects.
 
 Note: By default it performs the action `:none`.
-Note 2: In the `:update_port_monitor` action, if the same field is informed inside both `data` and `port_monitor`, the value of that field inside data will supersede the value inside `port_monitor`.
+
+Note: In the `:update_port_monitor` action, if the same field is informed inside both `data` and `port_monitor`, the value of that field inside `data` will supersede the value inside `port_monitor`.
 
 ```ruby
 oneview_logical_interconnect 'LogicalInterconnect1' do

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ end
 Performs actions on logical interconnect and associated interconnects.
 
 Note: By default it performs the action `:none`.
-Note 2: In :update_port_monitor action, if the data is informed, this will always precede the port_monitor property.
+Note 2: In the `:update_port_monitor` action, if the same field is informed inside both `data` and `port_monitor`, the value of that field inside data will supersede the value inside `port_monitor`.
 
 ```ruby
 oneview_logical_interconnect 'LogicalInterconnect1' do

--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ end
 Performs actions on logical interconnect and associated interconnects.
 
 Note: By default it performs the action `:none`.
+Note 2: In :update_port_monitor action, if the data is informed, this will always precede the port_monitor property.
 
 ```ruby
 oneview_logical_interconnect 'LogicalInterconnect1' do

--- a/README.md
+++ b/README.md
@@ -289,10 +289,15 @@ oneview_logical_interconnect 'LogicalInterconnect1' do
   trap_destinations <trap_options>   # Hash: Optional for :update_snmp_configuration
   enclosure <enclosure_name>         # String: Required for :add_interconnect and :remove_interconnect
   bay_number <bay>                   # Integer: Required for :add_interconnect and :remove_interconnect
+  operation <op>                     # String. Used in patch action only. e.g., 'add'
+  path <path>                        # String. Used in patch option only. e.g., '/scopeUris/-'
+  value <val>                        # String. Used in patch option only. e.g., 'scope uri'
+  scopes <scope_names>               # Array - Optional. Array of scope names. Used in add_to_scopes, remove_from_scopes or replace_scopes options only. e.g., ['Scope1', 'Scope2']
   action [:none, :add_interconnect, :remove_interconnect, :update_internal_networks,
           :update_settings,:update_ethernet_settings, :update_port_monitor, :update_qos_configuration,
           :update_telemetry_configuration, :update_snmp_configuration, :update_firmware, :stage_firmware,
-          :activate_firmware, :update_from_group, :reapply_configuration]
+          :activate_firmware, :update_from_group, :reapply_configuration, :patch, :add_to_scopes,
+          :remove_from_scopes, :replace_scopes]
 end
 ```
 

--- a/examples/logical_interconnect.rb
+++ b/examples/logical_interconnect.rb
@@ -63,21 +63,31 @@ end
 # Activate the port monitor service
 oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
   client my_client
-  data(
-    portMonitor: {
-      analyzerPort: {
-        portUri: '/rest/interconnects/c3498956-ece5-4abf-9e7f-793cee92acca/ports/c3498956-ece5-4abf-9e7f-793cee92acca:1',
-        portMonitorConfigInfo: 'AnalyzerPort'
-      },
-      enablePortMonitor: true,
-      type: 'port-monitor',
-      monitoredPorts: [
-        {
-          portUri: '/rest/interconnects/c3498956-ece5-4abf-9e7f-793cee92acca/ports/c3498956-ece5-4abf-9e7f-793cee92acca:d3',
-          portMonitorConfigInfo: 'MonitoredBoth'
-        }
-      ]
-    }
+  port_monitor(
+    analyzerPort: {
+      port_name: 'Q1.3',
+      portMonitorConfigInfo: 'AnalyzerPort'
+    },
+    enablePortMonitor: true,
+    type: 'port-monitor',
+    monitoredPorts: [
+      {
+        port_name: 'd1',
+        portMonitorConfigInfo: 'MonitoredBoth'
+      }
+    ]
+  )
+  action :update_port_monitor
+end
+
+# Disable the port monitor service
+oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
+  client my_client
+  port_monitor(
+    analyzerPort: nil,
+    enablePortMonitor: false,
+    type: 'port-monitor',
+    monitoredPorts: []
   )
   action :update_port_monitor
 end
@@ -117,7 +127,7 @@ oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
     }
   )
   trap_destinations(
-    '172.18.6.16': {
+    '172.18.6.16' => {
       trapFormat: 'SNMPv1',
       communityString: 'public',
       severities: ['Critical', 'Major', 'Unknown'],

--- a/examples/logical_interconnect.rb
+++ b/examples/logical_interconnect.rb
@@ -92,7 +92,7 @@ oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
   action :update_port_monitor
 end
 
-# Activate the port monitor service with data properties
+# Activate the port monitor service with data
 oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup_1' do
   client my_client
   data(
@@ -114,7 +114,7 @@ oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup_1' do
   action :update_port_monitor
 end
 
-# Disable the port monitor service with data properties
+# Disable the port monitor service with data
 oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup_1' do
   client my_client
   data(
@@ -124,6 +124,30 @@ oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup_1' do
       type: 'port-monitor',
       monitoredPorts: []
     }
+  )
+  action :update_port_monitor
+end
+
+# Activate the port monitor service with data and port_monitor property
+oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup_1' do
+  client my_client
+  data(
+    portMonitor: {
+      analyzerPort: {
+        portUri: '/rest/interconnects/da9f7d38-c2bd-47e4-b651-9bcb4993ac9d/ports/da9f7d38-c2bd-47e4-b651-9bcb4993ac9d:Q1.3',
+        portMonitorConfigInfo: 'AnalyzerPort'
+      },
+      enablePortMonitor: true,
+      type: 'port-monitor'
+    }
+  )
+  port_monitor(
+    monitoredPorts: [
+      {
+        portName: 'd1',
+        portMonitorConfigInfo: 'MonitoredBoth'
+      }
+    ]
   )
   action :update_port_monitor
 end

--- a/examples/logical_interconnect.rb
+++ b/examples/logical_interconnect.rb
@@ -92,6 +92,42 @@ oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
   action :update_port_monitor
 end
 
+# Activate the port monitor service with data properties
+oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup_1' do
+  client my_client
+  data(
+    portMonitor: {
+      analyzerPort: {
+        portUri: '/rest/interconnects/da9f7d38-c2bd-47e4-b651-9bcb4993ac9d/ports/da9f7d38-c2bd-47e4-b651-9bcb4993ac9d:Q1.3',
+        portMonitorConfigInfo: 'AnalyzerPort'
+      },
+      enablePortMonitor: true,
+      type: 'port-monitor',
+      monitoredPorts: [
+        {
+          portUri: '/rest/interconnects/da9f7d38-c2bd-47e4-b651-9bcb4993ac9d/ports/da9f7d38-c2bd-47e4-b651-9bcb4993ac9d:d1',
+          portMonitorConfigInfo: 'MonitoredBoth'
+        }
+      ]
+    }
+  )
+  action :update_port_monitor
+end
+
+# Disable the port monitor service with data properties
+oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup_1' do
+  client my_client
+  data(
+    portMonitor: {
+      analyzerPort: nil,
+      enablePortMonitor: false,
+      type: 'port-monitor',
+      monitoredPorts: []
+    }
+  )
+  action :update_port_monitor
+end
+
 # Update quality of service configuration
 oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
   client my_client

--- a/examples/logical_interconnect.rb
+++ b/examples/logical_interconnect.rb
@@ -65,14 +65,14 @@ oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
   client my_client
   port_monitor(
     analyzerPort: {
-      port_name: 'Q1.3',
+      portName: 'Q1.3',
       portMonitorConfigInfo: 'AnalyzerPort'
     },
     enablePortMonitor: true,
     type: 'port-monitor',
     monitoredPorts: [
       {
-        port_name: 'd1',
+        portName: 'd1',
         portMonitorConfigInfo: 'MonitoredBoth'
       }
     ]

--- a/examples/logical_interconnect.rb
+++ b/examples/logical_interconnect.rb
@@ -9,8 +9,10 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-# NOTE: This recipe requires:
+# NOTE 1: This recipe requires:
 # Ethernet Networks: EthernetNetwork1, EthernetNetwork2
+# NOTE 2: This example requires two Scopes named "Scope1" and "Scope2" to be present in the appliance.
+# NOTE 3: The api_version client should be 300 or greater if you run the examples using Scopes
 
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
@@ -50,9 +52,9 @@ end
 oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
   client my_client
   data(
-    'ethernetSettings' => {
-      'igmpIdleTimeoutInterval' => 230,
-      'macRefreshInterval' => 15
+    ethernetSettings: {
+      igmpIdleTimeoutInterval: 230,
+      macRefreshInterval: 15
     }
   )
   action :update_ethernet_settings
@@ -62,8 +64,19 @@ end
 oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
   client my_client
   data(
-    'portMonitor' => {
-      'enabled' => true
+    portMonitor: {
+      analyzerPort: {
+        portUri: '/rest/interconnects/c3498956-ece5-4abf-9e7f-793cee92acca/ports/c3498956-ece5-4abf-9e7f-793cee92acca:1',
+        portMonitorConfigInfo: 'AnalyzerPort'
+      },
+      enablePortMonitor: true,
+      type: 'port-monitor',
+      monitoredPorts: [
+        {
+          portUri: '/rest/interconnects/c3498956-ece5-4abf-9e7f-793cee92acca/ports/c3498956-ece5-4abf-9e7f-793cee92acca:d3',
+          portMonitorConfigInfo: 'MonitoredBoth'
+        }
+      ]
     }
   )
   action :update_port_monitor
@@ -73,10 +86,10 @@ end
 oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
   client my_client
   data(
-    'qosConfiguration' => {
-      'activeQosConfig' => {
-        'configType' => 'Passthrough',
-        'description' => 'Configured by chef-oneview'
+    qosConfiguration: {
+      activeQosConfig: {
+        configType: 'Passthrough',
+        description: 'Configured by chef-oneview'
       }
     }
   )
@@ -87,9 +100,9 @@ end
 oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
   client my_client
   data(
-    'telemetryConfiguration' => {
-      'sampleCount' => 25,
-      'sampleInterval' => 225
+    telemetryConfiguration: {
+      sampleCount: 25,
+      sampleInterval: 225
     }
   )
   action :update_telemetry_configuration
@@ -99,18 +112,18 @@ end
 oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
   client my_client
   data(
-    'snmpConfiguration' => {
-      'snmpAccess' => ['172.18.6.15/24']
+    snmpConfiguration: {
+      snmpAccess: ['172.18.6.15/24']
     }
   )
   trap_destinations(
-    '172.18.6.16' => {
-      'trapFormat' => 'SNMPv1',
-      'communityString' => 'public',
-      'severities' => ['Critical', 'Major', 'Unknown'],
-      'vcmTraps' => ['Legacy'],
-      'enetTraps' => ['PortStatus', 'PortThresholds'],
-      'fcTraps' => ['Other']
+    '172.18.6.16': {
+      trapFormat: 'SNMPv1',
+      communityString: 'public',
+      severities: ['Critical', 'Major', 'Unknown'],
+      vcmTraps: ['Legacy'],
+      enetTraps: ['PortStatus', 'PortThresholds'],
+      fcTraps: ['Other']
     }
   )
   action :update_snmp_configuration
@@ -120,8 +133,8 @@ end
 oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
   client my_client
   data(
-    'snmpConfiguration' => {
-      'snmpAccess' => []
+    snmpConfiguration: {
+      snmpAccess: []
     }
   )
   action :update_snmp_configuration
@@ -175,4 +188,34 @@ end
 oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
   client my_client
   action :update_from_group
+end
+
+# Example: Adds 'Encl1-LogicalInterconnectGroup1' to 'Scope1' and 'Scope2'
+oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
+  client my_client
+  scopes ['Scope1', 'Scope2']
+  action :add_to_scopes
+end
+
+# Example: Removes 'Encl1-LogicalInterconnectGroup1' from 'Scope1'
+oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
+  client my_client
+  scopes ['Scope1']
+  action :remove_from_scopes
+end
+
+# Example: Replaces 'Scope1' and 'Scope2' for 'Encl1-LogicalInterconnectGroup1'
+oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
+  client my_client
+  scopes ['Scope1', 'Scope2']
+  action :replace_scopes
+end
+
+# Example: Replaces all scopes to empty list of scopes
+oneview_logical_interconnect 'Encl1-LogicalInterconnectGroup1' do
+  client my_client
+  operation 'replace'
+  path '/scopeUris'
+  value []
+  action :patch
 end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -38,7 +38,7 @@ if defined?(ChefSpec)
     oneview_logical_interconnect:       %i[none add_interconnect remove_interconnect update_internal_networks update_settings
                                            update_ethernet_settings update_port_monitor update_qos_configuration update_telemetry_configuration
                                            update_snmp_configuration update_firmware stage_firmware activate_firmware update_from_group
-                                           reapply_configuration],
+                                           reapply_configuration] + scope_actions,
     oneview_logical_switch_group:       standard_actions + scope_actions,
     oneview_logical_switch:             standard_actions + scope_actions + %i[refresh],
     oneview_managed_san:                %i[refresh set_policy set_public_attributes],

--- a/libraries/oneview_helper.rb
+++ b/libraries/oneview_helper.rb
@@ -168,7 +168,11 @@ module OneviewCookbook
       return nil unless info
       support = {}
       info.each do |k, v|
-        con = convert_keys(v, conversion_method) if v && v.class == Hash
+        if v && v.class == Hash
+          con = convert_keys(v, conversion_method)
+        elsif v.class == Array
+          con = v.map { |h| convert_keys(h, conversion_method) } if v.any? { |value| value.class == Hash }
+        end
         support[k.public_send(conversion_method)] = con || v
       end
       support

--- a/libraries/oneview_helper.rb
+++ b/libraries/oneview_helper.rb
@@ -168,7 +168,7 @@ module OneviewCookbook
       return nil unless info
       support = {}
       info.each do |k, v|
-        if v && v.class == Hash
+        if v.class == Hash
           con = convert_keys(v, conversion_method)
         elsif v.class == Array
           con = v.map { |h| convert_keys(h, conversion_method) } if v.any? { |value| value.class == Hash }

--- a/libraries/resource_providers/api200/logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api200/logical_interconnect_provider.rb
@@ -38,7 +38,7 @@ module OneviewCookbook
       # Recursive helper method to set hash values
       def recursive_set(actual, updates)
         updates.each_pair do |k, v|
-          if v.respond_to?(:each_pair)
+          if v.respond_to?(:each_pair) && actual[k].respond_to?(:each_pair)
             recursive_set(actual[k], v)
           else
             actual[k] = v

--- a/libraries/resource_providers/api200/logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api200/logical_interconnect_provider.rb
@@ -82,17 +82,25 @@ module OneviewCookbook
         end
       end
 
+      def set_analyzer_port(param_name, data)
+        param_value = 'portUri' if param_name == 'uri'
+        param_value ||= param_name
+        port = @item.get_unassigned_uplink_ports_for_port_monitor.find { |k| k[param_name.to_s] == data[param_value.to_s] }
+        raise("Port with name or uri '#{data[param_value.to_s]}' was not found or is already being monitored!") unless port
+        data['portUri'] = port['uri']
+        data.delete('portName')
+        port
+      end
+
       def load_ports(item_to_update)
         port_monitor_attributes = convert_keys(@new_resource.port_monitor, :to_s)
-        enable_port_monitor = item_to_update['portMonitor']['enablePortMonitor'] if item_to_update['portMonitor'] && item_to_update['portMonitor']['enablePortMonitor']
+        enable_port_monitor = item_to_update['portMonitor']['enablePortMonitor'] if item_to_update['portMonitor']
         enable_port_monitor ||= port_monitor_attributes['enablePortMonitor']
         if enable_port_monitor
-          port = @item.get_unassigned_uplink_ports_for_port_monitor.select { |k| k['portName'] == port_monitor_attributes['analyzerPort']['portName'] }.first
-          raise("Port '#{port_monitor_attributes['analyzerPort']['portName']}' was not found or is already being monitored!") unless port
-          load_downlink_ports(port_monitor_attributes['monitoredPorts'], port['interconnectName'])
-          port_monitor_attributes['analyzerPort']['portUri'] = port['uri']
-          port_monitor_attributes['analyzerPort'].delete('portName')
-          port_monitor_attributes['monitoredPorts'].each { |k| k.delete('portName') }
+          port = nil
+          port = set_analyzer_port('uri', item_to_update['portMonitor']['analyzerPort']) if item_to_update['portMonitor'] && item_to_update['portMonitor']['analyzerPort']
+          port ||= set_analyzer_port('portName', port_monitor_attributes['analyzerPort'])
+          load_downlink_ports(port_monitor_attributes['monitoredPorts'], port['interconnectName']) unless item_to_update['portMonitor'] && item_to_update['portMonitor']['monitoredPorts']
         end
         temp = item_to_update['portMonitor'] || {}
         item_to_update['portMonitor'] = temp.merge(port_monitor_attributes)
@@ -102,8 +110,10 @@ module OneviewCookbook
         interconnect = load_resource(:Interconnect, interconnect_name)
         monitored_ports.each do |downlink|
           interconnect['ports'].each do |k|
-            downlink['portUri'] = k['uri'] if k['portName'] == downlink['portName']
-            break if downlink['portUri']
+            next unless k['portName'] == downlink['portName']
+            downlink['portUri'] = k['uri']
+            downlink.delete('portName')
+            break
           end
           raise("Downlink '#{downlink['portName']}' was not found or is already being monitored!") unless downlink['portUri']
         end
@@ -156,10 +166,10 @@ module OneviewCookbook
       end
 
       def update_port_monitor
-        temp = Marshal.load(Marshal.dump(@item.data))
+        new_data = Marshal.load(Marshal.dump(@item.data))
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-        load_ports(temp) if @new_resource.port_monitor.any?
-        @item.data = temp
+        load_ports(new_data) if @new_resource.port_monitor.any?
+        @item.data = new_data
         update_handler(:update_port_monitor, 'portMonitor')
       end
 

--- a/libraries/resource_providers/api500/c7000/logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api500/c7000/logical_interconnect_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module C7000
+      # LogicalInterconnect API500 C7000 provider
+      class LogicalInterconnectProvider < API300::C7000::LogicalInterconnectProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api500/synergy/logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api500/synergy/logical_interconnect_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module Synergy
+      # LogicalInterconnect API500 Synergy provider
+      class LogicalInterconnectProvider < API300::Synergy::LogicalInterconnectProvider
+      end
+    end
+  end
+end

--- a/resources/logical_interconnect.rb
+++ b/resources/logical_interconnect.rb
@@ -17,6 +17,7 @@ property :internal_networks, Array, default: []
 property :trap_destinations, Hash, default: {}
 property :firmware, String
 property :firmware_data, Hash, default: {}
+property :scopes, Array
 
 default_action :none
 
@@ -77,4 +78,20 @@ end
 
 action :reapply_configuration do
   OneviewCookbook::Helper.do_resource_action(self, :LogicalInterconnect, :reapply_configuration)
+end
+
+action :add_to_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :LogicalInterconnect, :add_to_scopes)
+end
+
+action :remove_from_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :LogicalInterconnect, :remove_from_scopes)
+end
+
+action :replace_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :LogicalInterconnect, :replace_scopes)
+end
+
+action :patch do
+  OneviewCookbook::Helper.do_resource_action(self, :LogicalInterconnect, :patch)
 end

--- a/resources/logical_interconnect.rb
+++ b/resources/logical_interconnect.rb
@@ -18,6 +18,7 @@ property :trap_destinations, Hash, default: {}
 property :firmware, String
 property :firmware_data, Hash, default: {}
 property :scopes, Array
+property :port_monitor, Hash, default: {}
 
 default_action :none
 

--- a/spec/fixtures/cookbooks/oneview_test/recipes/logical_interconnect_update_port_monitor.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/logical_interconnect_update_port_monitor.rb
@@ -18,14 +18,14 @@ oneview_logical_interconnect 'LogicalInterconnect-update_port_monitor' do
   client node['oneview_test']['client']
   port_monitor(
     analyzerPort: {
-      port_name: 'Q1:3',
+      portName: 'Q1:3',
       portMonitorConfigInfo: 'AnalyzerPort'
     },
     enablePortMonitor: true,
     type: 'port-monitor',
     monitoredPorts: [
       {
-        port_name: 'd1',
+        portName: 'd1',
         portMonitorConfigInfo: 'MonitoredBoth'
       }
     ]

--- a/spec/fixtures/cookbooks/oneview_test/recipes/logical_interconnect_update_port_monitor.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/logical_interconnect_update_port_monitor.rb
@@ -16,10 +16,19 @@
 
 oneview_logical_interconnect 'LogicalInterconnect-update_port_monitor' do
   client node['oneview_test']['client']
-  data(
-    'portMonitor' => {
-      'unit' => 'Test'
-    }
+  port_monitor(
+    analyzerPort: {
+      port_name: 'Q1:3',
+      portMonitorConfigInfo: 'AnalyzerPort'
+    },
+    enablePortMonitor: true,
+    type: 'port-monitor',
+    monitoredPorts: [
+      {
+        port_name: 'd1',
+        portMonitorConfigInfo: 'MonitoredBoth'
+      }
+    ]
   )
   action :update_port_monitor
 end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/logical_interconnect_update_port_monitor_data.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/logical_interconnect_update_port_monitor_data.rb
@@ -1,0 +1,36 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: logical_interconnect_update_port_monitor_data
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_logical_interconnect 'LogicalInterconnect-update_port_monitor_data' do
+  client node['oneview_test']['client']
+  data(
+    portMonitor: {
+      analyzerPort: {
+        portUri: '/rest/fake/Q1:3',
+        portMonitorConfigInfo: 'AnalyzerPort'
+      },
+      enablePortMonitor: true,
+      type: 'port-monitor',
+      monitoredPorts: [
+        {
+          portUri: '/rest/fake/d1',
+          portMonitorConfigInfo: 'MonitoredBoth'
+        }
+      ]
+    }
+  )
+  action :update_port_monitor
+end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/logical_interconnect_update_port_monitor_data_and_property.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/logical_interconnect_update_port_monitor_data_and_property.rb
@@ -1,0 +1,38 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: logical_interconnect_update_port_monitor_data_and_property
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_logical_interconnect 'LogicalInterconnect-update_port_monitor_data_and_property' do
+  client node['oneview_test']['client']
+  data(
+    portMonitor: {
+      analyzerPort: {
+        portUri: '/rest/fake/Q1:3',
+        portMonitorConfigInfo: 'AnalyzerPort'
+      },
+      enablePortMonitor: true,
+      type: 'port-monitor'
+    }
+  )
+  port_monitor(
+    monitoredPorts: [
+      {
+        portName: 'd1',
+        portMonitorConfigInfo: 'MonitoredBoth'
+      }
+    ]
+  )
+  action :update_port_monitor
+end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/logical_interconnect_add_to_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/logical_interconnect_add_to_scopes.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: logical_interconnect_add_to_scopes
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_logical_interconnect 'LogicalInterconnect1' do
+  client node['oneview_test']['client']
+  scopes ['Scope1', 'Scope2']
+  action :add_to_scopes
+end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/logical_interconnect_patch.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/logical_interconnect_patch.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: logical_interconnect_patch
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_logical_interconnect 'LogicalInterconnect1' do
+  client node['oneview_test']['client']
+  operation 'test'
+  path 'test/'
+  value 'TestMessage'
+  action :patch
+end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/logical_interconnect_remove_from_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/logical_interconnect_remove_from_scopes.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: logical_interconnect_remove_from_scopes
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_logical_interconnect 'LogicalInterconnect1' do
+  client node['oneview_test']['client']
+  scopes ['Scope1', 'Scope2']
+  action :remove_from_scopes
+end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/logical_interconnect_replace_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/logical_interconnect_replace_scopes.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: logical_interconnect_replace_scopes
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_logical_interconnect 'LogicalInterconnect1' do
+  client node['oneview_test']['client']
+  scopes ['Scope1', 'Scope2']
+  action :replace_scopes
+end

--- a/spec/unit/libraries/oneview_helper_spec.rb
+++ b/spec/unit/libraries/oneview_helper_spec.rb
@@ -269,6 +269,12 @@ RSpec.describe OneviewCookbook::Helper do
       expect(conv['a']).to eq(1)
     end
 
+    it 'converts an array of hash keys' do
+      array_hash = { hash: [{ a: 1, b: 2, c: 3 }] }
+      conv = described_class.convert_keys(array_hash, :to_s)
+      expect(conv).to eq('hash' => [{ 'a' => 1, 'b' => 2, 'c' => 3 }])
+    end
+
     it 'ignores empty hashes' do
       expect { described_class.convert_keys({}, :to_s) }.to_not raise_error
     end

--- a/spec/unit/resources/logical_interconnect/add_to_scopes_spec.rb
+++ b/spec/unit/resources/logical_interconnect/add_to_scopes_spec.rb
@@ -1,0 +1,11 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::logical_interconnect_add_to_scopes' do
+  let(:resource_name) { 'logical_interconnect' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API300::Synergy::LogicalInterconnect }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:add_oneview_logical_interconnect_to_scopes, 'LogicalInterconnect1'] }
+  it_behaves_like 'action :add_to_scopes'
+end

--- a/spec/unit/resources/logical_interconnect/patch_spec.rb
+++ b/spec/unit/resources/logical_interconnect/patch_spec.rb
@@ -1,0 +1,10 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::logical_interconnect_patch' do
+  let(:resource_name) { 'logical_interconnect' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API300::Synergy::LogicalInterconnect }
+  let(:target_match_method) { [:patch_oneview_logical_interconnect, 'LogicalInterconnect1'] }
+  it_behaves_like 'action :patch'
+end

--- a/spec/unit/resources/logical_interconnect/remove_from_scopes_spec.rb
+++ b/spec/unit/resources/logical_interconnect/remove_from_scopes_spec.rb
@@ -1,0 +1,11 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::logical_interconnect_remove_from_scopes' do
+  let(:resource_name) { 'logical_interconnect' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API300::Synergy::LogicalInterconnect }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:remove_oneview_logical_interconnect_from_scopes, 'LogicalInterconnect1'] }
+  it_behaves_like 'action :remove_from_scopes'
+end

--- a/spec/unit/resources/logical_interconnect/replace_scopes_spec.rb
+++ b/spec/unit/resources/logical_interconnect/replace_scopes_spec.rb
@@ -1,0 +1,11 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::logical_interconnect_replace_scopes' do
+  let(:resource_name) { 'logical_interconnect' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API300::Synergy::LogicalInterconnect }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:replace_oneview_logical_interconnect_scopes, 'LogicalInterconnect1'] }
+  it_behaves_like 'action :replace_scopes'
+end

--- a/spec/unit/resources/logical_interconnect/update_port_monitor_spec.rb
+++ b/spec/unit/resources/logical_interconnect/update_port_monitor_spec.rb
@@ -7,7 +7,7 @@ describe 'oneview_test::logical_interconnect_update_port_monitor' do
 
   let(:provider) { OneviewCookbook::API200::LogicalInterconnectProvider }
   let(:interconnect_name) { 'interconnect1' }
-  let(:unassigned_uplink_ports) { [{ 'portName' => 'Q1:3', 'uri' => 'rest/fake/Q1:3', 'interconnectName' => interconnect_name }] }
+  let(:unassigned_uplink_ports) { [{ 'portName' => 'Q1:3', 'uri' => '/rest/fake/Q1:3', 'interconnectName' => interconnect_name }] }
   let(:interconnect) { OneviewSDK::Interconnect.new(@client, ports: [{ 'portName' => 'd1', 'uri' => '/rest/d1' }]) }
 
   # Mocks the update_handler
@@ -28,7 +28,7 @@ describe 'oneview_test::logical_interconnect_update_port_monitor' do
   it 'fails when port is not found' do
     allow_any_instance_of(OneviewSDK::LogicalInterconnect)
       .to receive(:get_unassigned_uplink_ports_for_port_monitor).and_return([])
-    expect { real_chef_run }.to raise_error(RuntimeError, /Port 'Q1:3' was not found or is already being monitored/)
+    expect { real_chef_run }.to raise_error(RuntimeError, /Port with name or uri 'Q1:3' was not found or is already being monitored/)
   end
 
   it 'fails when downlink port is not found' do
@@ -59,5 +59,31 @@ describe 'oneview_test::logical_interconnect_update_port_monitor_data' do
   it 'updates port monitor configurations passing the parameters in data' do
     expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:update_port_monitor).and_return(true)
     expect(real_chef_run).to update_oneview_logical_interconnect_port_monitor('LogicalInterconnect-update_port_monitor_data')
+  end
+end
+
+describe 'oneview_test::logical_interconnect_update_port_monitor_data_and_property' do
+  let(:resource_name) { 'logical_interconnect' }
+  include_context 'chef context'
+  include_context 'shared context'
+
+  let(:provider) { OneviewCookbook::API200::LogicalInterconnectProvider }
+  let(:interconnect_name) { 'interconnect1' }
+  let(:unassigned_uplink_ports) { [{ 'uri' => '/rest/fake/Q1:3', 'interconnectName' => interconnect_name }] }
+  let(:interconnect) { OneviewSDK::Interconnect.new(@client, ports: [{ 'portName' => 'd1', 'uri' => '/rest/d1' }]) }
+
+  # Mocks the update_handler
+  before(:each) do
+    allow_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:exists?).and_return(true)
+    allow_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:like?).and_return(false)
+  end
+
+  it 'updates port monitor configurations passing the parameters in data' do
+    allow_any_instance_of(OneviewSDK::LogicalInterconnect)
+      .to receive(:get_unassigned_uplink_ports_for_port_monitor).and_return(unassigned_uplink_ports)
+    allow_any_instance_of(provider).to receive(:load_resource).with(:Interconnect, interconnect_name).and_return(interconnect)
+    expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:update_port_monitor).and_return(true)
+    expect(real_chef_run).to update_oneview_logical_interconnect_port_monitor('LogicalInterconnect-update_port_monitor_data_and_property')
   end
 end

--- a/spec/unit/resources/logical_interconnect/update_port_monitor_spec.rb
+++ b/spec/unit/resources/logical_interconnect/update_port_monitor_spec.rb
@@ -5,9 +5,10 @@ describe 'oneview_test::logical_interconnect_update_port_monitor' do
   include_context 'chef context'
   include_context 'shared context'
 
+  let(:provider) { OneviewCookbook::API200::LogicalInterconnectProvider }
   let(:interconnect_name) { 'interconnect1' }
   let(:unassigned_uplink_ports) { [{ 'portName' => 'Q1:3', 'uri' => 'rest/fake/Q1:3', 'interconnectName' => interconnect_name }] }
-  let(:interconnect) { [OneviewSDK::Interconnect.new(@client, ports: [{ 'portName' => 'd1', 'uri' => '/rest/d1' }])] }
+  let(:interconnect) { OneviewSDK::Interconnect.new(@client, ports: [{ 'portName' => 'd1', 'uri' => '/rest/d1' }]) }
 
   # Mocks the update_handler
   before(:each) do
@@ -19,8 +20,7 @@ describe 'oneview_test::logical_interconnect_update_port_monitor' do
   it 'updates port monitor configurations' do
     allow_any_instance_of(OneviewSDK::LogicalInterconnect)
       .to receive(:get_unassigned_uplink_ports_for_port_monitor).and_return(unassigned_uplink_ports)
-    allow(OneviewSDK::Interconnect).to receive(:find_by)
-      .with(instance_of(OneviewSDK::Client), name: interconnect_name).and_return(interconnect)
+    allow_any_instance_of(provider).to receive(:load_resource).with(:Interconnect, interconnect_name).and_return(interconnect)
     expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:update_port_monitor).and_return(true)
     expect(real_chef_run).to update_oneview_logical_interconnect_port_monitor('LogicalInterconnect-update_port_monitor')
   end
@@ -34,12 +34,30 @@ describe 'oneview_test::logical_interconnect_update_port_monitor' do
   it 'fails when downlink port is not found' do
     allow_any_instance_of(OneviewSDK::LogicalInterconnect)
       .to receive(:get_unassigned_uplink_ports_for_port_monitor).and_return(unassigned_uplink_ports)
-    allow(OneviewSDK::Interconnect).to receive(:find_by).and_return([OneviewSDK::Interconnect.new(@client, ports: [])])
+    allow_any_instance_of(provider).to receive(:load_resource)
+      .with(:Interconnect, interconnect_name).and_return(OneviewSDK::Interconnect.new(@client, ports: []))
     expect { real_chef_run }.to raise_error(RuntimeError, /Downlink 'd1' was not found or is already being monitored/)
   end
 
   it 'fails if the resource is not found' do
     expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:retrieve!).and_return(false)
     expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
+end
+
+describe 'oneview_test::logical_interconnect_update_port_monitor_data' do
+  let(:resource_name) { 'logical_interconnect' }
+  include_context 'chef context'
+
+  # Mocks the update_handler
+  before(:each) do
+    allow_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:exists?).and_return(true)
+    allow_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:like?).and_return(false)
+  end
+
+  it 'updates port monitor configurations passing the parameters in data' do
+    expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:update_port_monitor).and_return(true)
+    expect(real_chef_run).to update_oneview_logical_interconnect_port_monitor('LogicalInterconnect-update_port_monitor_data')
   end
 end

--- a/spec/unit/resources/logical_interconnect/update_port_monitor_spec.rb
+++ b/spec/unit/resources/logical_interconnect/update_port_monitor_spec.rb
@@ -3,6 +3,11 @@ require_relative './../../../spec_helper'
 describe 'oneview_test::logical_interconnect_update_port_monitor' do
   let(:resource_name) { 'logical_interconnect' }
   include_context 'chef context'
+  include_context 'shared context'
+
+  let(:interconnect_name) { 'interconnect1' }
+  let(:unassigned_uplink_ports) { [{ 'portName' => 'Q1:3', 'uri' => 'rest/fake/Q1:3', 'interconnectName' => interconnect_name }] }
+  let(:interconnect) { [OneviewSDK::Interconnect.new(@client, ports: [{ 'portName' => 'd1', 'uri' => '/rest/d1' }])] }
 
   # Mocks the update_handler
   before(:each) do
@@ -12,7 +17,29 @@ describe 'oneview_test::logical_interconnect_update_port_monitor' do
   end
 
   it 'updates port monitor configurations' do
+    allow_any_instance_of(OneviewSDK::LogicalInterconnect)
+      .to receive(:get_unassigned_uplink_ports_for_port_monitor).and_return(unassigned_uplink_ports)
+    allow(OneviewSDK::Interconnect).to receive(:find_by)
+      .with(instance_of(OneviewSDK::Client), name: interconnect_name).and_return(interconnect)
     expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:update_port_monitor).and_return(true)
     expect(real_chef_run).to update_oneview_logical_interconnect_port_monitor('LogicalInterconnect-update_port_monitor')
+  end
+
+  it 'fails when port is not found' do
+    allow_any_instance_of(OneviewSDK::LogicalInterconnect)
+      .to receive(:get_unassigned_uplink_ports_for_port_monitor).and_return([])
+    expect { real_chef_run }.to raise_error(RuntimeError, /Port 'Q1:3' was not found or is already being monitored/)
+  end
+
+  it 'fails when downlink port is not found' do
+    allow_any_instance_of(OneviewSDK::LogicalInterconnect)
+      .to receive(:get_unassigned_uplink_ports_for_port_monitor).and_return(unassigned_uplink_ports)
+    allow(OneviewSDK::Interconnect).to receive(:find_by).and_return([OneviewSDK::Interconnect.new(@client, ports: [])])
+    expect { real_chef_run }.to raise_error(RuntimeError, /Downlink 'd1' was not found or is already being monitored/)
+  end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 end

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -122,6 +122,10 @@ describe 'oneview_test::default' do
     expect(chef_run).to_not update_oneview_logical_interconnect_settings('')
     expect(chef_run).to_not update_oneview_logical_interconnect_snmp_configuration('')
     expect(chef_run).to_not update_oneview_logical_interconnect_telemetry_configuration('')
+    expect(chef_run).to_not add_oneview_logical_interconnect_to_scopes('')
+    expect(chef_run).to_not remove_oneview_logical_interconnect_from_scopes('')
+    expect(chef_run).to_not replace_oneview_logical_interconnect_scopes('')
+    expect(chef_run).to_not patch_oneview_logical_interconnect('')
 
     # oneview_logical_interconnect_group
     expect(chef_run).to_not create_oneview_logical_interconnect_group('')


### PR DESCRIPTION
### Description
Adding Logical Interconnect for HPE OneView API500 support.

### Issues Resolved
N/A

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
