### PR TITLE
UplinkSets API500 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Adds API 500 support to the following HPE OneView resources:
   - oneview_storage_system
   - oneview_switch
   - oneview_unmanaged_device
+  - oneview_uplink_set
   - oneview_user
 
 Enhancements:

--- a/libraries/resource_providers/api500/c7000/uplink_set_provider.rb
+++ b/libraries/resource_providers/api500/c7000/uplink_set_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module C7000
+      # UplinkSet API500 C7000 provider
+      class UplinkSetProvider < API300::C7000::UplinkSetProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api500/synergy/uplink_set_provider.rb
+++ b/libraries/resource_providers/api500/synergy/uplink_set_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    module Synergy
+      # UplinkSet API500 Synergy provider
+      class UplinkSetProvider < API300::Synergy::UplinkSetProvider
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description
Adds support to UplinkSets on API500 for Chef.

### Check List
- [X] All tests pass (`$ rake test`).
(https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [X] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
