### PR TITLE
Creating volume attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Enhancements:
 - [#304](https://github.com/HewlettPackard/oneview-chef/issues/304) Add refresh actions to oneview_storage_system
 - [#306](https://github.com/HewlettPackard/oneview-chef/issues/306) Create shared examples to unit tests that using scope actions
 - [#336](https://github.com/HewlettPackard/oneview-chef/issues/336) Remove :new_profile action of oneview_server_profile_template
+- [#309](https://github.com/HewlettPackard/oneview-chef/issues/309) Add volume_attachment property to Server Profiles and SP Templates so VAs can be more easily managed
 
 Bug fixes:
 - [#284](https://github.com/HewlettPackard/oneview-chef/issues/284) Nested and cyclic requires are causing the first resource to be skipped

--- a/README.md
+++ b/README.md
@@ -789,21 +789,21 @@ You can specify the association of the server profile with each of the resources
 - **\<resource_name\>_connections** (Array/Hash) Optional - Specify connections with the desired resource type. The Hash entry should have `<network_name> => <connection_data>` associations. The Array contains these Hash entries. See the examples for more information.
 - **volume_attachments** (Array<Hash>) Optional - Specify a list of volume attachments to be created when create/update the Server Profile Template. See the [example](examples/server_profile_template.rb) for more information.
 
-  To attach a existent Volume use a data as the below to be the volume attachment data:
+  To attach a Volume already created, put into the 'volume_attachments' something like:
   ```ruby
   {
     volume: 'test2', # name of existent Oneview Volume
-    attachment_data: {} # # key-pair data to be the specific attributes of Oneview Volume Attachment
+    attachment_data: {} # key-pair data to be the specific attributes of the Oneview Volume Attachment
   }
   ```
-  To create a new Volume and attach it, use a data as the below to be the volume attachment data:
+  To create a new Volume and attach it, put into the 'volume_attachments' something like:
   ```ruby
     {
       volume_data: {}, # key-pair data to create a new Volume to the Oneview
       storage_system: 'ThreePAR-1', # name of Storage System associated with the Volume Attachment
       storage_pool: 'CPG-SSD', # name of Storage Pool associated with the Volume Attachment
       host_os_type: 'Windows 2012 / WS2012 R2', # the hostOsType info of San Storage
-      attachment_data: {} # key-pair data to be the specific attributes of Oneview Volume Attachment
+      attachment_data: {} # key-pair data to be the specific attributes of the Oneview Volume Attachment
     }
   ```
 
@@ -836,21 +836,21 @@ You can specify the association of the server profile with each of the resources
 - **os_deployment_plan** (String) Optional - Specify the OS Deployment Plan to be applied with the Server Profile. The OS Deployment Plan needs to be created in Image Streamer appliance in order to appear in OneView. See the [example](examples/image_streamer/server_profile_deploy.rb) for more information.
 - **volume_attachments** (Array<Hash>) Optional - Specify a list of volume attachments to be created when create/update the Server Profile. See the [example](examples/server_profile.rb) for more information.
 
-  To attach a existent Volume use a data as the below to be the volume attachment data:
+  To attach a Volume already created, put into the 'volume_attachments' something like:
   ```ruby
   {
     volume: 'test2', # name of existent Oneview Volume
-    attachment_data: {} # # key-pair data to be the specific attributes of Oneview Volume Attachment
+    attachment_data: {} # key-pair data to be the specific attributes of the Oneview Volume Attachment
   }
   ```
-  To create a new Volume and attach it, use a data as the below to be the volume attachment data:
+  To create a new Volume and attach it, put into the 'volume_attachments' something like:
   ```ruby
     {
       volume_data: {}, # key-pair data to create a new Volume to the Oneview
       storage_system: 'ThreePAR-1', # name of Storage System associated with the Volume Attachment
       storage_pool: 'CPG-SSD', # name of Storage Pool associated with the Volume Attachment
       host_os_type: 'Windows 2012 / WS2012 R2', # the hostOsType info of San Storage
-      attachment_data: {} # key-pair data to be the specific attributes of Oneview Volume Attachment
+      attachment_data: {} # key-pair data to be the specific attributes of the Oneview Volume Attachment
     }
   ```
 

--- a/README.md
+++ b/README.md
@@ -779,6 +779,7 @@ oneview_server_profile_template 'ServerProfileTemplate1' do
   network_set_connections <network_set_connections_data>
   server_profile_name <profile_name>  # String - Optional. Used in create and create_if_missing actions. It is the name of the Server Profile be used as base for the Server Profile Template. Only available on API500 and onwards to be used as base.
   os_deployment_plan <os_deployment_plan_name>
+  volume_attachments <volume_attachments_data> # Array<Hash> - The volume attachments data to be created with Server Profile Template.
   action [:create, :create_if_missing, :delete]
 end
 ```
@@ -786,6 +787,25 @@ end
 You can specify the association of the server profile with each of the resources using the resource properties. Also it is easy to add connections using the connection properties:
 
 - **\<resource_name\>_connections** (Array/Hash) Optional - Specify connections with the desired resource type. The Hash entry should have `<network_name> => <connection_data>` associations. The Array contains these Hash entries. See the examples for more information.
+- **volume_attachments** (Array<Hash>) Optional - Specify a list of volume attachments to be created when create/update the Server Profile Template. See the [example](examples/server_profile_template.rb) for more information.
+
+  To attach a existent Volume use a data as the below to be the volume attachment data:
+  ```ruby
+  {
+    volume: 'test2', # name of existent Oneview Volume
+    attachment_data: {} # # key-pair data to be the specific attributes of Oneview Volume Attachment
+  }
+  ```
+  To create a new Volume and attach it, use a data as the below to be the volume attachment data:
+  ```ruby
+    {
+      volume_data: {}, # key-pair data to create a new Volume to the Oneview
+      storage_system: 'ThreePAR-1', # name of Storage System associated with the Volume Attachment
+      storage_pool: 'CPG-SSD', # name of Storage Pool associated with the Volume Attachment
+      host_os_type: 'Windows 2012 / WS2012 R2', # the hostOsType info of San Storage
+      attachment_data: {} # key-pair data to be the specific attributes of Oneview Volume Attachment
+    }
+  ```
 
 
 ### [oneview_server_profile](examples/server_profile.rb)
@@ -805,6 +825,7 @@ oneview_server_profile 'ServerProfile1' do
   fcoe_network_connections <fcoe_network_connections_data>
   network_set_connections <network_set_connections_data>
   os_deployment_plan <os_deployment_plan_name>
+  volume_attachments <volume_attachments_data> # Array<Hash> - The volume attachments data to be created with Server Profile Template.
   action [:create, :create_if_missing, :delete]
 end
 ```
@@ -813,6 +834,25 @@ You can specify the association of the server profile with each of the resources
 
 - **\<network_type\>_connections** (Hash) Optional - Specify connections with the desired resource type. The Hash should have `<network_name> => <connection_data>` associations. See the [examples](examples/server_profile.rb) for more information.
 - **os_deployment_plan** (String) Optional - Specify the OS Deployment Plan to be applied with the Server Profile. The OS Deployment Plan needs to be created in Image Streamer appliance in order to appear in OneView. See the [example](examples/image_streamer/server_profile_deploy.rb) for more information.
+- **volume_attachments** (Array<Hash>) Optional - Specify a list of volume attachments to be created when create/update the Server Profile. See the [example](examples/server_profile.rb) for more information.
+
+  To attach a existent Volume use a data as the below to be the volume attachment data:
+  ```ruby
+  {
+    volume: 'test2', # name of existent Oneview Volume
+    attachment_data: {} # # key-pair data to be the specific attributes of Oneview Volume Attachment
+  }
+  ```
+  To create a new Volume and attach it, use a data as the below to be the volume attachment data:
+  ```ruby
+    {
+      volume_data: {}, # key-pair data to create a new Volume to the Oneview
+      storage_system: 'ThreePAR-1', # name of Storage System associated with the Volume Attachment
+      storage_pool: 'CPG-SSD', # name of Storage Pool associated with the Volume Attachment
+      host_os_type: 'Windows 2012 / WS2012 R2', # the hostOsType info of San Storage
+      attachment_data: {} # key-pair data to be the specific attributes of Oneview Volume Attachment
+    }
+  ```
 
 
 ### [oneview_switch](examples/switch.rb)

--- a/README.md
+++ b/README.md
@@ -787,13 +787,13 @@ end
 You can specify the association of the server profile with each of the resources using the resource properties. Also it is easy to add connections using the connection properties:
 
 - **\<resource_name\>_connections** (Array/Hash) Optional - Specify connections with the desired resource type. The Hash entry should have `<network_name> => <connection_data>` associations. The Array contains these Hash entries. See the examples for more information.
-- **volume_attachments** (Array<Hash>) Optional - Specify a list of volume attachments to be created when create/update the Server Profile Template. See the [example](examples/server_profile_template.rb) for more information.
+- **volume_attachments** (Array<Hash>) Optional - Specify a list of volume attachments to be created when creating or updating the Server Profile Template. See the [example](examples/server_profile_template.rb) for more information.
 
   To attach a Volume already created, put into the 'volume_attachments' something like:
   ```ruby
   {
     volume: 'test2', # name of existent Oneview Volume
-    attachment_data: {} # key-pair data to be the specific attributes of the Oneview Volume Attachment
+    attachment_data: { ... } # key-pair data to be the specific attributes of the Oneview Volume Attachment
   }
   ```
   To create a new Volume and attach it, put into the 'volume_attachments' something like:
@@ -803,7 +803,7 @@ You can specify the association of the server profile with each of the resources
       storage_system: 'ThreePAR-1', # name of Storage System associated with the Volume Attachment
       storage_pool: 'CPG-SSD', # name of Storage Pool associated with the Volume Attachment
       host_os_type: 'Windows 2012 / WS2012 R2', # the hostOsType info of San Storage
-      attachment_data: {} # key-pair data to be the specific attributes of the Oneview Volume Attachment
+      attachment_data: { ... } # key-pair data to be the specific attributes of the Oneview Volume Attachment
     }
   ```
 
@@ -834,13 +834,13 @@ You can specify the association of the server profile with each of the resources
 
 - **\<network_type\>_connections** (Hash) Optional - Specify connections with the desired resource type. The Hash should have `<network_name> => <connection_data>` associations. See the [examples](examples/server_profile.rb) for more information.
 - **os_deployment_plan** (String) Optional - Specify the OS Deployment Plan to be applied with the Server Profile. The OS Deployment Plan needs to be created in Image Streamer appliance in order to appear in OneView. See the [example](examples/image_streamer/server_profile_deploy.rb) for more information.
-- **volume_attachments** (Array<Hash>) Optional - Specify a list of volume attachments to be created when create/update the Server Profile. See the [example](examples/server_profile.rb) for more information.
+- **volume_attachments** (Array<Hash>) Optional - Specify a list of volume attachments to be created when creating or updating the Server Profile. See the [example](examples/server_profile.rb) for more information.
 
   To attach a Volume already created, put into the 'volume_attachments' something like:
   ```ruby
   {
     volume: 'test2', # name of existent Oneview Volume
-    attachment_data: {} # key-pair data to be the specific attributes of the Oneview Volume Attachment
+    attachment_data: { ... } # key-pair data to be the specific attributes of the Oneview Volume Attachment
   }
   ```
   To create a new Volume and attach it, put into the 'volume_attachments' something like:
@@ -850,7 +850,7 @@ You can specify the association of the server profile with each of the resources
       storage_system: 'ThreePAR-1', # name of Storage System associated with the Volume Attachment
       storage_pool: 'CPG-SSD', # name of Storage Pool associated with the Volume Attachment
       host_os_type: 'Windows 2012 / WS2012 R2', # the hostOsType info of San Storage
-      attachment_data: {} # key-pair data to be the specific attributes of the Oneview Volume Attachment
+      attachment_data: { ... } # key-pair data to be the specific attributes of the Oneview Volume Attachment
     }
   ```
 

--- a/attributes/volume_attachments_variables.rb
+++ b/attributes/volume_attachments_variables.rb
@@ -12,7 +12,7 @@
 # NOTE: variables to be used within server_profile and server_profile_template examples.
 
 # use this to create server profile or server profile template with volume attachments using api200 or api300
-volume_data_api_200 = {
+volume_data = {
   name: 'Volume1',
   description: 'volume for api200 or api300',
   provisioningParameters: {
@@ -23,16 +23,16 @@ volume_data_api_200 = {
 }
 
 # use this to create server profile or server profile template with volume attachments using api500 or greater
-volume_data_api_500 = {
-  name: 'Volume1',
-  description: 'Volume store serv for api500',
-  size: 1024 * 1024 * 1024,
-  provisioningType: 'Thin',
-  isShareable: false
-}
+# volume_data = {
+#   name: 'Volume1',
+#   description: 'Volume store serv for api500',
+#   size: 1024 * 1024 * 1024,
+#   provisioningType: 'Thin',
+#   isShareable: false
+# }
 
 # use this to add storage paths to volume attachments using api200 or api300
-storage_paths_api_200 = [
+storage_paths = [
   {
     isEnabled: true,
     storageTargetType: 'Auto',
@@ -41,13 +41,13 @@ storage_paths_api_200 = [
 ]
 
 # use this to add storage paths to volume attachments using api500 or greater
-storage_paths_api500 = [
-  {
-    isEnabled: true,
-    targetSelector: 'Auto',
-    connectionId: 1
-  }
-]
+# storage_paths = [
+#   {
+#     isEnabled: true,
+#     targetSelector: 'Auto',
+#     connectionId: 1
+#   }
+# ]
 
-node.run_state[:volume_data_for_volume_attachment] = volume_data_api_200 # change to 'volume_data_api_500' if you want use with api500
-node.run_state[:storage_paths_for_volume_attachment] = storage_paths_api_200 # change to 'storage_paths_api500' if you want use with api500
+node.run_state['volume_data_for_volume_attachment'] = volume_data
+node.run_state['storage_paths_for_volume_attachment'] = storage_paths

--- a/attributes/volume_attachments_variables.rb
+++ b/attributes/volume_attachments_variables.rb
@@ -1,0 +1,53 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# NOTE: variables to be used within server_profile and server_profile_template examples.
+
+# use this to create server profile or server profile template with volume attachments using api200 or api300
+volume_data_api_200 = {
+  name: 'Volume1',
+  description: 'volume for api200 or api300',
+  provisioningParameters: {
+    provisionType: 'Full',
+    requestedCapacity: 1024 * 1024 * 1024,
+    shareable: false
+  }
+}
+
+# use this to create server profile or server profile template with volume attachments using api500 or greater
+volume_data_api_500 = {
+  name: 'Volume1',
+  description: 'Volume store serv for api500',
+  size: 1024 * 1024 * 1024,
+  provisioningType: 'Thin',
+  isShareable: false
+}
+
+# use this to add storage paths to volume attachments using api200 or api300
+storage_paths_api_200 = [
+  {
+    isEnabled: true,
+    storageTargetType: 'Auto',
+    connectionId: 1
+  }
+]
+
+# use this to add storage paths to volume attachments using api500 or greater
+storage_paths_api500 = [
+  {
+    isEnabled: true,
+    targetSelector: 'Auto',
+    connectionId: 1
+  }
+]
+
+node.run_state[:volume_data_for_volume_attachment] = volume_data_api_200 # change to 'volume_data_api_500' if you want use with api500
+node.run_state[:storage_paths_for_volume_attachment] = storage_paths_api_200 # change to 'storage_paths_api500' if you want use with api500

--- a/examples/server_profile.rb
+++ b/examples/server_profile.rb
@@ -12,18 +12,18 @@
 # NOTES:
 # This example requires the following resources to be available in the appliance:
 #  - FC Network: 'FCNetwork1'
-#  - FCoE Network: 'fcoe1'
+#  - FCoE Network: 'FCoENetwork1'
 #  - Ethernet Network: 'EthernetNetwork1'
 #  - Storage System: 'ThreePAR-1'
 #  - Storage Pool: 'cpg-growth-limit-1TiB' (managed)
-#  - Server Profile Template: 'spt1'
+#  - Server Profile Template: 'ServerProfileTemplate1'
 #  - Server Hardware Type: 'BL660c Gen9 1'
 #  - Server Hardware: 'Encl1, bay 2'
-#  - Enclosure Group: 'EG_1'
+#  - Enclosure Group: 'EnclosureGroup1'
 # To create volume attachments:
 #  - The attributes file "volume_attachments_variables" is loading variables to be used in this example.
-#  - The Storage System must have at least one connection using 'FCNetwork1' and this same network network must have uplinkSet connected on the Interconnect,
-#   and the Server Hardware related to that network network is the Server Hardware used in this example.
+#  - The Storage System must have at least one connection using 'FCNetwork1' and this same network connection must have an uplinkSet connected on the Interconnect,
+#   and the Server Hardware related to that network connection is the Server Hardware used in this example.
 
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
@@ -31,10 +31,10 @@ my_client = {
   password: ENV['ONEVIEWSDK_PASSWORD']
 }
 
-my_server_profile_template = 'spt1'
+my_server_profile_template = 'ServerProfileTemplate1'
 my_server_hardware_type = 'BL660c Gen9 1'
 my_server_hardware = 'Encl1, bay 2'
-my_enclosure_group = 'EG_1'
+my_enclosure_group = 'EnclosureGroup1'
 
 # Creates a server profile with the desired Enclosure group and Server hardware type
 oneview_server_profile 'ServerProfile1' do
@@ -93,7 +93,7 @@ oneview_server_profile 'ServerProfile3' do
     }
   )
   fcoe_network_connections(
-    fcoe1: {
+    FCoENetwork1: {
       name: 'c1',
       functionType: 'FibreChannel',
       portId: 'None'

--- a/examples/server_profile.rb
+++ b/examples/server_profile.rb
@@ -14,16 +14,10 @@
 #  - FC Network: 'FCNetwork1'
 #  - FCoE Network: 'FCoENetwork1'
 #  - Ethernet Network: 'EthernetNetwork1'
-#  - Storage System: 'ThreePAR-1'
-#  - Storage Pool: 'cpg-growth-limit-1TiB' (managed)
 #  - Server Profile Template: 'ServerProfileTemplate1'
 #  - Server Hardware Type: 'BL660c Gen9 1'
 #  - Server Hardware: 'Encl1, bay 2'
 #  - Enclosure Group: 'EnclosureGroup1'
-# To create volume attachments:
-#  - The attributes file "volume_attachments_variables" is loading variables to be used in this example.
-#  - The Storage System must have at least one connection using 'FCNetwork1' and this same network connection must have an uplinkSet connected on the Interconnect,
-#   and the Server Hardware related to that network connection is the Server Hardware used in this example.
 
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
@@ -31,9 +25,7 @@ my_client = {
   password: ENV['ONEVIEWSDK_PASSWORD']
 }
 
-my_server_profile_template = 'ServerProfileTemplate1'
 my_server_hardware_type = 'BL660c Gen9 1'
-my_server_hardware = 'Encl1, bay 2'
 my_enclosure_group = 'EnclosureGroup1'
 
 # Creates a server profile with the desired Enclosure group and Server hardware type
@@ -57,8 +49,8 @@ oneview_server_profile 'ServerProfile2' do
       manageBoot: true
     }
   )
-  server_profile_template my_server_profile_template
-  server_hardware my_server_hardware
+  server_profile_template 'ServerProfileTemplate1'
+  server_hardware 'Encl1, bay 2'
 end
 
 # If a profile does get in an inconsistent state, you can update it from it's template. Note that this action
@@ -142,37 +134,6 @@ oneview_server_profile 'ServerProfile4' do
   client my_client
   enclosure_group my_enclosure_group
   server_hardware_type my_server_hardware_type
-  fc_network_connections(
-    FCNetwork1: {
-      id: 1,
-      name: 'Connection1',
-      functionType: 'FibreChannel',
-      portId: 'Auto'
-    }
-  )
-  volume_attachments(
-    [
-      {
-        volume: 'Volume2',
-        attachment_data: {
-          id: 1,
-          lunType: 'Auto',
-          storagePaths: node.run_state['storage_paths_for_volume_attachment']
-        }
-      },
-      {
-        volume_data: node.run_state['volume_data_for_volume_attachment'],
-        storage_system: 'ThreePAR-1',
-        storage_pool: 'cpg-growth-limit-1TiB',
-        host_os_type: 'Windows 2012 / WS2012 R2',
-        attachment_data: {
-          id: 2,
-          lunType: 'Auto',
-          storagePaths: node.run_state['storage_paths_for_volume_attachment']
-        }
-      }
-    ]
-  )
 end
 
 # Clean up the profiles:

--- a/examples/server_profile.rb
+++ b/examples/server_profile.rb
@@ -10,8 +10,20 @@
 # specific language governing permissions and limitations under the License.
 
 # NOTES:
-#  - It is needed configure previously some things like the network connections, storage pool, storage system, etc., to run this example.
+# This example requires the following resources to be available in the appliance:
+#  - FC Network: 'FCNetwork1'
+#  - FCoE Network: 'fcoe1'
+#  - Ethernet Network: 'EthernetNetwork1'
+#  - Storage System: 'ThreePAR-1'
+#  - Storage Pool: 'cpg-growth-limit-1TiB' (managed)
+#  - Server Profile Template: 'spt1'
+#  - Server Hardware Type: 'BL660c Gen9 1'
+#  - Server Hardware: 'Encl1, bay 2'
+#  - Enclosure Group: 'EG_1'
+# To create volume attachments:
 #  - The attributes file "volume_attachments_variables" is loading variables to be used in this example.
+#  - The Storage System must have at least one connection using 'FCNetwork1' and this same network network must have uplinkSet connected on the Interconnect,
+#   and the Server Hardware related to that network network is the Server Hardware used in this example.
 
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],

--- a/examples/server_profile.rb
+++ b/examples/server_profile.rb
@@ -145,18 +145,18 @@ oneview_server_profile 'ServerProfile4' do
         attachment_data: {
           id: 1,
           lunType: 'Auto',
-          storagePaths: node.run_state[:storage_paths_for_volume_attachment]
+          storagePaths: node.run_state['storage_paths_for_volume_attachment']
         }
       },
       {
-        volume_data: node.run_state[:volume_data_for_volume_attachment],
+        volume_data: node.run_state['volume_data_for_volume_attachment'],
         storage_system: 'ThreePAR-1',
         storage_pool: 'cpg-growth-limit-1TiB',
         host_os_type: 'Windows 2012 / WS2012 R2',
         attachment_data: {
           id: 2,
           lunType: 'Auto',
-          storagePaths: node.run_state[:storage_paths_for_volume_attachment]
+          storagePaths: node.run_state['storage_paths_for_volume_attachment']
         }
       }
     ]

--- a/examples/server_profile.rb
+++ b/examples/server_profile.rb
@@ -9,58 +9,20 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+# NOTES:
+#  - It is needed configure previously some things like the network connections, storage pool, storage system, etc., to run this example.
+#  - The attributes file "volume_attachments_variables" is loading variables to be used in this example.
+
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
   user: ENV['ONEVIEWSDK_USER'],
   password: ENV['ONEVIEWSDK_PASSWORD']
 }
 
-# my_server_profile_template = 'spt1'
-# my_server_hardware_type = 'SY 480 Gen9 2'
-# my_server_hardware = '0000A66101, bay 5'
-# my_enclosure_group = 'eg1'
 my_server_profile_template = 'spt1'
 my_server_hardware_type = 'BL660c Gen9 1'
 my_server_hardware = 'Encl1, bay 2'
 my_enclosure_group = 'EG_1'
-
-# use this to create server profile with volume attachments using api200 or api300
-volume_data_api_200 = {
-  name: 'Volume1',
-  description: 'volume for api200 or api300',
-  provisioningParameters: {
-    provisionType: 'Full',
-    requestedCapacity: 1024 * 1024 * 1024,
-    shareable: false
-  }
-}
-
-# use this to create server profile with volume attachments using api500 or greater
-volume_data_api_500 = {
-  name: 'Volume1',
-  description: 'Volume store serv for api500',
-  size: 1024 * 1024 * 1024,
-  provisioningType: 'Thin',
-  isShareable: false
-}
-
-# use this to add storage paths to volume attachments using api200 or api300
-storage_paths_api_200 = [
-  {
-    isEnabled: true,
-    storageTargetType: 'Auto',
-    connectionId: 1
-  }
-]
-
-# use this to add storage paths to volume attachments using api500 or greater
-storage_paths_api500 = [
-  {
-    isEnabled: true,
-    targetSelector: 'Auto',
-    connectionId: 1
-  }
-]
 
 # Creates a server profile with the desired Enclosure group and Server hardware type
 oneview_server_profile 'ServerProfile1' do
@@ -179,22 +141,22 @@ oneview_server_profile 'ServerProfile4' do
   volume_attachments(
     [
       {
-        volume: 'test2',
+        volume: 'Volume2',
         attachment_data: {
           id: 1,
           lunType: 'Auto',
-          storagePaths: storage_paths_api_200
+          storagePaths: node.run_state[:storage_paths_for_volume_attachment]
         }
       },
       {
-        volume_data: volume_data_api_200,
+        volume_data: node.run_state[:volume_data_for_volume_attachment],
         storage_system: 'ThreePAR-1',
         storage_pool: 'cpg-growth-limit-1TiB',
         host_os_type: 'Windows 2012 / WS2012 R2',
         attachment_data: {
           id: 2,
           lunType: 'Auto',
-          storagePaths: storage_paths_api_200
+          storagePaths: node.run_state[:storage_paths_for_volume_attachment]
         }
       }
     ]

--- a/examples/server_profile_template.rb
+++ b/examples/server_profile_template.rb
@@ -9,21 +9,93 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
+# NOTE:
+#  It is needed configure previously some things like the network connections, storage pool, storage system, etc., to run this example.
+
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
   user: ENV['ONEVIEWSDK_USER'],
   password: ENV['ONEVIEWSDK_PASSWORD']
 }
 
-enclosure_group = 'eg1'
-server_hardware_type = 'SY 480 Gen9 2'
+enclosure_group = 'EG_1'
+server_hardware_type = 'BL660c Gen9 1'
 sp_name = 'sp1'
+
+# use this to create server profile template with volume attachments using api200 or api300
+volume_data_api_200 = {
+  name: 'Volume1',
+  description: 'volume for api200 or api300',
+  provisioningParameters: {
+    provisionType: 'Full',
+    requestedCapacity: 1024 * 1024 * 1024,
+    shareable: false
+  }
+}
+
+# use this to create server profile template with volume attachments using api500 or greater
+volume_data_api_500 = {
+  name: 'Volume1',
+  description: 'Volume store serv for api500',
+  size: 1024 * 1024 * 1024,
+  provisioningType: 'Thin',
+  isShareable: false
+}
+
+# use this to add storage paths to volume attachments using api200 or api300
+storage_paths_api_200 = [
+  {
+    isEnabled: true,
+    storageTargetType: 'Auto',
+    connectionId: 1
+  }
+]
+
+# use this to add storage paths to volume attachments using api500 or greater
+storage_paths_api_500 = [
+  {
+    isEnabled: true,
+    targetSelector: 'Auto',
+    connectionId: 1
+  }
+]
 
 # Creates on server profile template with the desired Enclosure group and Server hardware type
 oneview_server_profile_template 'ServerProfileTemplate1' do
   client my_client
   enclosure_group enclosure_group
   server_hardware_type server_hardware_type
+  fc_network_connections(
+    FCNetwork1: {
+      id: 1,
+      name: 'Connection1',
+      functionType: 'FibreChannel',
+      portId: 'Auto'
+    }
+  )
+  volume_attachments(
+    [
+      {
+        volume: 'test2',
+        attachment_data: {
+          id: 1,
+          lunType: 'Auto',
+          storagePaths: storage_paths_api_200
+        }
+      },
+      {
+        volume_data: volume_data_api_200,
+        storage_system: 'ThreePAR-1',
+        storage_pool: 'cpg-growth-limit-1TiB',
+        host_os_type: 'Windows 2012 / WS2012 R2',
+        attachment_data: {
+          id: 2,
+          lunType: 'Auto',
+          storagePaths: storage_paths_api_200
+        }
+      }
+    ]
+  )
 end
 
 # Creates on server profile template with the desired Enclosure group and Server hardware type
@@ -34,9 +106,11 @@ oneview_server_profile_template 'ServerProfileTemplate1' do
   action :create_if_missing
 end
 
-# Creates a server profile template using the server profile 'sp1' as a template
+# Creates a server profile template using the server profile 'sp1' as a templates
+# Note: Only to api 500 or greater, comments this recipe if you do not running using api500
 oneview_server_profile_template 'ServerProfileTemplate2' do
   client my_client
+  api_version 500
   server_profile_name sp_name
 end
 

--- a/examples/server_profile_template.rb
+++ b/examples/server_profile_template.rb
@@ -43,18 +43,18 @@ oneview_server_profile_template 'ServerProfileTemplate1' do
         attachment_data: {
           id: 1,
           lunType: 'Auto',
-          storagePaths: node.run_state[:storage_paths_for_volume_attachment]
+          storagePaths: node.run_state['storage_paths_for_volume_attachment']
         }
       },
       {
-        volume_data: node.run_state[:volume_data_for_volume_attachment],
+        volume_data: node.run_state['volume_data_for_volume_attachment'],
         storage_system: 'ThreePAR-1',
         storage_pool: 'cpg-growth-limit-1TiB',
         host_os_type: 'Windows 2012 / WS2012 R2',
         attachment_data: {
           id: 2,
           lunType: 'Auto',
-          storagePaths: node.run_state[:storage_paths_for_volume_attachment]
+          storagePaths: node.run_state['storage_paths_for_volume_attachment']
         }
       }
     ]

--- a/examples/server_profile_template.rb
+++ b/examples/server_profile_template.rb
@@ -12,11 +12,11 @@
 # NOTES:
 # This example requires the following resources to be available in the appliance:
 #  - FC Network: 'FCNetwork1'
-#  - Server Profile: 'sp1'
+#  - Server Profile: 'ServerProfile1'
 #  - Server Hardware Type: 'BL660c Gen9 1'
 #  - Storage System: 'ThreePAR-1'
 #  - Storage Pool: 'cpg-growth-limit-1TiB' (managed)
-#  - Enclosure Group: 'EG_1'
+#  - Enclosure Group: 'EnclosureGroup1'
 #  - Volume: 'Volume2'
 # To create volume attachments:
 #  - The attributes file "volume_attachments_variables" is loading variables to be used in this example.
@@ -29,9 +29,9 @@ my_client = {
   password: ENV['ONEVIEWSDK_PASSWORD']
 }
 
-enclosure_group = 'EG_1'
+enclosure_group = 'EnclosureGroup1'
 server_hardware_type = 'BL660c Gen9 1'
-sp_name = 'sp1'
+sp_name = 'ServerProfile1'
 
 # Creates on server profile template with the desired Enclosure group and Server hardware type
 oneview_server_profile_template 'ServerProfileTemplate1' do
@@ -79,7 +79,7 @@ oneview_server_profile_template 'ServerProfileTemplate1' do
   action :create_if_missing
 end
 
-# Creates a server profile template using the server profile 'sp1' as a templates
+# Creates a server profile template using the server profile 'ServerProfile1' as a templates
 # Note: Only to api 500 or greater, comments this recipe if you do not running using api500
 oneview_server_profile_template 'ServerProfileTemplate2' do
   client my_client

--- a/examples/server_profile_template.rb
+++ b/examples/server_profile_template.rb
@@ -9,8 +9,9 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-# NOTE:
-#  It is needed configure previously some things like the network connections, storage pool, storage system, etc., to run this example.
+# NOTES:
+#  - It is needed configure previously some things like the network connections, storage pool, storage system, etc., to run this example.
+#  - The attributes file "volume_attachments_variables" is loading variables to be used in this example.
 
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
@@ -21,44 +22,6 @@ my_client = {
 enclosure_group = 'EG_1'
 server_hardware_type = 'BL660c Gen9 1'
 sp_name = 'sp1'
-
-# use this to create server profile template with volume attachments using api200 or api300
-volume_data_api_200 = {
-  name: 'Volume1',
-  description: 'volume for api200 or api300',
-  provisioningParameters: {
-    provisionType: 'Full',
-    requestedCapacity: 1024 * 1024 * 1024,
-    shareable: false
-  }
-}
-
-# use this to create server profile template with volume attachments using api500 or greater
-volume_data_api_500 = {
-  name: 'Volume1',
-  description: 'Volume store serv for api500',
-  size: 1024 * 1024 * 1024,
-  provisioningType: 'Thin',
-  isShareable: false
-}
-
-# use this to add storage paths to volume attachments using api200 or api300
-storage_paths_api_200 = [
-  {
-    isEnabled: true,
-    storageTargetType: 'Auto',
-    connectionId: 1
-  }
-]
-
-# use this to add storage paths to volume attachments using api500 or greater
-storage_paths_api_500 = [
-  {
-    isEnabled: true,
-    targetSelector: 'Auto',
-    connectionId: 1
-  }
-]
 
 # Creates on server profile template with the desired Enclosure group and Server hardware type
 oneview_server_profile_template 'ServerProfileTemplate1' do
@@ -76,22 +39,22 @@ oneview_server_profile_template 'ServerProfileTemplate1' do
   volume_attachments(
     [
       {
-        volume: 'test2',
+        volume: 'Volume2',
         attachment_data: {
           id: 1,
           lunType: 'Auto',
-          storagePaths: storage_paths_api_200
+          storagePaths: node.run_state[:storage_paths_for_volume_attachment]
         }
       },
       {
-        volume_data: volume_data_api_200,
+        volume_data: node.run_state[:volume_data_for_volume_attachment],
         storage_system: 'ThreePAR-1',
         storage_pool: 'cpg-growth-limit-1TiB',
         host_os_type: 'Windows 2012 / WS2012 R2',
         attachment_data: {
           id: 2,
           lunType: 'Auto',
-          storagePaths: storage_paths_api_200
+          storagePaths: node.run_state[:storage_paths_for_volume_attachment]
         }
       }
     ]

--- a/examples/server_profile_template.rb
+++ b/examples/server_profile_template.rb
@@ -11,17 +11,9 @@
 
 # NOTES:
 # This example requires the following resources to be available in the appliance:
-#  - FC Network: 'FCNetwork1'
 #  - Server Profile: 'ServerProfile1'
 #  - Server Hardware Type: 'BL660c Gen9 1'
-#  - Storage System: 'ThreePAR-1'
-#  - Storage Pool: 'cpg-growth-limit-1TiB' (managed)
 #  - Enclosure Group: 'EnclosureGroup1'
-#  - Volume: 'Volume2'
-# To create volume attachments:
-#  - The attributes file "volume_attachments_variables" is loading variables to be used in this example.
-#  - The Storage System must have at least one connection using 'FCNetwork1' and this same network network must have uplinkSet connected on the Interconnect,
-#   and the Server Hardware related to that network network is the Server Hardware used in this example.
 
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
@@ -38,37 +30,6 @@ oneview_server_profile_template 'ServerProfileTemplate1' do
   client my_client
   enclosure_group enclosure_group
   server_hardware_type server_hardware_type
-  fc_network_connections(
-    FCNetwork1: {
-      id: 1,
-      name: 'Connection1',
-      functionType: 'FibreChannel',
-      portId: 'Auto'
-    }
-  )
-  volume_attachments(
-    [
-      {
-        volume: 'Volume2',
-        attachment_data: {
-          id: 1,
-          lunType: 'Auto',
-          storagePaths: node.run_state['storage_paths_for_volume_attachment']
-        }
-      },
-      {
-        volume_data: node.run_state['volume_data_for_volume_attachment'],
-        storage_system: 'ThreePAR-1',
-        storage_pool: 'cpg-growth-limit-1TiB',
-        host_os_type: 'Windows 2012 / WS2012 R2',
-        attachment_data: {
-          id: 2,
-          lunType: 'Auto',
-          storagePaths: node.run_state['storage_paths_for_volume_attachment']
-        }
-      }
-    ]
-  )
 end
 
 # Creates on server profile template with the desired Enclosure group and Server hardware type

--- a/examples/server_profile_template.rb
+++ b/examples/server_profile_template.rb
@@ -10,8 +10,18 @@
 # specific language governing permissions and limitations under the License.
 
 # NOTES:
-#  - It is needed configure previously some things like the network connections, storage pool, storage system, etc., to run this example.
+# This example requires the following resources to be available in the appliance:
+#  - FC Network: 'FCNetwork1'
+#  - Server Profile: 'sp1'
+#  - Server Hardware Type: 'BL660c Gen9 1'
+#  - Storage System: 'ThreePAR-1'
+#  - Storage Pool: 'cpg-growth-limit-1TiB' (managed)
+#  - Enclosure Group: 'EG_1'
+#  - Volume: 'Volume2'
+# To create volume attachments:
 #  - The attributes file "volume_attachments_variables" is loading variables to be used in this example.
+#  - The Storage System must have at least one connection using 'FCNetwork1' and this same network network must have uplinkSet connected on the Interconnect,
+#   and the Server Hardware related to that network network is the Server Hardware used in this example.
 
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],

--- a/examples/server_profiles_with_volume_attachments.rb
+++ b/examples/server_profiles_with_volume_attachments.rb
@@ -1,0 +1,112 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# NOTES:
+# This example requires the following resources to be available in the appliance:
+#  - FC Network: 'FCNetwork1'
+#  - Server Hardware Type: 'BL660c Gen9 1'
+#  - Storage System: 'ThreePAR-1'
+#  - Storage Pool: 'cpg-growth-limit-1TiB' (managed)
+#  - Enclosure Group: 'EnclosureGroup1'
+#  - Volume: 'Volume1'
+# To create volume attachments:
+#  - The Storage System must have at least one connection using 'FCNetwork1' and this same network connection must have an uplinkSet connected on the Interconnect,
+#   and the Server Hardware related to that network connection is the Server Hardware used in this example.
+
+my_client = {
+  url: ENV['ONEVIEWSDK_URL'],
+  user: ENV['ONEVIEWSDK_USER'],
+  password: ENV['ONEVIEWSDK_PASSWORD']
+}
+
+enclosure_group_name = 'EnclosureGroup1'
+server_hardware_type_name = 'BL660c Gen9 1'
+fc_network_connection_data = {
+  FCNetwork1: {
+    id: 1,
+    name: 'Connection1',
+    functionType: 'FibreChannel',
+    portId: 'Auto'
+  }
+}
+
+volume_attachments_list = [
+  {
+    volume: 'Volume1',
+    attachment_data: {
+      id: 1,
+      lunType: 'Auto',
+      storagePaths: [
+        {
+          isEnabled: true,
+          storageTargetType: 'Auto',
+          connectionId: 1
+        }
+      ]
+    }
+  },
+  {
+    volume_data: {
+      name: 'Volume2',
+      description: 'volume for api200 or api300',
+      provisioningParameters: {
+        provisionType: 'Full',
+        requestedCapacity: 1024 * 1024 * 1024,
+        shareable: false
+      }
+    },
+    storage_system: 'ThreePAR-1',
+    storage_pool: 'cpg-growth-limit-1TiB',
+    host_os_type: 'Windows 2012 / WS2012 R2',
+    attachment_data: {
+      id: 2,
+      lunType: 'Auto',
+      storagePaths: [
+        {
+          isEnabled: true,
+          storageTargetType: 'Auto',
+          connectionId: 1
+        }
+      ]
+    }
+  }
+]
+
+# Creates a Server Profile Template with volume attachments
+oneview_server_profile_template 'ServerProfileTemplate1' do
+  client my_client
+  enclosure_group enclosure_group_name
+  server_hardware_type server_hardware_type_name
+  fc_network_connections fc_network_connection_data
+  volume_attachments volume_attachments_list
+end
+
+
+# Creates a Server Profile with volume attachments
+oneview_server_profile 'ServerProfile1' do
+  client my_client
+  enclosure_group enclosure_group_name
+  server_hardware_type server_hardware_type_name
+  fc_network_connections fc_network_connection_data
+  volume_attachments volume_attachments_list
+end
+
+# Deletes server profile created
+oneview_server_profile_template 'ServerProfileTemplate1' do
+  client my_client
+  action :delete
+end
+
+# Deletes server profile created
+oneview_server_profile 'ServerProfile1' do
+  client my_client
+  action :delete
+end

--- a/examples/server_profiles_with_volume_attachments_api500.rb
+++ b/examples/server_profiles_with_volume_attachments_api500.rb
@@ -1,0 +1,111 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# NOTES:
+# This example requires the following resources to be available in the appliance:
+#  - FC Network: 'FCNetwork1'
+#  - Server Hardware Type: 'BL660c Gen9 1'
+#  - Storage System: 'ThreePAR-1'
+#  - Storage Pool: 'cpg-growth-limit-1TiB' (managed)
+#  - Enclosure Group: 'EnclosureGroup1'
+#  - Volume: 'Volume1'
+# To create volume attachments:
+#  - The Storage System must have at least one connection using 'FCNetwork1' and this same network connection must have an uplinkSet connected on the Interconnect,
+#   and the Server Hardware related to that network connection is the Server Hardware used in this example.
+
+my_client = {
+  url: ENV['ONEVIEWSDK_URL'],
+  user: ENV['ONEVIEWSDK_USER'],
+  password: ENV['ONEVIEWSDK_PASSWORD'],
+  api_version: 500
+}
+
+enclosure_group_name = 'EnclosureGroup1'
+server_hardware_type_name = 'BL660c Gen9 1'
+fc_network_connection_data = {
+  FCNetwork1: {
+    id: 1,
+    name: 'Connection1',
+    functionType: 'FibreChannel',
+    portId: 'Auto'
+  }
+}
+
+volume_attachments_list = [
+  {
+    volume: 'Volume1',
+    attachment_data: {
+      id: 1,
+      lunType: 'Auto',
+      storagePaths: [
+        {
+          isEnabled: true,
+          targetSelector: 'Auto',
+          connectionId: 1
+        }
+      ]
+    }
+  },
+  {
+    volume_data: {
+      name: 'Volume2',
+      description: 'volume for api200 or api300',
+      size: 1024 * 1024 * 1024,
+      provisioningType: 'Thin',
+      isShareable: false
+    },
+    storage_system: 'ThreePAR-1',
+    storage_pool: 'cpg-growth-limit-1TiB',
+    host_os_type: 'Windows 2012 / WS2012 R2',
+    attachment_data: {
+      id: 2,
+      lunType: 'Auto',
+      storagePaths: [
+        {
+          isEnabled: true,
+          targetSelector: 'Auto',
+          connectionId: 1
+        }
+      ]
+    }
+  }
+]
+
+# Creates a Server Profile Template with volume attachments
+oneview_server_profile_template 'ServerProfileTemplate1' do
+  client my_client
+  enclosure_group enclosure_group_name
+  server_hardware_type server_hardware_type_name
+  fc_network_connections fc_network_connection_data
+  volume_attachments volume_attachments_list
+end
+
+
+# Creates a Server Profile with volume attachments
+oneview_server_profile 'ServerProfile1' do
+  client my_client
+  enclosure_group enclosure_group_name
+  server_hardware_type server_hardware_type_name
+  fc_network_connections fc_network_connection_data
+  volume_attachments volume_attachments_list
+end
+
+# Deletes the Server Profile Template created
+oneview_server_profile_template 'ServerProfileTemplate1' do
+  client my_client
+  action :delete
+end
+
+# Deletes the Server Profile created
+oneview_server_profile 'ServerProfile1' do
+  client my_client
+  action :delete
+end

--- a/libraries/resource_providers/api200/server_profile_provider.rb
+++ b/libraries/resource_providers/api200/server_profile_provider.rb
@@ -31,13 +31,12 @@ module OneviewCookbook
       end
 
       def build_volume_attachments
-        return unless @new_resource.volume_attachments
         @new_resource.volume_attachments.each do |options|
           options = convert_keys(options, :to_s)
           volume_name = options['volume']
           volume_data = options['volume_data']
           attachment_data = options.fetch('attachment_data', {})
-          raise("To add volume attachments you need to specify the 'volume' or 'volume_data' insides 'volume_attachments' options") unless volume_name || volume_data
+          raise("To add volume attachments you need to specify the 'volume' or 'volume_data' inside 'volume_attachments' options") unless volume_name || volume_data
           if volume_name
             volume = load_resource(:Volume, name: volume_name)
             @item.add_volume_attachment(volume, attachment_data)

--- a/libraries/resource_providers/api200/server_profile_provider.rb
+++ b/libraries/resource_providers/api200/server_profile_provider.rb
@@ -37,14 +37,15 @@ module OneviewCookbook
           volume_name = options['volume']
           volume_data = options['volume_data']
           attachment_data = options.fetch('attachment_data', {})
-          raise('To add volume attachments you need volume or volume_data into each data of volume_attachments') unless volume_name || volume_data
+          raise("To add volume attachments you need to specify the 'volume' or 'volume_data' insides 'volume_attachments' options") unless volume_name || volume_data
           if volume_name
             volume = load_resource(:Volume, name: volume_name)
             @item.add_volume_attachment(volume, attachment_data)
           else
             storage_system_name = options.delete('storage_system')
             storage_pool_name = options.delete('storage_pool')
-            raise('To create a new volume with attachment you need storage_system and storage_pool') unless storage_system_name && storage_pool_name
+            can_create_volume = storage_system_name && storage_pool_name
+            raise("To create a new volume with an attachment you need to specify the 'storage_system' and 'storage_pool' names inside 'volume_attachments' options.") unless can_create_volume
             storage_system_uri = load_resource(:StorageSystem, { hostname: storage_system_name, name: storage_system_name }, :uri)
             storage_pool = load_resource(:StoragePool, name: storage_pool_name, storageSystemUri: storage_system_uri)
             @item.create_volume_with_attachment(storage_pool, volume_data, attachment_data)

--- a/libraries/resource_providers/api200/server_profile_provider.rb
+++ b/libraries/resource_providers/api200/server_profile_provider.rb
@@ -30,6 +30,29 @@ module OneviewCookbook
         true
       end
 
+      def build_volume_attachments
+        return unless @new_resource.volume_attachments
+        @new_resource.volume_attachments.each do |options|
+          options = convert_keys(options, :to_s)
+          volume_name = options['volume']
+          volume_data = options['volume_data']
+          attachment_data = options.fetch('attachment_data', {})
+          raise('To add volume attachments you need volume or volume_data into each data of volume_attachments') unless volume_name || volume_data
+          if volume_name
+            volume = load_resource(:Volume, name: volume_name)
+            @item.add_volume_attachment(volume, attachment_data)
+          else
+            storage_system_name = options.delete('storage_system')
+            storage_pool_name = options.delete('storage_pool')
+            raise('To create a new volume with attachment you need storage_system and storage_pool') unless storage_system_name && storage_pool_name
+            storage_system_uri = load_resource(:StorageSystem, { hostname: storage_system_name, name: storage_system_name }, :uri)
+            storage_pool = load_resource(:StoragePool, name: storage_pool_name, storageSystemUri: storage_system_uri)
+            @item.create_volume_with_attachment(storage_pool, volume_data, attachment_data)
+          end
+          @item['sanStorage']['hostOSType'] = options['host_os_type']
+        end
+      end
+
       def set_resource(type, name, method, args = [])
         return false unless name
         @item.public_send(method, load_resource(type, name), *args)
@@ -51,6 +74,7 @@ module OneviewCookbook
         set_connections(:FCNetwork, @new_resource.fc_network_connections)
         set_connections(:FCoENetwork, @new_resource.fcoe_network_connections)
         set_connections(:NetworkSet, @new_resource.network_set_connections)
+        build_volume_attachments
       end
 
       # Override create method to allow creation from a template

--- a/libraries/resource_providers/api200/server_profile_template_provider.rb
+++ b/libraries/resource_providers/api200/server_profile_template_provider.rb
@@ -24,6 +24,7 @@ module OneviewCookbook
         set_connections(:EthernetNetwork, @new_resource.ethernet_network_connections)
         set_connections(:FCNetwork, @new_resource.fc_network_connections)
         set_connections(:NetworkSet, @new_resource.network_set_connections)
+        build_volume_attachments
       end
 
       def create_or_update

--- a/resources/server_profile.rb
+++ b/resources/server_profile.rb
@@ -22,6 +22,7 @@ property :fcoe_network_connections, Object
 property :network_set_connections, Object
 property :server_profile_template, String
 property :os_deployment_plan, String
+property :volume_attachments, Array, default: []
 
 default_action :create
 

--- a/resources/server_profile_template.rb
+++ b/resources/server_profile_template.rb
@@ -21,6 +21,7 @@ property :network_set_connections, Object
 property :fc_network_connections, Object
 property :server_profile_name, String
 property :os_deployment_plan, String
+property :volume_attachments, Array, default: []
 
 default_action :create
 

--- a/spec/fixtures/cookbooks/oneview_test/recipes/server_profile_add_volume_attachments.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/server_profile_add_volume_attachments.rb
@@ -1,0 +1,32 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: server_profile_add_volume_attachments
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_server_profile 'ServerProfile1' do
+  client node['oneview_test']['client']
+  volume_attachments(
+    [
+      {
+        'volume' => 'Volume1',
+        'attachment_data' => { 'attr_1' => 'attr 1' }
+      },
+      {
+        'volume' => 'Volume2',
+        'attachment_data' => { 'attr_2' => 'attr 2' }
+      }
+    ]
+  )
+  action :create
+end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/server_profile_create_volume_attachments.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/server_profile_create_volume_attachments.rb
@@ -1,0 +1,36 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: server_profile_create_volume_attachments
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_server_profile 'ServerProfile1' do
+  client node['oneview_test']['client']
+  volume_attachments(
+    [
+      {
+        'volume_data' => { 'name' => 'Volume1' },
+        'storage_system' => 'StorageSystem1',
+        'storage_pool' => 'StoragePool1',
+        'attachment_data' => { 'attr_1' => 'attr 1' }
+      },
+      {
+        'volume_data' => { 'name' => 'Volume2' },
+        'storage_system' => 'StorageSystem2',
+        'storage_pool' => 'StoragePool2',
+        'attachment_data' => { 'attr_2' => 'attr 2' }
+      }
+    ]
+  )
+  action :create
+end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/server_profile_create_wrong_volume_attachments.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/server_profile_create_wrong_volume_attachments.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: server_profile_create_wrong_volume_attachments
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_server_profile 'ServerProfile1' do
+  client node['oneview_test']['client']
+  volume_attachments [{}]
+  action :create
+end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/server_profile_template_add_volume_attachments.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/server_profile_template_add_volume_attachments.rb
@@ -1,0 +1,32 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: server_profile_template_add_volume_attachments
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_server_profile_template 'ServerProfileTemplate1' do
+  client node['oneview_test']['client']
+  volume_attachments(
+    [
+      {
+        'volume' => 'Volume1',
+        'attachment_data' => { 'attr_1' => 'attr 1' }
+      },
+      {
+        'volume' => 'Volume2',
+        'attachment_data' => { 'attr_2' => 'attr 2' }
+      }
+    ]
+  )
+  action :create
+end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/server_profile_template_create_volume_attachments.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/server_profile_template_create_volume_attachments.rb
@@ -1,0 +1,36 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: server_profile_template_create_volume_attachments
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_server_profile_template 'ServerProfileTemplate1' do
+  client node['oneview_test']['client']
+  volume_attachments(
+    [
+      {
+        'volume_data' => { 'name' => 'Volume1' },
+        'storage_system' => 'StorageSystem1',
+        'storage_pool' => 'StoragePool1',
+        'attachment_data' => { 'attr_1' => 'attr 1' }
+      },
+      {
+        'volume_data' => { 'name' => 'Volume2' },
+        'storage_system' => 'StorageSystem2',
+        'storage_pool' => 'StoragePool2',
+        'attachment_data' => { 'attr_2' => 'attr 2' }
+      }
+    ]
+  )
+  action :create
+end

--- a/spec/fixtures/cookbooks/oneview_test/recipes/server_profile_template_create_wrong_volume_attachments.rb
+++ b/spec/fixtures/cookbooks/oneview_test/recipes/server_profile_template_create_wrong_volume_attachments.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: oneview_test
+# Recipe:: server_profile_template_create_wrong_volume_attachments
+#
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+oneview_server_profile_template 'ServerProfileTemplate1' do
+  client node['oneview_test']['client']
+  volume_attachments [{}]
+  action :create
+end

--- a/spec/unit/resources/server_profile/create_spec.rb
+++ b/spec/unit/resources/server_profile/create_spec.rb
@@ -4,26 +4,36 @@ describe 'oneview_test::server_profile_create' do
   let(:resource_name) { 'server_profile' }
   include_context 'chef context'
 
+  let(:target_class) { OneviewSDK::ServerProfile }
+
   it 'creates it when it does not exist' do
-    expect_any_instance_of(OneviewSDK::ServerProfile).to receive(:exists?).and_return(false)
-    expect_any_instance_of(OneviewSDK::ServerProfile).to receive(:create).and_return(true)
+    expect_any_instance_of(target_class).to receive(:exists?).and_return(false)
+    expect_any_instance_of(target_class).to receive(:create).and_return(true)
     expect(real_chef_run).to create_oneview_server_profile('ServerProfile1')
   end
 
   it 'updates it when it exists but not alike' do
-    expect_any_instance_of(OneviewSDK::ServerProfile).to receive(:exists?).and_return(true)
-    expect_any_instance_of(OneviewSDK::ServerProfile).to receive(:retrieve!).and_return(true)
-    expect_any_instance_of(OneviewSDK::ServerProfile).to receive(:like?).and_return(false)
-    expect_any_instance_of(OneviewSDK::ServerProfile).to receive(:update).and_return(true)
+    expect_any_instance_of(target_class).to receive(:exists?).and_return(true)
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:like?).and_return(false)
+    expect_any_instance_of(target_class).to receive(:update).and_return(true)
     expect(real_chef_run).to create_oneview_server_profile('ServerProfile1')
   end
 
   it 'does nothing when it exists and is alike' do
-    expect_any_instance_of(OneviewSDK::ServerProfile).to receive(:exists?).and_return(true)
-    expect_any_instance_of(OneviewSDK::ServerProfile).to receive(:retrieve!).and_return(true)
-    expect_any_instance_of(OneviewSDK::ServerProfile).to receive(:like?).and_return(true)
-    expect_any_instance_of(OneviewSDK::ServerProfile).to_not receive(:update)
-    expect_any_instance_of(OneviewSDK::ServerProfile).to_not receive(:create)
+    expect_any_instance_of(target_class).to receive(:exists?).and_return(true)
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:like?).and_return(true)
+    expect_any_instance_of(target_class).to_not receive(:update)
+    expect_any_instance_of(target_class).to_not receive(:create)
+    expect(real_chef_run).to create_oneview_server_profile('ServerProfile1')
+  end
+
+  it 'does not build volume attachments' do
+    expect_any_instance_of(target_class).to receive(:exists?).and_return(false)
+    expect_any_instance_of(target_class).to receive(:create).and_return(true)
+    expect_any_instance_of(target_class).to_not receive(:add_volume_attachment)
+    expect_any_instance_of(target_class).to_not receive(:create_volume_with_attachment)
     expect(real_chef_run).to create_oneview_server_profile('ServerProfile1')
   end
 end

--- a/spec/unit/resources/server_profile/create_spec.rb
+++ b/spec/unit/resources/server_profile/create_spec.rb
@@ -4,7 +4,7 @@ describe 'oneview_test::server_profile_create' do
   let(:resource_name) { 'server_profile' }
   include_context 'chef context'
 
-  let(:target_class) { OneviewSDK::ServerProfile }
+  let(:target_class) { OneviewSDK::API200::ServerProfile }
 
   it 'creates it when it does not exist' do
     expect_any_instance_of(target_class).to receive(:exists?).and_return(false)

--- a/spec/unit/resources/server_profile/with_volume_attachments_spec.rb
+++ b/spec/unit/resources/server_profile/with_volume_attachments_spec.rb
@@ -1,0 +1,32 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test::server_profile_add_volume_attachments' do
+  let(:resource_name) { 'server_profile' }
+  include_context 'chef context'
+
+  let(:base_sdk) { OneviewSDK::API200 }
+  let(:target_class) { base_sdk::ServerProfile }
+  let(:target_provider_class) { OneviewCookbook::API200::ServerProfileProvider }
+  let(:target_match_method) { [:create_oneview_server_profile, 'ServerProfile1'] }
+  it_behaves_like 'action :create #add_volume_attachments'
+end
+
+describe 'oneview_test::server_profile_create_volume_attachments' do
+  let(:resource_name) { 'server_profile' }
+  include_context 'chef context'
+
+  let(:base_sdk) { OneviewSDK::API200 }
+  let(:target_class) { base_sdk::ServerProfile }
+  let(:target_provider_class) { OneviewCookbook::API200::ServerProfileProvider }
+  let(:target_match_method) { [:create_oneview_server_profile, 'ServerProfile1'] }
+  it_behaves_like 'action :create #create_volume_attachments'
+end
+
+describe 'oneview_test::server_profile_create_wrong_volume_attachments' do
+  let(:resource_name) { 'server_profile' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API200::ServerProfile }
+  let(:target_match_method) { [:create_oneview_server_profile, 'ServerProfile1'] }
+  it_behaves_like 'action :create #create_volume_attachments with wrong data'
+end

--- a/spec/unit/resources/server_profile_template/with_volume_attachments_spec.rb
+++ b/spec/unit/resources/server_profile_template/with_volume_attachments_spec.rb
@@ -1,0 +1,32 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test::server_profile_template_add_volume_attachments' do
+  let(:resource_name) { 'server_profile_template' }
+  include_context 'chef context'
+
+  let(:base_sdk) { OneviewSDK::API200 }
+  let(:target_class) { base_sdk::ServerProfileTemplate }
+  let(:target_provider_class) { OneviewCookbook::API200::ServerProfileTemplateProvider }
+  let(:target_match_method) { [:create_oneview_server_profile_template, 'ServerProfileTemplate1'] }
+  it_behaves_like 'action :create #add_volume_attachments'
+end
+
+describe 'oneview_test::server_profile_template_create_volume_attachments' do
+  let(:resource_name) { 'server_profile_template' }
+  include_context 'chef context'
+
+  let(:base_sdk) { OneviewSDK::API200 }
+  let(:target_class) { base_sdk::ServerProfileTemplate }
+  let(:target_provider_class) { OneviewCookbook::API200::ServerProfileTemplateProvider }
+  let(:target_match_method) { [:create_oneview_server_profile_template, 'ServerProfileTemplate1'] }
+  it_behaves_like 'action :create #create_volume_attachments'
+end
+
+describe 'oneview_test::server_profile_template_create_wrong_volume_attachments' do
+  let(:resource_name) { 'server_profile_template' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API200::ServerProfileTemplate }
+  let(:target_match_method) { [:create_oneview_server_profile_template, 'ServerProfileTemplate1'] }
+  it_behaves_like 'action :create #create_volume_attachments with wrong data'
+end

--- a/spec/unit/shared_examples/volume_attachments.rb
+++ b/spec/unit/shared_examples/volume_attachments.rb
@@ -89,6 +89,6 @@ RSpec.shared_examples 'action :create #create_volume_attachments with wrong data
     allow_any_instance_of(target_class).to receive(:exists?).and_return(false)
     expect_any_instance_of(target_class).not_to receive(:create_volume_with_attachment)
     expect_any_instance_of(target_class).not_to receive(:add_volume_attachment)
-    expect { real_chef_run }.to raise_error(/To add volume attachments you need to specify the 'volume' or 'volume_data' insides 'volume_attachments' options/)
+    expect { real_chef_run }.to raise_error(/specify the 'volume' or 'volume_data' inside 'volume_attachments'/)
   end
 end

--- a/spec/unit/shared_examples/volume_attachments.rb
+++ b/spec/unit/shared_examples/volume_attachments.rb
@@ -89,6 +89,6 @@ RSpec.shared_examples 'action :create #create_volume_attachments with wrong data
     allow_any_instance_of(target_class).to receive(:exists?).and_return(false)
     expect_any_instance_of(target_class).not_to receive(:create_volume_with_attachment)
     expect_any_instance_of(target_class).not_to receive(:add_volume_attachment)
-    expect { real_chef_run }.to raise_error(/To add volume attachments you need volume or volume_data into each data of volume_attachments/)
+    expect { real_chef_run }.to raise_error(/To add volume attachments you need to specify the 'volume' or 'volume_data' insides 'volume_attachments' options/)
   end
 end

--- a/spec/unit/shared_examples/volume_attachments.rb
+++ b/spec/unit/shared_examples/volume_attachments.rb
@@ -1,0 +1,94 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# NOTE:
+# This shared example requires the following variables:
+#  base_sdk - The base sdk prefix of Oneview resources used in this test.
+#    e.g: let(:base_sdk) { OneviewSDK::API200 }
+#  target_class - Full name of the OneView resource to be tested
+#  target_provider_class - Full name of the resource provider to be tested
+#  target_match_method - Array with name of match method called and with the argument of the match method,
+#    e.g: let(:target_match_method) { [:create_oneview_server_profile, 'ServerProfileName'] }
+RSpec.shared_examples 'action :create #add_volume_attachments' do
+  it 'should #add_volume_attachment' do
+    allow_any_instance_of(target_class).to receive(:[]).with('name')
+    allow_any_instance_of(target_class).to receive(:exists?).and_return(false)
+    allow_any_instance_of(target_class).to receive(:create).and_return(true)
+    allow_any_instance_of(base_sdk::Volume).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_provider_class)
+      .to receive(:load_resource)
+      .with(:Volume, name: 'Volume1')
+      .and_call_original
+    expect_any_instance_of(target_provider_class)
+      .to receive(:load_resource)
+      .with(:Volume, name: 'Volume2')
+      .and_call_original
+    expect_any_instance_of(target_class).to receive(:add_volume_attachment)
+      .with(instance_of(base_sdk::Volume), 'attr_1' => 'attr 1')
+    expect_any_instance_of(target_class).to receive(:add_volume_attachment)
+      .with(instance_of(base_sdk::Volume), 'attr_2' => 'attr 2')
+    expect_any_instance_of(target_class).to receive(:[]).twice.with('sanStorage').and_return({})
+    expect_any_instance_of(base_sdk::StorageSystem).not_to receive(:retrieve!)
+    expect_any_instance_of(base_sdk::StoragePool).not_to receive(:retrieve!)
+    expect_any_instance_of(target_class).not_to receive(:create_volume_with_attachment)
+    expect(real_chef_run).to public_send(*target_match_method)
+  end
+end
+
+RSpec.shared_examples 'action :create #create_volume_attachments' do
+  it 'should #add_volume_attachment' do
+    allow_any_instance_of(target_class).to receive(:[]).with('name')
+    allow_any_instance_of(target_class).to receive(:exists?).and_return(false)
+    allow_any_instance_of(target_class).to receive(:create).and_return(true)
+    allow_any_instance_of(base_sdk::StorageSystem).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(base_sdk::StoragePool).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_provider_class)
+      .to receive(:load_resource)
+      .with(:StorageSystem, { hostname: 'StorageSystem1', name: 'StorageSystem1' }, :uri)
+      .and_call_original
+    expect_any_instance_of(target_provider_class)
+      .to receive(:load_resource)
+      .with(:StorageSystem, { hostname: 'StorageSystem2', name: 'StorageSystem2' }, :uri)
+      .and_call_original
+    expect(base_sdk::StorageSystem).to receive(:new)
+      .and_return(base_sdk::StorageSystem.new(client, uri: 'fake/StorageSystem1'), base_sdk::StorageSystem.new(client, uri: 'fake/StorageSystem2'))
+    expect_any_instance_of(target_provider_class)
+      .to receive(:load_resource)
+      .with(:StoragePool, name: 'StoragePool1', storageSystemUri: 'fake/StorageSystem1')
+      .and_call_original
+    expect_any_instance_of(target_provider_class)
+      .to receive(:load_resource)
+      .with(:StoragePool, name: 'StoragePool2', storageSystemUri: 'fake/StorageSystem2')
+      .and_call_original
+    expect_any_instance_of(target_class).to receive(:create_volume_with_attachment)
+      .with(instance_of(base_sdk::StoragePool), { 'name' => 'Volume1' }, 'attr_1' => 'attr 1')
+    expect_any_instance_of(target_class).to receive(:create_volume_with_attachment)
+      .with(instance_of(base_sdk::StoragePool), { 'name' => 'Volume2' }, 'attr_2' => 'attr 2')
+    expect_any_instance_of(target_class).to receive(:[]).twice.with('sanStorage').and_return({})
+    expect_any_instance_of(base_sdk::Volume).not_to receive(:retrieve!)
+    expect_any_instance_of(target_class).not_to receive(:add_volume_attachment)
+    expect(real_chef_run).to public_send(*target_match_method)
+  end
+end
+
+# NOTE:
+# This shared example requires the following variables:
+#  target_class - Full name of the OneView resource to be tested
+#  target_match_method - Array with name of match method called and with the argument of the match method,
+#    e.g: let(:target_match_method) { [:create_oneview_server_profile, 'ServerProfileName'] }
+RSpec.shared_examples 'action :create #create_volume_attachments with wrong data' do
+  it 'should #add_volume_attachment' do
+    allow_any_instance_of(target_class).to receive(:exists?).and_return(false)
+    expect_any_instance_of(target_class).not_to receive(:create_volume_with_attachment)
+    expect_any_instance_of(target_class).not_to receive(:add_volume_attachment)
+    expect { real_chef_run }.to raise_error(/To add volume attachments you need volume or volume_data into each data of volume_attachments/)
+  end
+end


### PR DESCRIPTION
### Description
Added helper method to be used by Server Profile and Server Profile Template to attach Volumes.
The method can create a Volume and attach it or just attach a already created Volume, just based on the information of `volume_attachments` property of oneview_server_profile resource or oneview_server_profile_template resource.

The tests about volume attachments are shared by oneview_server_profile and oneview_server_profile_template.

### Issues Resolved
#309 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
