### PR TITLE
Removing warning logs when runs some unit tests

### DIFF
--- a/spec/unit/resources/power_device/discover_spec.rb
+++ b/spec/unit/resources/power_device/discover_spec.rb
@@ -37,7 +37,7 @@ describe 'oneview_test::power_device_discover' do
     allow(target_class).to receive(:get_ipdu_devices).and_return([])
     allow(target_class).to receive(:discover) { OneviewSDK::TaskError.raise!('... Unable to retrieve the input certificate ...') }
     expect(target_class).to receive(:discover).once
-    expect { real_chef_run }.to raise_error(/Unable to retrieve the input certificate/)
+    expect { real_chef_run }.to raise_error(StandardError, /Unable to retrieve the input certificate/)
   end
 end
 
@@ -59,6 +59,7 @@ describe 'oneview_test::power_device_discover_auto_import_certificate' do
     allow(target_class).to receive(:discover) do
       OneviewSDK::TaskError.raise!('... Unable to retrieve the input certificate ...') if with_error_seq.shift
     end
+    expect(Chef::Log).to receive(:warn)
     expect(target_class).to receive(:discover)
       .with(
         kind_of(OneviewSDK::Client),
@@ -88,6 +89,7 @@ describe 'oneview_test::power_device_discover_auto_import_certificate' do
     allow(target_class).to receive(:discover) do
       OneviewSDK::TaskError.raise!('... Unable to retrieve the input certificate ...') if with_error_seq.shift
     end
+    expect(Chef::Log).to receive(:warn)
     expect_any_instance_of(base_sdk::ClientCertificate).to receive(:retrieve!).and_return(true)
     expect_any_instance_of(base_sdk::ClientCertificate).not_to receive(:import)
     expect(target_class).to receive(:discover).twice
@@ -98,6 +100,6 @@ describe 'oneview_test::power_device_discover_auto_import_certificate' do
     allow(target_class).to receive(:get_ipdu_devices).and_return([])
     allow(target_class).to receive(:discover) { OneviewSDK::TaskError.raise!('some error') }
     expect(target_class).to receive(:discover).once
-    expect { real_chef_run }.to raise_error(/some error/)
+    expect { real_chef_run }.to raise_error(StandardError, /some error/)
   end
 end

--- a/spec/unit/shared_examples/volume_attachments.rb
+++ b/spec/unit/shared_examples/volume_attachments.rb
@@ -89,6 +89,6 @@ RSpec.shared_examples 'action :create #create_volume_attachments with wrong data
     allow_any_instance_of(target_class).to receive(:exists?).and_return(false)
     expect_any_instance_of(target_class).not_to receive(:create_volume_with_attachment)
     expect_any_instance_of(target_class).not_to receive(:add_volume_attachment)
-    expect { real_chef_run }.to raise_error(/specify the 'volume' or 'volume_data' inside 'volume_attachments'/)
+    expect { real_chef_run }.to raise_error(StandardError, /specify the 'volume' or 'volume_data' inside 'volume_attachments'/)
   end
 end


### PR DESCRIPTION
### Description
The unit tests related to volume attachments and :discover of power device are showing logs warnings when tests are executed, making the result of tests on console much dirty with messages.

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [ ] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
