### PR TITLE
Fixed wrong name of property used at firmware example

### DIFF
--- a/examples/firmware.rb
+++ b/examples/firmware.rb
@@ -40,7 +40,7 @@ end
 # Uses spp_file and hotfixes_files as reference
 oneview_firmware 'CustomSPP' do
   client my_client
-  spp_files '/bundles/firmware_bundle_name.iso'
+  spp_file '/bundles/firmware_bundle_name.iso'
   hotfixes_files ['/bundles/hotfix_name.rpm']
   action :create_custom_spp
 end


### PR DESCRIPTION
### Description
Just a fixing of wrong property used at firmware example.

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [ ] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
