### PR TITLE
Support Server Profile Templates in API500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Adds API 500 support to the following HPE OneView resources:
   - oneview_scope
   - oneview_server_hardware_type
   - oneview_server_profile
+  - oneview_server_profile_template
   - oneview_storage_pool
   - oneview_storage_system
   - oneview_switch

--- a/README.md
+++ b/README.md
@@ -765,6 +765,7 @@ oneview_server_profile_template 'ServerProfileTemplate1' do
   fc_network_connections <fc_network_connections_data>
   network_set_connections <network_set_connections_data>
   server_profile_name <profile_name>  # String - Optional. In :new_profile action represents the name of the Server Profile to created. In create/create_if_missing is the name of the Server Profile be used as base for the Server Profile Template. Only available on API500 and onwards to be used as base.
+  os_deployment_plan <os_deployment_plan_name>
   action [:create, :create_if_missing, :delete, :new_profile]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -764,7 +764,7 @@ oneview_server_profile_template 'ServerProfileTemplate1' do
   ethernet_network_connections <ethernet_network_connections_data>
   fc_network_connections <fc_network_connections_data>
   network_set_connections <network_set_connections_data>
-  profile_name <profile_name>
+  server_profile_name <profile_name>  # String - Optional. In :new_profile action represents the name of the Server Profile to created. In create/create_if_missing is the name of the Server Profile be used as base for the Server Profile Template. Only available on API500 and onwards to be used as base.
   action [:create, :create_if_missing, :delete, :new_profile]
 end
 ```

--- a/examples/server_profile_template.rb
+++ b/examples/server_profile_template.rb
@@ -15,30 +15,46 @@ my_client = {
   password: ENV['ONEVIEWSDK_PASSWORD']
 }
 
+enclosure_group = 'eg1'
+server_hardware_type = 'SY 480 Gen9 2'
+sp_name = 'sp1'
+
 # Creates on server profile template with the desired Enclosure group and Server hardware type
 oneview_server_profile_template 'ServerProfileTemplate1' do
   client my_client
-  enclosure_group 'EnclosureGroup1'
-  server_hardware_type 'DL360 Gen8 1'
+  enclosure_group enclosure_group
+  server_hardware_type server_hardware_type
 end
 
 # Creates on server profile template with the desired Enclosure group and Server hardware type
 oneview_server_profile_template 'ServerProfileTemplate1' do
   client my_client
-  enclosure_group 'EnclosureGroup1'
-  server_hardware_type 'DL360 Gen8 1'
+  enclosure_group enclosure_group
+  server_hardware_type server_hardware_type
   action :create_if_missing
 end
 
-# Deletes server profile 'ServerProfile2'
-oneview_server_profile 'ServerProfileTemplate1' do
+# Creates a server profile template using the server profile 'sp1' as a template
+oneview_server_profile_template 'ServerProfileTemplate2' do
+  client my_client
+  server_profile_name sp_name
+end
+
+# Deletes server profile 'ServerProfileTemplate1'
+oneview_server_profile_template 'ServerProfileTemplate1' do
   client my_client
   action :delete
 end
 
-# Creates a server profile from 'ServerProfileTemplate1'
-oneview_server_profile 'ServerProfileTemplate1' do
+# Deletes server profile 'ServerProfileTemplate2'
+oneview_server_profile_template 'ServerProfileTemplate2' do
   client my_client
-  profile_name 'ServerProfile1'
+  action :delete
+end
+
+# Creates a new Server Profile based on a Server Profile Template
+oneview_server_profile_template 'ServerProfileTemplate1' do
+  client my_client
   action :new_profile
+  server_profile_name 'ServerProfile1'
 end

--- a/libraries/resource_providers/api200/server_profile_template_provider.rb
+++ b/libraries/resource_providers/api200/server_profile_template_provider.rb
@@ -37,9 +37,9 @@ module OneviewCookbook
       end
 
       def new_profile
-        raise "Unspecified property: 'profile_name'. Please set it before attempting this action." unless @new_resource.profile_name
+        raise "Unspecified property: 'server_profile_name'. Please set it before attempting this action." unless @new_resource.server_profile_name
         @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-        @item = @item.new_profile(@new_resource.profile_name)
+        @item = @item.new_profile(@new_resource.server_profile_name)
         create_if_missing
       end
     end

--- a/libraries/resource_providers/api300/synergy/server_profile_provider.rb
+++ b/libraries/resource_providers/api300/synergy/server_profile_provider.rb
@@ -12,15 +12,8 @@
 module OneviewCookbook
   module API300
     module Synergy
-      # ServerProfile API300 Synergy provider
-      class ServerProfileProvider < API200::ServerProfileProvider
-        def create_or_update
-          load_os_deployment_plan
-          super
-        end
-
-        protected
-
+      # Helper module containing methods for loading OS Deployment Plans into @item
+      module ServerProfileHelpers
         def load_os_deployment_plan
           # Return if the property is not defined
           return unless @new_resource.os_deployment_plan
@@ -63,6 +56,15 @@ module OneviewCookbook
             end
           end
           target << custom_attribute unless was_replaced
+        end
+      end
+
+      # ServerProfile API300 Synergy provider
+      class ServerProfileProvider < API200::ServerProfileProvider
+        include OneviewCookbook::API300::Synergy::ServerProfileHelpers
+        def create_or_update
+          load_os_deployment_plan
+          super
         end
       end
     end

--- a/libraries/resource_providers/api500/c7000/server_profile_template_provider.rb
+++ b/libraries/resource_providers/api500/c7000/server_profile_template_provider.rb
@@ -1,0 +1,30 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module C7000
+      # Server Profile Template API500 C7000 provider
+      class ServerProfileTemplateProvider < API300::C7000::ServerProfileTemplateProvider
+        # Override create method to allow creation from a template
+        def create(method)
+          if @new_resource.server_profile_name
+            sp_as_template = load_resource(:ServerProfile, @new_resource.server_profile_name)
+            Chef::Log.info "Using Server profile '#{@new_resource.server_profile_name}' as template to #{method} #{@resource_name} '#{@name}'"
+            new_spt_data = sp_as_template.get_profile_template.data
+            @item.data = new_spt_data.merge(@item.data)
+          end
+          super
+        end
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api500/synergy/server_profile_template_provider.rb
+++ b/libraries/resource_providers/api500/synergy/server_profile_template_provider.rb
@@ -1,8 +1,4 @@
-#
-# Cookbook Name:: oneview_test
-# Recipe:: server_profile_template_new_profile
-#
-# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,10 +8,13 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
-#
 
-oneview_server_profile_template 'ServerProfileTemplate1' do
-  client node['oneview_test']['client']
-  server_profile_name 'Profile1'
-  action :new_profile
+module OneviewCookbook
+  module API500
+    module Synergy
+      # Server Profile Template API500 Synergy provider
+      class ServerProfileTemplateProvider < API500::C7000::ServerProfileTemplateProvider
+      end
+    end
+  end
 end

--- a/resources/server_profile_template.rb
+++ b/resources/server_profile_template.rb
@@ -19,7 +19,7 @@ property :firmware_driver, String
 property :ethernet_network_connections, Object
 property :network_set_connections, Object
 property :fc_network_connections, Object
-property :profile_name, String
+property :server_profile_name, String
 
 default_action :create
 

--- a/resources/server_profile_template.rb
+++ b/resources/server_profile_template.rb
@@ -20,6 +20,7 @@ property :ethernet_network_connections, Object
 property :network_set_connections, Object
 property :fc_network_connections, Object
 property :server_profile_name, String
+property :os_deployment_plan, String
 
 default_action :create
 

--- a/spec/fixtures/cookbooks/oneview_test/recipes/server_profile_template_from_sp.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/server_profile_template_from_sp.rb
@@ -15,7 +15,7 @@
 #
 
 oneview_server_profile_template 'ServerProfileTemplate1' do
+  api_version 500
   client node['oneview_test']['client']
   server_profile_name 'Profile1'
-  action :new_profile
 end

--- a/spec/fixtures/cookbooks/oneview_test_api500_synergy/recipes/server_profile_template_from_sp.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api500_synergy/recipes/server_profile_template_from_sp.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: oneview_test
 # Recipe:: server_profile_template_new_profile
 #
-# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/fixtures/cookbooks/oneview_test_api500_synergy/recipes/server_profile_template_properties.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api500_synergy/recipes/server_profile_template_properties.rb
@@ -1,3 +1,7 @@
+#
+# Cookbook Name:: oneview_test_api500_synergy
+# Recipe:: server_profile_template_new_profile
+#
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -8,18 +12,11 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+#
 
-module OneviewCookbook
-  module API500
-    module Synergy
-      # Server Profile Template API500 Synergy provider
-      class ServerProfileTemplateProvider < API500::C7000::ServerProfileTemplateProvider
-        include OneviewCookbook::API300::Synergy::ServerProfileHelpers
-        def create_or_update
-          load_os_deployment_plan
-          super
-        end
-      end
-    end
-  end
+oneview_server_profile_template 'ServerProfileTemplate1' do
+  api_version 500
+  client node['oneview_test']['client']
+  os_deployment_plan 'OSDeploymentPlan1'
+  data('osDeploymentSettings' => { 'customAttributes' => [{ 'name' => 'it', 'value' => 'works' }] })
 end

--- a/spec/unit/resources/server_profile_template/from_sp_spec.rb
+++ b/spec/unit/resources/server_profile_template/from_sp_spec.rb
@@ -1,6 +1,6 @@
 require_relative './../../../spec_helper'
 
-describe 'oneview_test::server_profile_template_from_sp' do
+describe 'oneview_test_api500_synergy::server_profile_template_from_sp' do
   let(:resource_name) { 'server_profile_template' }
   let(:spt_klass) { OneviewSDK::API500::C7000::ServerProfileTemplate }
   let(:sp_klass) { OneviewSDK::API500::C7000::ServerProfile }

--- a/spec/unit/resources/server_profile_template/from_sp_spec.rb
+++ b/spec/unit/resources/server_profile_template/from_sp_spec.rb
@@ -1,0 +1,16 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test::server_profile_template_from_sp' do
+  let(:resource_name) { 'server_profile_template' }
+  let(:spt_klass) { OneviewSDK::API500::C7000::ServerProfileTemplate }
+  let(:sp_klass) { OneviewSDK::API500::C7000::ServerProfile }
+  include_context 'chef context'
+
+  it 'creates it when it does not exist' do
+    expect_any_instance_of(sp_klass).to receive(:retrieve!).and_return(sp_klass.new(client))
+    expect_any_instance_of(sp_klass).to receive(:get_profile_template).and_return(spt_klass.new(client))
+    expect_any_instance_of(spt_klass).to receive(:exists?).and_return(false)
+    expect_any_instance_of(spt_klass).to receive(:create).and_return(true)
+    expect(real_chef_run).to create_oneview_server_profile_template('ServerProfileTemplate1')
+  end
+end

--- a/spec/unit/resources/server_profile_template/properties_spec.rb
+++ b/spec/unit/resources/server_profile_template/properties_spec.rb
@@ -24,3 +24,80 @@ describe 'oneview_test::server_profile_template_properties' do
     expect(real_chef_run).to create_oneview_server_profile_template('ServerProfileTemplate1')
   end
 end
+
+describe 'oneview_test_api500_synergy::server_profile_template_properties' do
+  let(:resource_name) { 'server_profile_template' }
+  include_context 'chef context'
+  include_context 'shared context'
+
+  let(:provider) { OneviewCookbook::API500::Synergy::ServerProfileTemplateProvider }
+  let(:base_sdk) { OneviewSDK::API500::Synergy }
+
+  it 'loads the associated resource OS Deployment Plan adding the customAttributes' do
+    osdp = base_sdk::OSDeploymentPlan.new(@client, name: 'OSDeploymentPlan1', uri: 'rest/fake0', additionalParameters: [])
+    allow_any_instance_of(provider).to receive(:load_resource).and_call_original
+    allow_any_instance_of(provider).to receive(:load_resource)
+      .with(:OSDeploymentPlan, 'OSDeploymentPlan1').and_return(osdp)
+
+    expect_any_instance_of(base_sdk::ServerProfileTemplate).to receive(:set_os_deployment_settings)
+      .with(osdp, ['name' => 'it', 'value' => 'works'])
+
+    # Mock create
+    expect_any_instance_of(base_sdk::ServerProfileTemplate).to receive(:exists?).and_return(false)
+    expect_any_instance_of(base_sdk::ServerProfileTemplate).to receive(:create).and_return(true)
+
+    expect(real_chef_run).to create_oneview_server_profile_template('ServerProfileTemplate1')
+  end
+
+  it 'loads the associated resource OS Deployment Plan adding the osCustomAttributes' do
+    osdp = base_sdk::OSDeploymentPlan.new(@client, name: 'OSDeploymentPlan1', uri: 'rest/fake0', additionalParameters: [])
+    allow_any_instance_of(provider).to receive(:load_resource).and_call_original
+    allow_any_instance_of(provider).to receive(:load_resource)
+      .with(:OSDeploymentPlan, 'OSDeploymentPlan1').and_return(osdp)
+
+    allow_any_instance_of(base_sdk::ServerProfileTemplate).to receive(:[]).and_call_original
+    allow_any_instance_of(base_sdk::ServerProfileTemplate).to receive(:[]).with('osDeploymentSettings')
+                                                                          .and_return('osCustomAttributes' => ['name' => 'works', 'value' => 'too'])
+
+    expect_any_instance_of(base_sdk::ServerProfileTemplate).to receive(:set_os_deployment_settings)
+      .with(osdp, ['name' => 'works', 'value' => 'too'])
+
+    # Mock create
+    expect_any_instance_of(base_sdk::ServerProfileTemplate).to receive(:exists?).and_return(false)
+    expect_any_instance_of(base_sdk::ServerProfileTemplate).to receive(:create).and_return(true)
+
+    expect(real_chef_run).to create_oneview_server_profile_template('ServerProfileTemplate1')
+  end
+
+  it 'loads the associated resource OS Deployment Plan merging the osCustomAttributes' do
+    osdp = base_sdk::OSDeploymentPlan.new(@client,
+                                          name: 'OSDeploymentPlan1',
+                                          uri: 'rest/fake0',
+                                          additionalParameters: [
+                                            { 'name' => 'a', 'value' => 'default' },
+                                            { 'name' => 'c', 'value' => 'default' }
+                                          ])
+    allow_any_instance_of(provider).to receive(:load_resource).and_call_original
+    allow_any_instance_of(provider).to receive(:load_resource).with(:OSDeploymentPlan, 'OSDeploymentPlan1').and_return(osdp)
+
+    allow_any_instance_of(base_sdk::ServerProfileTemplate).to receive(:[]).and_call_original
+    allow_any_instance_of(base_sdk::ServerProfileTemplate)
+      .to receive(:[])
+      .with('osDeploymentSettings')
+      .and_return('osCustomAttributes' => [{ 'name' => 'b', 'value' => 'custom' },
+                                           { 'name' => 'c', 'value' => 'override' },
+                                           { 'name' => 'd', 'value' => 'custom' }])
+
+    expect_any_instance_of(base_sdk::ServerProfileTemplate).to receive(:set_os_deployment_settings)
+      .with(osdp, a_collection_containing_exactly({ 'name' => 'a', 'value' => 'default' },
+                                                  { 'name' => 'b', 'value' => 'custom' },
+                                                  { 'name' => 'c', 'value' => 'override' },
+                                                  'name' => 'd', 'value' => 'custom'))
+
+    # Mock create
+    expect_any_instance_of(base_sdk::ServerProfileTemplate).to receive(:exists?).and_return(false)
+    expect_any_instance_of(base_sdk::ServerProfileTemplate).to receive(:create).and_return(true)
+
+    expect(real_chef_run).to create_oneview_server_profile_template('ServerProfileTemplate1')
+  end
+end


### PR DESCRIPTION
### Description
Adds support to the SPT resource on API500

- Added possibility to create a SPT based off a SP
- Updated Tests, README & CHANGELOG

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
  - [X] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [X] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
