### PR TITLE
API 500 Support for Server Hardware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Adds API 500 support to the following HPE OneView resources:
   - oneview_sas_interconnect
   - oneview_sas_logical_interconnect_group
   - oneview_scope
+  - oneview_server_hardware
   - oneview_server_hardware_type
   - oneview_server_profile
   - oneview_storage_pool

--- a/README.md
+++ b/README.md
@@ -736,7 +736,9 @@ oneview_server_hardware 'ServerHardware1' do
   operation <op>          # String. Used in patch action only. e.g., 'replace'
   path <path>             # String. Used in patch option only. e.g., '/name'
   value <val>             # String. Used in patch option only. e.g., 'New Name'
-  action [:add_if_missing, :remove, :refresh, :set_power_state, :update_ilo_firmware, :patch]
+  scopes <scope_names>    # Array - Optional. Array of scope names. Used in add_to_scopes, remove_from_scopes or replace_scopes options only. e.g., ['Scope1', 'Scope2']
+  action [:add_if_missing, :remove, :refresh, :set_power_state, :update_ilo_firmware, :patch,
+          :add_to_scopes, :remove_from_scopes, :replace_scopes]
 end
 ```
 

--- a/examples/server_hardware.rb
+++ b/examples/server_hardware.rb
@@ -9,10 +9,14 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+# NOTE 1: This example requires two Scopes named "Scope1" and "Scope2" to be present in the appliance.
+# NOTE 2: The api_version client should be 300 or greater if you run the examples using Scopes
+
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
   user: ENV['ONEVIEWSDK_USER'],
-  password: ENV['ONEVIEWSDK_PASSWORD']
+  password: ENV['ONEVIEWSDK_PASSWORD'],
+  api_version: 300
 }
 
 # Example: Add server hardware to OneView for management
@@ -60,12 +64,33 @@ oneview_server_hardware '172.18.6.4' do
   action :update_ilo_firmware
 end
 
-# Example: Add the Scope with URI /rest/scopes/3b292baf-8b59-4671-9e5c-deca07496c60 to ServerHardware1
-oneview_server_hardware 'ServerHardware1' do
+# Example: Adds '172.18.6.4' to 'Scope1' and 'Scope2'
+oneview_server_hardware '172.18.6.4' do
   client my_client
-  operation 'add'
-  path '/scopeUris/-'
-  value '/rest/scopes/3b292baf-8b59-4671-9e5c-deca07496c60'
+  scopes ['Scope1', 'Scope2']
+  action :add_to_scopes
+end
+
+# Example: Removes '172.18.6.4' from 'Scope1'
+oneview_server_hardware '172.18.6.4' do
+  client my_client
+  scopes ['Scope1']
+  action :remove_from_scopes
+end
+
+# Example: Replaces 'Scope1' and 'Scope2' for '172.18.6.4'
+oneview_server_hardware '172.18.6.4' do
+  client my_client
+  scopes ['Scope1', 'Scope2']
+  action :replace_scopes
+end
+
+# Example: Replaces all scopes to empty list of scopes
+oneview_server_hardware '172.18.6.4' do
+  client my_client
+  operation 'replace'
+  path '/scopeUris'
+  value []
   action :patch
 end
 

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -50,7 +50,7 @@ if defined?(ChefSpec)
     oneview_sas_interconnect:           %i[reset hard_reset patch refresh set_uid_light set_power_state],
     oneview_sas_logical_interconnect_group: standard_actions,
     oneview_scope:                      standard_actions + [:change_resource_assignments],
-    oneview_server_hardware:            %i[add_if_missing remove refresh set_power_state update_ilo_firmware patch],
+    oneview_server_hardware:            %i[add_if_missing remove refresh set_power_state update_ilo_firmware] + scope_actions,
     oneview_server_hardware_type:       %i[edit remove],
     oneview_server_profile_template:    standard_actions + [:new_profile],
     oneview_server_profile:             standard_actions + [:update_from_template],

--- a/libraries/resource_providers/api200/enclosure_provider.rb
+++ b/libraries/resource_providers/api200/enclosure_provider.rb
@@ -13,6 +13,7 @@ module OneviewCookbook
   module API200
     # Enclosure API200 provider
     class EnclosureProvider < ResourceProvider
+      include OneviewCookbook::RefreshActions::SetRefreshState
       def add_or_edit
         if @new_resource.enclosure_group
           eg = resource_named(:EnclosureGroup).new(@item.client, name: @new_resource.enclosure_group)
@@ -29,15 +30,6 @@ module OneviewCookbook
           end
         else
           Chef::Log.info("#{@resource_name} '#{@name}' configuration is already running. State: #{@item['reconfigurationState']}")
-        end
-      end
-
-      def refresh
-        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-        refresh_ready = ['RefreshFailed', 'NotRefreshing', ''].include? @item['refreshState']
-        return Chef::Log.info("#{@resource_name} '#{@name}' refresh is already running. State: #{@item['refreshState']}") unless refresh_ready
-        @context.converge_by "#{@resource_name} '#{@name}' was refreshed." do
-          @item.set_refresh_state(@new_resource.refresh_state, @new_resource.options)
         end
       end
     end

--- a/libraries/resource_providers/api200/server_hardware_provider.rb
+++ b/libraries/resource_providers/api200/server_hardware_provider.rb
@@ -13,6 +13,7 @@ module OneviewCookbook
   module API200
     # ServerHardware API200 provider
     class ServerHardwareProvider < ResourceProvider
+      include OneviewCookbook::RefreshActions::SetRefreshState
       def update_ilo_firmware
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
         @context.converge_by "Updated iLO firmware on #{@resource_name} '#{@name}'" do
@@ -30,15 +31,6 @@ module OneviewCookbook
           @context.converge_by "Power #{ps} #{@resource_name} '#{@name}'" do
             @item.public_send("power_#{ps}".to_sym)
           end
-        end
-      end
-
-      def refresh
-        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-        refresh_ready = ['RefreshFailed', 'NotRefreshing', ''].include? @item['refreshState']
-        return Chef::Log.info("#{@resource_name} '#{@name}' refresh is already running.") unless refresh_ready
-        @context.converge_by "Refresh #{@resource_name} '#{@name}'." do
-          @item.set_refresh_state('RefreshPending', @new_resource.refresh_options)
         end
       end
     end

--- a/libraries/resource_providers/api500/c7000/server_hardware_provider.rb
+++ b/libraries/resource_providers/api500/c7000/server_hardware_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module C7000
+      # ServerHardware API500 C7000 provider
+      class ServerHardwareProvider < API300::C7000::ServerHardwareProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api500/synergy/server_hardware_provider.rb
+++ b/libraries/resource_providers/api500/synergy/server_hardware_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module Synergy
+      # ServerHardware API500 Synergy provider
+      class ServerHardwareProvider < API300::Synergy::ServerHardwareProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/helpers/refresh_actions.rb
+++ b/libraries/resource_providers/helpers/refresh_actions.rb
@@ -21,7 +21,11 @@ module OneviewCookbook
         state_value = @new_resource.refresh_state if @new_resource.respond_to?(:refresh_state)
         state_value ||= 'RefreshPending'
         @context.converge_by "#{@resource_name} '#{@name}' was refreshed." do
-          @item.set_refresh_state(state_value)
+          if @new_resource.respond_to?(:refresh_options)
+            @item.set_refresh_state(state_value, @new_resource.refresh_options)
+          else
+            @item.set_refresh_state(state_value)
+          end
         end
       end
     end

--- a/resources/server_hardware.rb
+++ b/resources/server_hardware.rb
@@ -13,6 +13,7 @@ OneviewCookbook::ResourceBaseProperties.load(self)
 
 property :power_state, [String, Symbol], regex: /^(on|off)$/i # Used in :set_power_state action only
 property :refresh_options, Hash, default: {}                  # Used in :refresh action only
+property :scopes, Array                                       # Used in :add_to_scopes, :remove_from_scopes and :replace_scopes actions only
 
 default_action :add_if_missing
 
@@ -38,4 +39,16 @@ end
 
 action :patch do
   OneviewCookbook::Helper.do_resource_action(self, :ServerHardware, :patch)
+end
+
+action :add_to_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :ServerHardware, :add_to_scopes)
+end
+
+action :remove_from_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :ServerHardware, :remove_from_scopes)
+end
+
+action :replace_scopes do
+  OneviewCookbook::Helper.do_resource_action(self, :ServerHardware, :replace_scopes)
 end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/server_hardware_add_to_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/server_hardware_add_to_scopes.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: server_hardware_add_to_scopes
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_server_hardware 'ServerHardware1' do
+  client node['oneview_test']['client']
+  scopes ['Scope1', 'Scope2']
+  action :add_to_scopes
+end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/server_hardware_remove_from_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/server_hardware_remove_from_scopes.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: server_remove_from_scopes
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_server_hardware 'ServerHardware1' do
+  client node['oneview_test']['client']
+  scopes ['Scope1', 'Scope2']
+  action :remove_from_scopes
+end

--- a/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/server_hardware_replace_scopes.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api300_synergy/recipes/server_hardware_replace_scopes.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: oneview_test_api300_synergy
+# Recipe:: server_hardware_replace_scopes
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_server_hardware 'ServerHardware1' do
+  client node['oneview_test']['client']
+  scopes ['Scope1', 'Scope2']
+  action :replace_scopes
+end

--- a/spec/unit/resources/enclosure/refresh_spec.rb
+++ b/spec/unit/resources/enclosure/refresh_spec.rb
@@ -4,28 +4,7 @@ describe 'oneview_test::enclosure_refresh' do
   let(:resource_name) { 'enclosure' }
   include_context 'chef context'
 
-  it 'refresh enclosure already triggered' do
-    expect_any_instance_of(OneviewSDK::Enclosure).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::Enclosure).to receive(:[]).with('refreshState')
-                                                                .and_return('RefreshPending')
-    allow_any_instance_of(OneviewSDK::Enclosure).to receive(:[]).with('name')
-                                                                .and_return('Enclosure1')
-    expect_any_instance_of(OneviewSDK::Enclosure).to_not receive(:set_refresh_state)
-    expect(real_chef_run).to refresh_oneview_enclosure('Enclosure1')
-  end
-
-  it 'refresh enclosure with default options' do
-    expect_any_instance_of(OneviewSDK::Enclosure).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::Enclosure).to receive(:[]).with('refreshState')
-                                                                .and_return('NotRefreshing')
-    allow_any_instance_of(OneviewSDK::Enclosure).to receive(:[]).with('name')
-                                                                .and_return('Enclosure1')
-    expect_any_instance_of(OneviewSDK::Enclosure).to receive(:set_refresh_state).and_return(true)
-    expect(real_chef_run).to refresh_oneview_enclosure('Enclosure1')
-  end
-
-  it 'fails if the resource is not found' do
-    expect_any_instance_of(OneviewSDK::Enclosure).to receive(:retrieve!).and_return(false)
-    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
-  end
+  let(:target_class) { OneviewSDK::Enclosure }
+  let(:target_match_method) { [:refresh_oneview_enclosure, 'Enclosure1'] }
+  it_behaves_like 'action :refresh #set_refresh_state'
 end

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -220,6 +220,9 @@ describe 'oneview_test::default' do
     expect(chef_run).to_not set_oneview_server_hardware_power_state('')
     expect(chef_run).to_not update_oneview_server_hardware_ilo_firmware('')
     expect(chef_run).to_not patch_oneview_server_hardware('')
+    expect(chef_run).to_not add_oneview_server_hardware_to_scopes('')
+    expect(chef_run).to_not remove_oneview_server_hardware_from_scopes('')
+    expect(chef_run).to_not replace_oneview_server_hardware_scopes('')
 
     # oneview_server_hardware_type
     expect(chef_run).to_not edit_oneview_server_hardware_type('')

--- a/spec/unit/resources/server_hardware/add_to_scopes_spec.rb
+++ b/spec/unit/resources/server_hardware/add_to_scopes_spec.rb
@@ -1,0 +1,11 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::server_hardware_add_to_scopes' do
+  let(:resource_name) { 'server_hardware' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API300::Synergy::ServerHardware }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:add_oneview_server_hardware_to_scopes, 'ServerHardware1'] }
+  it_behaves_like 'action :add_to_scopes'
+end

--- a/spec/unit/resources/server_hardware/patch_spec.rb
+++ b/spec/unit/resources/server_hardware/patch_spec.rb
@@ -4,9 +4,7 @@ describe 'oneview_test_api300_synergy::server_hardware_patch' do
   let(:resource_name) { 'server_hardware' }
   include_context 'chef context'
 
-  it 'performs patch operation' do
-    expect_any_instance_of(OneviewSDK::API300::Synergy::ServerHardware).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::API300::Synergy::ServerHardware).to receive(:patch).with('test', 'test/', 'TestMessage').and_return(true)
-    expect(real_chef_run).to patch_oneview_server_hardware('ServerHardware1')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::ServerHardware }
+  let(:target_match_method) { [:patch_oneview_server_hardware, 'ServerHardware1'] }
+  it_behaves_like 'action :patch'
 end

--- a/spec/unit/resources/server_hardware/refresh_spec.rb
+++ b/spec/unit/resources/server_hardware/refresh_spec.rb
@@ -4,23 +4,7 @@ describe 'oneview_test::server_hardware_refresh' do
   let(:resource_name) { 'server_hardware' }
   include_context 'chef context'
 
-  it 'refresh server hardware already triggered' do
-    expect_any_instance_of(OneviewSDK::ServerHardware).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::ServerHardware).to receive(:[]).with('refreshState')
-                                                                     .and_return('RefreshPending')
-    allow_any_instance_of(OneviewSDK::ServerHardware).to receive(:[]).with('name')
-                                                                     .and_return('ServerHardware1')
-    expect_any_instance_of(OneviewSDK::ServerHardware).to_not receive(:set_refresh_state)
-    expect(real_chef_run).to refresh_oneview_server_hardware('ServerHardware1')
-  end
-
-  it 'refresh server hardware with default options' do
-    expect_any_instance_of(OneviewSDK::ServerHardware).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::ServerHardware).to receive(:[]).with('refreshState')
-                                                                     .and_return('NotRefreshing')
-    allow_any_instance_of(OneviewSDK::ServerHardware).to receive(:[]).with('name')
-                                                                     .and_return('ServerHardware1')
-    expect_any_instance_of(OneviewSDK::ServerHardware).to receive(:set_refresh_state).and_return(true)
-    expect(real_chef_run).to refresh_oneview_server_hardware('ServerHardware1')
-  end
+  let(:target_class) { OneviewSDK::ServerHardware }
+  let(:target_match_method) { [:refresh_oneview_server_hardware, 'ServerHardware1'] }
+  it_behaves_like 'action :refresh #set_refresh_state'
 end

--- a/spec/unit/resources/server_hardware/remove_from_scopes_spec.rb
+++ b/spec/unit/resources/server_hardware/remove_from_scopes_spec.rb
@@ -1,0 +1,11 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::server_hardware_remove_from_scopes' do
+  let(:resource_name) { 'server_hardware' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API300::Synergy::ServerHardware }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:remove_oneview_server_hardware_from_scopes, 'ServerHardware1'] }
+  it_behaves_like 'action :remove_from_scopes'
+end

--- a/spec/unit/resources/server_hardware/replace_scopes_spec.rb
+++ b/spec/unit/resources/server_hardware/replace_scopes_spec.rb
@@ -1,0 +1,11 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api300_synergy::server_hardware_replace_scopes' do
+  let(:resource_name) { 'server_hardware' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API300::Synergy::ServerHardware }
+  let(:scope_class) { OneviewSDK::API300::Synergy::Scope }
+  let(:target_match_method) { [:replace_oneview_server_hardware_scopes, 'ServerHardware1'] }
+  it_behaves_like 'action :replace_scopes'
+end

--- a/spec/unit/shared_examples/add_to_scopes.rb
+++ b/spec/unit/shared_examples/add_to_scopes.rb
@@ -10,9 +10,9 @@
 # specific language governing permissions and limitations under the License.
 
 # NOTE:
-# This shared examples needs of below variables:
-#  target_class - The full name of Oneview resource target of the test
-#  scope_class - The full name of Oneview Scope resource used in the test
+# This shared example requires the following variables:
+#  target_class - Full name of the OneView resource to be tested
+#  scope_class -  Full name of Oneview Scope resource used in the test
 #  target_match_method - Array with name of match method called and with the argument of the match method,
 #    e.g: let(:target_match_method) { [:add_oneview_enclosure_to_scopes, 'EnclosureName'] }
 

--- a/spec/unit/shared_examples/patch.rb
+++ b/spec/unit/shared_examples/patch.rb
@@ -10,8 +10,8 @@
 # specific language governing permissions and limitations under the License.
 
 # NOTE:
-# This shared examples needs of below variables:
-#  target_class - The full name of Oneview resource target of the test
+# This shared example requires the following variables:
+#  target_class - Full name of the OneView resource to be tested
 #  target_match_method - Array with name of match method called and with the argument of the match method,
 #    e.g: let(:target_match_method) { [:add_oneview_enclosure_to_scopes, 'EnclosureName'] }
 

--- a/spec/unit/shared_examples/refresh_request_refresh.rb
+++ b/spec/unit/shared_examples/refresh_request_refresh.rb
@@ -10,8 +10,8 @@
 # specific language governing permissions and limitations under the License.
 
 # NOTE:
-# This shared examples needs of below variables:
-#  target_class - The full name of Oneview resource target of the test
+# This shared example requires the following variables:
+#  target_class - Full name of the OneView resource to be tested
 #  target_match_method - Array with name of match method called and with the argument of the match method,
 #    e.g: let(:target_match_method) { [:add_oneview_enclosure_to_scopes, 'EnclosureName'] }
 

--- a/spec/unit/shared_examples/remove_from_scopes.rb
+++ b/spec/unit/shared_examples/remove_from_scopes.rb
@@ -10,9 +10,9 @@
 # specific language governing permissions and limitations under the License.
 
 # NOTE:
-# This shared examples needs of below variables:
-#  target_class - The full name of Oneview resource target of the test
-#  scope_class - The full name of Oneview Scope resource used in the test
+# This shared example requires the following variables:
+#  target_class - Full name of the OneView resource to be tested
+#  scope_class - Full name of Oneview Scope resource used in the test
 #  target_match_method - Array with name of match method called and with the argument of the match method,
 #    e.g: let(:target_match_method) { [:add_oneview_enclosure_to_scopes, 'EnclosureName'] }
 

--- a/spec/unit/shared_examples/replace_scopes.rb
+++ b/spec/unit/shared_examples/replace_scopes.rb
@@ -10,9 +10,9 @@
 # specific language governing permissions and limitations under the License.
 
 # NOTE:
-# This shared examples needs of below variables:
-#  target_class - The full name of Oneview resource target of the test
-#  scope_class - The full name of Oneview Scope resource used in the test
+# This shared example requires the following variables:
+#  target_class - Full name of the OneView resource to be tested
+#  scope_class - Full name of Oneview Scope resource used in the test
 #  target_match_method - Array with name of match method called and with the argument of the match method,
 #    e.g: let(:target_match_method) { [:add_oneview_enclosure_to_scopes, 'EnclosureName'] }
 

--- a/spec/unit/shared_examples/reset_connection_template.rb
+++ b/spec/unit/shared_examples/reset_connection_template.rb
@@ -10,9 +10,9 @@
 # specific language governing permissions and limitations under the License.
 
 # NOTE:
-# This shared examples needs of below variables:
-#  target_class - The full name of Oneview resource target of the test
-#  connection_template_class - The full name of Oneview ConnectionTemplate resource used in the test
+# This shared example requires the following variables:
+#  target_class - Full name of the OneView resource to be tested
+#  connection_template_class - Full name of Oneview ConnectionTemplate resource used in the test
 #  target_match_method - Array with name of match method called and with the argument of the match method,
 #    e.g: let(:target_match_method) { [:reset_oneview_ethernet_network_connection_template, 'EthernetNetworkName'] }
 

--- a/spec/unit/shared_examples/set_refresh_state.rb
+++ b/spec/unit/shared_examples/set_refresh_state.rb
@@ -1,0 +1,40 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# NOTE:
+# This shared examples needs of below variables:
+#  target_class - The full name of Oneview resource target of the test
+#  target_match_method - Array with name of match method called and with the argument of the match method,
+#    e.g: let(:target_match_method) { [:add_oneview_enclosure_to_scopes, 'EnclosureName'] }
+
+RSpec.shared_examples 'action :refresh #set_refresh_state' do
+  it 'refresh already triggered' do
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(target_class).to receive(:[]).with('refreshState').and_return('RefreshPending')
+    allow_any_instance_of(target_class).to receive(:[]).with('name').and_return(*target_match_method)
+    expect_any_instance_of(target_class).to_not receive(:set_refresh_state)
+    expect(real_chef_run).to send(*target_match_method)
+  end
+
+  it 'refresh with default options' do
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(target_class).to receive(:[]).with('refreshState').and_return('NotRefreshing')
+    allow_any_instance_of(target_class).to receive(:[]).with('name').and_return(*target_match_method)
+    expect_any_instance_of(target_class).to receive(:set_refresh_state).and_return(true)
+    expect(real_chef_run).to send(*target_match_method)
+  end
+
+  it 'raises an error when it does not exist' do
+    allow_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
+    expect_any_instance_of(target_class).to_not receive(:set_refresh_state)
+    expect { real_chef_run }.to raise_error(StandardError, /not found/)
+  end
+end

--- a/spec/unit/shared_examples/set_refresh_state.rb
+++ b/spec/unit/shared_examples/set_refresh_state.rb
@@ -10,8 +10,8 @@
 # specific language governing permissions and limitations under the License.
 
 # NOTE:
-# This shared examples needs of below variables:
-#  target_class - The full name of Oneview resource target of the test
+# This shared example requires the following variables:
+#  target_class - Full name of the OneView resource to be tested
 #  target_match_method - Array with name of match method called and with the argument of the match method,
 #    e.g: let(:target_match_method) { [:add_oneview_enclosure_to_scopes, 'EnclosureName'] }
 


### PR DESCRIPTION
### Description
Adding Server Hardware for HPE OneView API500 support.

### Issues Resolved
N/A

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
