### PR TITLE
Using helper method of StoragePool API500 into Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Enhancements:
 - [#306](https://github.com/HewlettPackard/oneview-chef/issues/306) Create shared examples to unit tests that using scope actions
 - [#336](https://github.com/HewlettPackard/oneview-chef/issues/336) Remove :new_profile action of oneview_server_profile_template
 - [#309](https://github.com/HewlettPackard/oneview-chef/issues/309) Add volume_attachment property to Server Profiles and SP Templates so VAs can be more easily managed
+- [#343](https://github.com/HewlettPackard/oneview-chef/issues/343) Use helper method of OneviewSDK StoragePool to set StorageSystem to a StoragePool of API500
 
 Bug fixes:
 - [#284](https://github.com/HewlettPackard/oneview-chef/issues/284) Nested and cyclic requires are causing the first resource to be skipped

--- a/libraries/resource_providers/api500/c7000/storage_pool_provider.rb
+++ b/libraries/resource_providers/api500/c7000/storage_pool_provider.rb
@@ -25,7 +25,7 @@ module OneviewCookbook
 
         def load_storage_system
           raise("Unspecified property: 'storage_system'. Please set it before attempting this action.") unless @new_resource.storage_system
-          @item['storageSystemUri'] = load_resource(:StorageSystem, { hostname: @new_resource.storage_system, name: @new_resource.storage_system }, :uri)
+          @item.set_storage_system(load_resource(:StorageSystem, hostname: @new_resource.storage_system, name: @new_resource.storage_system))
         end
 
         def update_manage_state(managed)

--- a/spec/unit/resources/storage_pool/add_for_management_spec.rb
+++ b/spec/unit/resources/storage_pool/add_for_management_spec.rb
@@ -7,7 +7,8 @@ describe 'oneview_test_api500_synergy::storage_pool_add_for_management' do
   include_context 'chef context'
 
   before(:each) do
-    allow_any_instance_of(provider_class).to receive(:load_resource).with(:StorageSystem, anything, :uri).and_return('LoadedStorageSystem')
+    allow_any_instance_of(base_sdk::StorageSystem).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(provider_class).to receive(:load_resource).with(:StorageSystem, anything).and_return(base_sdk::StorageSystem.new(client500, uri: '/sotrage-system/1'))
   end
 
   it 'raises an error if it does not exist' do

--- a/spec/unit/resources/storage_pool/refresh_spec.rb
+++ b/spec/unit/resources/storage_pool/refresh_spec.rb
@@ -4,11 +4,15 @@ describe 'oneview_test_api500_synergy::storage_pool_refresh' do
   let(:resource_name) { 'storage_pool' }
   include_context 'chef context'
 
-  let(:target_class) { OneviewSDK::API500::Synergy::StoragePool }
+  let(:base_sdk) { OneviewSDK::API500::Synergy }
+  let(:target_class) { base_sdk::StoragePool }
   let(:target_match_method) { [:refresh_oneview_storage_pool, 'StoragePool'] }
   it_behaves_like 'action :refresh #request_refresh' do
     before do
-      allow_any_instance_of(OneviewCookbook::API500::Synergy::StoragePoolProvider).to receive(:load_resource).with(:StorageSystem, anything, :uri)
+      allow_any_instance_of(base_sdk::StorageSystem).to receive(:retrieve!).and_return(true)
+      allow_any_instance_of(OneviewCookbook::API500::Synergy::StoragePoolProvider).to receive(:load_resource)
+        .with(:StorageSystem, anything)
+        .and_return(base_sdk::StorageSystem.new(client500, uri: '/sotrage-system/1'))
     end
   end
 end

--- a/spec/unit/resources/storage_pool/remove_from_management_spec.rb
+++ b/spec/unit/resources/storage_pool/remove_from_management_spec.rb
@@ -7,8 +7,8 @@ describe 'oneview_test_api500_synergy::storage_pool_remove_from_management' do
   include_context 'chef context'
 
   before(:each) do
-    allow_any_instance_of(provider_class).to receive(:load_resource).with(:StorageSystem, anything, :uri).and_return('LoadedStorageSystem')
-    allow_any_instance_of(base_sdk::StoragePool).to receive(:set_storage_system).with('LoadedStorageSystem').and_return(true)
+    allow_any_instance_of(base_sdk::StorageSystem).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(provider_class).to receive(:load_resource).with(:StorageSystem, anything).and_return(base_sdk::StorageSystem.new(client500, uri: '/sotrage-system/1'))
   end
 
   it 'raises an error if it does not exist' do

--- a/spec/unit/resources/storage_pool/update_spec.rb
+++ b/spec/unit/resources/storage_pool/update_spec.rb
@@ -7,8 +7,8 @@ describe 'oneview_test_api500_synergy::storage_pool_update' do
   include_context 'chef context'
 
   before(:each) do
-    allow_any_instance_of(provider_class).to receive(:load_resource).with(:StorageSystem, anything, :uri).and_return('LoadedStorageSystem')
-    allow_any_instance_of(base_sdk::StoragePool).to receive(:set_storage_system).with('LoadedStorageSystem').and_return(true)
+    allow_any_instance_of(base_sdk::StorageSystem).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(provider_class).to receive(:load_resource).with(:StorageSystem, anything).and_return(base_sdk::StorageSystem.new(client500, uri: '/sotrage-system/1'))
   end
 
   it 'raises an error if it does not exist' do


### PR DESCRIPTION
### Description
When StoragePoolProvider is loading StorageSystem to set it into StoragePool resource instance, the called method of StoragePool instance is now `set_storage_sytem`.

ATTENTION: 
- This PR cannot be merge for now, because the [PR 286](https://github.com/HewlettPackard/oneview-sdk-ruby/pull/286) of `oneview-sdk-ruby` must be merge before.
- The tests are failling (consequently, the build) because the reason cited above.
- For testing that changes you must change the path to oneview-sdk gem into your Gemfile, like code below:
```ruby
gem 'oneview-sdk', path: '/oneview-sdk-ruby'
```

### Issues Resolved
Fixes #343 

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
