### PR TITLE
Importing certificate to power device IPDU if auto_import_cert is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ oneview_power_device '<iPDU hostname>' do
   client <my_client>
   username <username>
   password <password>
-  auto_import_cert [true, false] # Optional. Only used with the :discover action. Default value is false.
+  auto_import_certificate [true, false] # Optional. Only used with the :discover action. Default value is true.
   action :discover
 end
 ```

--- a/README.md
+++ b/README.md
@@ -687,6 +687,7 @@ oneview_power_device '<iPDU hostname>' do
   client <my_client>
   username <username>
   password <password>
+  auto_import_cert [true, false] # Optional. Only used with the :discover action. Default value is false.
   action :discover
 end
 ```

--- a/examples/power_device.rb
+++ b/examples/power_device.rb
@@ -37,7 +37,7 @@ oneview_power_device '127.0.0.1' do
   client my_client
   username 'username'
   password 'password'
-  auto_import_cert false # Optional property, default is false
+  auto_import_cert false # Optional property, default is true
   action :discover
 end
 

--- a/examples/power_device.rb
+++ b/examples/power_device.rb
@@ -37,6 +37,7 @@ oneview_power_device '127.0.0.1' do
   client my_client
   username 'username'
   password 'password'
+  auto_import_cert false # Optional property, default is false
   action :discover
 end
 

--- a/examples/power_device.rb
+++ b/examples/power_device.rb
@@ -37,7 +37,7 @@ oneview_power_device '127.0.0.1' do
   client my_client
   username 'username'
   password 'password'
-  auto_import_cert false # Optional property, default is true
+  auto_import_certificate false # Optional property, default is true
   action :discover
 end
 

--- a/libraries/resource_providers/api200/power_device_provider.rb
+++ b/libraries/resource_providers/api200/power_device_provider.rb
@@ -17,10 +17,15 @@ module OneviewCookbook
         pd_klass = resource_named(:PowerDevice)
         power_devices_list = pd_klass.get_ipdu_devices(@item.client, @name)
         return Chef::Log.info("#{@resource_name} '#{@name}' is up to date") unless power_devices_list.empty?
-        import_certificate_for_ipdu if @new_resource.auto_import_cert
         Chef::Log.info "Discovering #{@resource_name} '#{@name}'"
         @context.converge_by "Discovered #{@resource_name} '#{@name}'" do
-          pd_klass.discover(@item.client, hostname: @name, username: @new_resource.username, password: @new_resource.password)
+          begin
+            pd_klass.discover(@item.client, hostname: @name, username: @new_resource.username, password: @new_resource.password)
+          rescue OneviewSDK::OneViewError => error
+            raise error unless @new_resource.auto_import_certificate && error.message.include?('Unable to retrieve the input certificate')
+            import_certificate_for_ipdu
+            pd_klass.discover(@item.client, hostname: @name, username: @new_resource.username, password: @new_resource.password)
+          end
         end
       end
 
@@ -75,7 +80,7 @@ module OneviewCookbook
       def import_certificate_for_ipdu
         Chef::Log.info("Verifying certificate for #{@resource_name} '#{@name}'")
         client_certificate = resource_named(:ClientCertificate).new(@item.client, aliasName: @name)
-        return Chef::Log.info("Certificate already imported for #{@resource_name} '#{@name}'") unless client_certificate.retrieve!
+        return Chef::Log.info("Certificate already imported for #{@resource_name} '#{@name}'") if client_certificate.retrieve!
         web_certificate = resource_named(:WebServerCertificate).get_certificate(@item.client, @name)
         Chef::Log.info("Importing certificate for #{@resource_name} '#{@name}'")
         client_certificate['base64SSLCertData'] = web_certificate['base64Data']

--- a/libraries/resource_providers/api200/power_device_provider.rb
+++ b/libraries/resource_providers/api200/power_device_provider.rb
@@ -23,6 +23,8 @@ module OneviewCookbook
             pd_klass.discover(@item.client, hostname: @name, username: @new_resource.username, password: @new_resource.password)
           rescue OneviewSDK::OneViewError => error
             raise error unless @new_resource.auto_import_certificate && error.message.include?('Unable to retrieve the input certificate')
+            Chef::Log.warn("Oneview returned the following error:\n: #{error.message}")
+            Chef::Log.info("Trying to import certificate for #{@resource_name} '#{@name}'")
             import_certificate_for_ipdu
             pd_klass.discover(@item.client, hostname: @name, username: @new_resource.username, password: @new_resource.password)
           end

--- a/libraries/resource_providers/api200/power_device_provider.rb
+++ b/libraries/resource_providers/api200/power_device_provider.rb
@@ -23,8 +23,8 @@ module OneviewCookbook
             pd_klass.discover(@item.client, hostname: @name, username: @new_resource.username, password: @new_resource.password)
           rescue OneviewSDK::OneViewError => error
             raise error unless @new_resource.auto_import_certificate && error.message.include?('Unable to retrieve the input certificate')
-            Chef::Log.warn("Oneview returned the following error:\n: #{error.message}")
-            Chef::Log.info("Trying to import certificate for #{@resource_name} '#{@name}'")
+            Chef::Log.warn("Oneview returned the following error:\n #{error.message}")
+            Chef::Log.info("Trying to automatically import certificate for #{@resource_name} '#{@name}'")
             import_certificate_for_ipdu
             pd_klass.discover(@item.client, hostname: @name, username: @new_resource.username, password: @new_resource.password)
           end

--- a/resources/power_device.rb
+++ b/resources/power_device.rb
@@ -16,7 +16,7 @@ property :password, String
 property :uid_state, [String, Symbol], regex: /^(on|off)$/i                   # Used in :set_power_state action only
 property :power_state, [String, Symbol], regex: /^(on|off)$/i                 # Used in :set_uid_state action only
 property :refresh_options, Hash, default: { refreshState: 'RefreshPending' }  # Used in :refresh action only
-property :auto_import_cert, [TrueClass, FalseClass], default: false           # Used in :discover action only
+property :auto_import_certificate, [TrueClass, FalseClass], default: true     # Used in :discover action only
 
 default_action :add
 

--- a/resources/power_device.rb
+++ b/resources/power_device.rb
@@ -16,6 +16,7 @@ property :password, String
 property :uid_state, [String, Symbol], regex: /^(on|off)$/i                   # Used in :set_power_state action only
 property :power_state, [String, Symbol], regex: /^(on|off)$/i                 # Used in :set_uid_state action only
 property :refresh_options, Hash, default: { refreshState: 'RefreshPending' }  # Used in :refresh action only
+property :auto_import_cert, [TrueClass, FalseClass], default: false           # Used in :discover action only
 
 default_action :add
 

--- a/spec/fixtures/cookbooks/oneview_test/recipes/power_device_discover.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/power_device_discover.rb
@@ -18,5 +18,6 @@ oneview_power_device '127.0.0.1' do
   client node['oneview_test']['client']
   username 'username'
   password 'password'
+  auto_import_certificate false
   action :discover
 end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/power_device_discover_auto_import_cert.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/power_device_discover_auto_import_cert.rb
@@ -1,0 +1,23 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: power_device_discover_auto_import_cert
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_power_device '127.0.0.1' do
+  client node['oneview_test']['client']
+  username 'username'
+  password 'password'
+  auto_import_cert true
+  action :discover
+end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/power_device_discover_auto_import_certificate.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/power_device_discover_auto_import_certificate.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: oneview_test
-# Recipe:: power_device_discover_auto_import_cert
+# Recipe:: power_device_discover_auto_import_certificate
 #
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
@@ -18,6 +18,6 @@ oneview_power_device '127.0.0.1' do
   client node['oneview_test']['client']
   username 'username'
   password 'password'
-  auto_import_cert true
+  auto_import_certificate true
   action :discover
 end

--- a/spec/unit/resources/power_device/discover_spec.rb
+++ b/spec/unit/resources/power_device/discover_spec.rb
@@ -32,22 +32,33 @@ describe 'oneview_test::power_device_discover' do
     expect(target_class).to_not receive(:discover)
     expect(real_chef_run).to discover_oneview_power_device('127.0.0.1')
   end
+
+  it 'discovers an ipdu without imported certificate and with auto_import_certificate property false' do
+    allow(target_class).to receive(:get_ipdu_devices).and_return([])
+    allow(target_class).to receive(:discover) { OneviewSDK::TaskError.raise!('... Unable to retrieve the input certificate ...') }
+    expect(target_class).to receive(:discover).once
+    expect { real_chef_run }.to raise_error(/Unable to retrieve the input certificate/)
+  end
 end
 
-describe 'oneview_test::power_device_discover_auto_import_cert' do
+describe 'oneview_test::power_device_discover_auto_import_certificate' do
   let(:resource_name) { 'power_device' }
   include_context 'chef context'
 
   let(:base_sdk) { OneviewSDK::API200 }
   let(:target_class) { base_sdk::PowerDevice }
 
-  it 'discovers an ipdu that does not exists' do
+  it 'discovers an ipdu that does not exists and certificate is not imported' do
     allow(target_class).to receive(:get_ipdu_devices).and_return([])
     expect(base_sdk::ClientCertificate).to receive(:new).with(kind_of(OneviewSDK::Client), aliasName: '127.0.0.1').and_call_original
-    expect_any_instance_of(base_sdk::ClientCertificate).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(base_sdk::ClientCertificate).to receive(:retrieve!).and_return(false)
     expect(base_sdk::WebServerCertificate).to receive(:get_certificate)
       .with(kind_of(OneviewSDK::Client), '127.0.0.1').and_return('base64Data' => 'some_value')
     expect_any_instance_of(base_sdk::ClientCertificate).to receive(:import)
+    with_error_seq = [true, false]
+    allow(target_class).to receive(:discover) do
+      OneviewSDK::TaskError.raise!('... Unable to retrieve the input certificate ...') if with_error_seq.shift
+    end
     expect(target_class).to receive(:discover)
       .with(
         kind_of(OneviewSDK::Client),
@@ -55,6 +66,7 @@ describe 'oneview_test::power_device_discover_auto_import_cert' do
         username: 'username',
         password: 'password'
       )
+      .twice
     expect(real_chef_run).to discover_oneview_power_device('127.0.0.1')
   end
 
@@ -68,5 +80,24 @@ describe 'oneview_test::power_device_discover_auto_import_cert' do
     expect_any_instance_of(base_sdk::ClientCertificate).not_to receive(:import)
     expect(target_class).to_not receive(:discover)
     expect(real_chef_run).to discover_oneview_power_device('127.0.0.1')
+  end
+
+  it 'discovers an ipdu that already imported certificate' do
+    allow(target_class).to receive(:get_ipdu_devices).and_return([])
+    with_error_seq = [true, false]
+    allow(target_class).to receive(:discover) do
+      OneviewSDK::TaskError.raise!('... Unable to retrieve the input certificate ...') if with_error_seq.shift
+    end
+    expect_any_instance_of(base_sdk::ClientCertificate).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(base_sdk::ClientCertificate).not_to receive(:import)
+    expect(target_class).to receive(:discover).twice
+    expect(real_chef_run).to discover_oneview_power_device('127.0.0.1')
+  end
+
+  it 'when occurs some error unknown should not import certificate' do
+    allow(target_class).to receive(:get_ipdu_devices).and_return([])
+    allow(target_class).to receive(:discover) { OneviewSDK::TaskError.raise!('some error') }
+    expect(target_class).to receive(:discover).once
+    expect { real_chef_run }.to raise_error(/some error/)
   end
 end

--- a/spec/unit/resources/power_device/discover_spec.rb
+++ b/spec/unit/resources/power_device/discover_spec.rb
@@ -6,6 +6,11 @@ describe 'oneview_test::power_device_discover' do
 
   let(:target_class) { OneviewSDK::API200::PowerDevice }
 
+  before do
+    expect_any_instance_of(OneviewSDK::API200::ClientCertificate).not_to receive(:import)
+    expect(OneviewSDK::API200::WebServerCertificate).not_to receive(:get_certificate)
+  end
+
   it 'discovers an ipdu that does not exists' do
     allow(target_class).to receive(:get_ipdu_devices).and_return([])
     expect(target_class).to receive(:discover)
@@ -24,6 +29,43 @@ describe 'oneview_test::power_device_discover' do
         target_class.new(client, managedBy: { name: '127.0.0.1' })
       ]
     )
+    expect(target_class).to_not receive(:discover)
+    expect(real_chef_run).to discover_oneview_power_device('127.0.0.1')
+  end
+end
+
+describe 'oneview_test::power_device_discover_auto_import_cert' do
+  let(:resource_name) { 'power_device' }
+  include_context 'chef context'
+
+  let(:base_sdk) { OneviewSDK::API200 }
+  let(:target_class) { base_sdk::PowerDevice }
+
+  it 'discovers an ipdu that does not exists' do
+    allow(target_class).to receive(:get_ipdu_devices).and_return([])
+    expect(base_sdk::ClientCertificate).to receive(:new).with(kind_of(OneviewSDK::Client), aliasName: '127.0.0.1').and_call_original
+    expect_any_instance_of(base_sdk::ClientCertificate).to receive(:retrieve!).and_return(true)
+    expect(base_sdk::WebServerCertificate).to receive(:get_certificate)
+      .with(kind_of(OneviewSDK::Client), '127.0.0.1').and_return('base64Data' => 'some_value')
+    expect_any_instance_of(base_sdk::ClientCertificate).to receive(:import)
+    expect(target_class).to receive(:discover)
+      .with(
+        kind_of(OneviewSDK::Client),
+        hostname: '127.0.0.1',
+        username: 'username',
+        password: 'password'
+      )
+    expect(real_chef_run).to discover_oneview_power_device('127.0.0.1')
+  end
+
+  it 'discovers an ipdu that already exists' do
+    allow(target_class).to receive(:get_ipdu_devices).and_return(
+      [
+        target_class.new(client, managedBy: { name: '127.0.0.1' })
+      ]
+    )
+    expect_any_instance_of(OneviewCookbook::API200::PowerDeviceProvider).not_to receive(:import_certificate_for_ipdu)
+    expect_any_instance_of(base_sdk::ClientCertificate).not_to receive(:import)
     expect(target_class).to_not receive(:discover)
     expect(real_chef_run).to discover_oneview_power_device('127.0.0.1')
   end


### PR DESCRIPTION
### Description
Importing certificate to power device IPDU if auto_import_cert property is set to true.
When we are applying discover action to oneview_power_device, some appliances (like appliance of OV 3.10) require the valid certificate to access IPDU server, this commit changes are inserting the code to import the certificate;

### Environment Details
 - **oneview Cookbook:** Version: 2.3.0
 - **OneView Version:** 3.10
 - **chef-client Version:** 12.0+
 - **platform:** Any

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [ ] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
