### PR TITLE
New reapply_configuration action to oneview_interconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.0 (Unreleased)
+
+## New Features:
+- [#346](https://github.com/HewlettPackard/oneview-chef/issues/346) Add action to reapply configuration of oneview_interconnect API500
+
 ## 3.0.0
 Adds API 500 support to the following HPE OneView resources:
   - oneview_connection_template

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ oneview_interconnect 'Interconnect1' do
   port_options <port_data_hash>            # Required for :update_port
   uid_light_state <uid_light_state_string> # Required for :set_uid_light
   power_state <power_state_string>         # Required for :set_power_state
-  action [:reset, :reset_port_protection, :update_port, :set_uid_light, :set_power_state]
+  action [:reset, :reset_port_protection, :update_port, :set_uid_light, :set_power_state, :reapply_configuration]
 end
 ```
 

--- a/examples/interconnect.rb
+++ b/examples/interconnect.rb
@@ -12,7 +12,8 @@
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
   user: ENV['ONEVIEWSDK_USER'],
-  password: ENV['ONEVIEWSDK_PASSWORD']
+  password: ENV['ONEVIEWSDK_PASSWORD'],
+  api_version: 500
 }
 
 # It will not do anything if no action is selected
@@ -50,4 +51,11 @@ end
 oneview_interconnect 'Encl1, interconnect 1' do
   client my_client
   action :reset
+end
+
+# Only for api500
+oneview_interconnect 'Encl1, interconnect 1' do
+  client my_client
+  api_version 500
+  action :reapply_configuration
 end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -32,7 +32,7 @@ if defined?(ChefSpec)
     oneview_fcoe_network:               standard_actions + scope_actions + %i[reset_connection_template],
     oneview_firmware:                   %i[add remove create_custom_spp],
     oneview_id_pool:                    %i[update allocate_list allocate_count collect_ids],
-    oneview_interconnect:               %i[set_uid_light set_power_state reset reset_port_protection update_port],
+    oneview_interconnect:               %i[set_uid_light set_power_state reset reset_port_protection update_port reapply_configuration],
     oneview_logical_enclosure:          %i[create_if_missing create update_from_group reconfigure set_script delete create_support_dump],
     oneview_logical_interconnect_group: standard_actions + scope_actions,
     oneview_logical_interconnect:       %i[none add_interconnect remove_interconnect update_internal_networks update_settings

--- a/libraries/resource_providers/api200/logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api200/logical_interconnect_provider.rb
@@ -13,6 +13,8 @@ module OneviewCookbook
   module API200
     # LogicalInterconnect API200 provider
     class LogicalInterconnectProvider < ResourceProvider
+      include OneviewCookbook::ReapplyConfigurationAction
+
       def interconnect_handler(present_block, absent_block)
         raise "Unspecified property: 'bay_number'. Please set it before attempting this action." unless @new_resource.bay_number
         raise "Unspecified property: 'enclosure'. Please set it before attempting this action." unless @new_resource.enclosure
@@ -210,14 +212,6 @@ module OneviewCookbook
         # Nothing to verify
         @context.converge_by "Update #{@resource_name} '#{@name}' from group" do
           @item.compliance
-        end
-      end
-
-      def reapply_configuration
-        @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-        # Nothing to verify
-        @context.converge_by "Reapply configuration in #{@resource_name} '#{@name}'" do
-          @item.configuration
         end
       end
     end

--- a/libraries/resource_providers/api500/synergy/interconnect_provider.rb
+++ b/libraries/resource_providers/api500/synergy/interconnect_provider.rb
@@ -13,7 +13,7 @@ module OneviewCookbook
   module API500
     module Synergy
       # Interconnect API500 Synergy provider
-      class InterconnectProvider < API300::Synergy::InterconnectProvider
+      class InterconnectProvider < API500::C7000::InterconnectProvider
       end
     end
   end

--- a/libraries/resource_providers/helpers/reapply_configuration_action.rb
+++ b/libraries/resource_providers/helpers/reapply_configuration_action.rb
@@ -6,15 +6,16 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-# CONDITIONS OF ANY KIND, either express or implied. See the License for the
-# specific language governing permissions and limitations under the License.
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
 
 module OneviewCookbook
-  module API500
-    module C7000
-      # Interconnect API500 C7000 provider
-      class InterconnectProvider < API300::C7000::InterconnectProvider
-        include OneviewCookbook::ReapplyConfigurationAction
+  # module for action related to reapply configuration of resource
+  module ReapplyConfigurationAction
+    def reapply_configuration
+      @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
+      @context.converge_by "Reapply configuration in #{@resource_name} '#{@name}'" do
+        @item.configuration
       end
     end
   end

--- a/libraries/resource_providers/helpers/reapply_configuration_action.rb
+++ b/libraries/resource_providers/helpers/reapply_configuration_action.rb
@@ -14,7 +14,8 @@ module OneviewCookbook
   module ReapplyConfigurationAction
     def reapply_configuration
       @item.retrieve! || raise("#{@resource_name} '#{@name}' not found!")
-      @context.converge_by "Reapply configuration in #{@resource_name} '#{@name}'" do
+      Chef::Log.info "Reapplying configuration in #{@resource_name} '#{@name}'"
+      @context.converge_by "Reapplied configuration in #{@resource_name} '#{@name}'" do
         @item.configuration
       end
     end

--- a/resources/interconnect.rb
+++ b/resources/interconnect.rb
@@ -39,3 +39,7 @@ end
 action :update_port do
   OneviewCookbook::Helper.do_resource_action(self, :Interconnect, :update_port)
 end
+
+action :reapply_configuration do
+  OneviewCookbook::Helper.do_resource_action(self, :Interconnect, :reapply_configuration)
+end

--- a/spec/fixtures/cookbooks/oneview_test_api500_synergy/recipes/interconnect_reapply_configuration.rb
+++ b/spec/fixtures/cookbooks/oneview_test_api500_synergy/recipes/interconnect_reapply_configuration.rb
@@ -1,3 +1,7 @@
+#
+# Cookbook Name:: oneview_test_api500_synergy
+# Recipe:: interconnect_reapply_configuration
+#
 # (c) Copyright 2017 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -8,14 +12,9 @@
 # under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
+#
 
-module OneviewCookbook
-  module API500
-    module C7000
-      # Interconnect API500 C7000 provider
-      class InterconnectProvider < API300::C7000::InterconnectProvider
-        include OneviewCookbook::ReapplyConfigurationAction
-      end
-    end
-  end
+oneview_interconnect 'Interconnect-reapply_configuration' do
+  client node['oneview_test']['client']
+  action :reapply_configuration
 end

--- a/spec/unit/resources/interconnect/reapply_configuration_spec.rb
+++ b/spec/unit/resources/interconnect/reapply_configuration_spec.rb
@@ -1,0 +1,10 @@
+require_relative './../../../spec_helper'
+
+describe 'oneview_test_api500_synergy::interconnect_reapply_configuration' do
+  let(:resource_name) { 'interconnect' }
+  include_context 'chef context'
+
+  let(:target_class) { OneviewSDK::API500::Synergy::Interconnect }
+  let(:target_match_method) { [:reapply_oneview_interconnect_configuration, 'Interconnect-reapply_configuration'] }
+  it_behaves_like 'action :reapply_configuration'
+end

--- a/spec/unit/resources/interconnect/reset_port_protection_spec.rb
+++ b/spec/unit/resources/interconnect/reset_port_protection_spec.rb
@@ -2,11 +2,12 @@ require_relative './../../../spec_helper'
 
 describe 'oneview_test::interconnect_reset_port_protection' do
   let(:resource_name) { 'interconnect' }
+  let(:target_class) { OneviewSDK::API200::Interconnect }
   include_context 'chef context'
 
-  it 'resets port protection for the Interconect' do
-    allow_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(true)
-    expect_any_instance_of(OneviewSDK::Interconnect).to receive(:reset_port_protection)
+  it 'resets port protection for the Interconnect' do
+    allow_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:reset_port_protection)
     expect(real_chef_run).to reset_oneview_interconnect_port_protection('Interconnect4')
   end
 end

--- a/spec/unit/resources/interconnect/reset_spec.rb
+++ b/spec/unit/resources/interconnect/reset_spec.rb
@@ -2,16 +2,17 @@ require_relative './../../../spec_helper'
 
 describe 'oneview_test::interconnect_reset' do
   let(:resource_name) { 'interconnect' }
+  let(:target_class) { OneviewSDK::API200::Interconnect }
   include_context 'chef context'
 
   it 'resets the Interconnect' do
-    allow_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(true)
-    expect_any_instance_of(OneviewSDK::Interconnect).to receive(:patch).with('replace', '/deviceResetState', 'Reset')
+    allow_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:patch).with('replace', '/deviceResetState', 'Reset')
     expect(real_chef_run).to reset_oneview_interconnect('Interconnect3')
   end
 
   it 'fails if the resource is not found' do
-    expect_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(false)
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
     expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 end

--- a/spec/unit/resources/interconnect/set_power_state_spec.rb
+++ b/spec/unit/resources/interconnect/set_power_state_spec.rb
@@ -2,16 +2,17 @@ require_relative './../../../spec_helper'
 
 describe 'oneview_test::interconnect_set_power_state' do
   let(:resource_name) { 'interconnect' }
+  let(:target_class) { OneviewSDK::API200::Interconnect }
   include_context 'chef context'
 
   it 'sets the Interconnect power state to a valid value' do
-    allow_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(true)
-    expect_any_instance_of(OneviewSDK::Interconnect).to receive(:patch).with('replace', '/powerState', anything)
+    allow_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:patch).with('replace', '/powerState', anything)
     expect(real_chef_run).to set_oneview_interconnect_power_state('Interconnect2')
   end
 
   it 'fails if the resource is not found' do
-    expect_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(false)
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
     expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 end
@@ -21,7 +22,7 @@ describe 'oneview_test::interconnect_set_power_state_invalid' do
   include_context 'chef context'
 
   it 'fails if power_state property is not set' do
-    allow_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API200::Interconnect).to receive(:retrieve!).and_return(true)
     expect { real_chef_run }.to raise_error(RuntimeError, /Unspecified property: 'power_state'/)
   end
 end

--- a/spec/unit/resources/interconnect/set_uid_light_spec.rb
+++ b/spec/unit/resources/interconnect/set_uid_light_spec.rb
@@ -2,16 +2,17 @@ require_relative './../../../spec_helper'
 
 describe 'oneview_test::interconnect_set_uid_light' do
   let(:resource_name) { 'interconnect' }
+  let(:target_class) { OneviewSDK::API200::Interconnect }
   include_context 'chef context'
 
   it 'sets the Interconnect UID light to a valid value' do
-    allow_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(true)
-    expect_any_instance_of(OneviewSDK::Interconnect).to receive(:patch).with('replace', '/uidState', anything)
+    allow_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:patch).with('replace', '/uidState', anything)
     expect(real_chef_run).to set_oneview_interconnect_uid_light('Interconnect1')
   end
 
   it 'fails if the resource is not found' do
-    expect_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(false)
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
     expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 end
@@ -21,7 +22,7 @@ describe 'oneview_test::interconnect_set_uid_light_invalid' do
   include_context 'chef context'
 
   it 'fails if uid_light_state property is not set' do
-    allow_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API200::Interconnect).to receive(:retrieve!).and_return(true)
     expect { real_chef_run }.to raise_error(RuntimeError, /Unspecified property: 'uid_light_state'/)
   end
 end

--- a/spec/unit/resources/interconnect/update_port_spec.rb
+++ b/spec/unit/resources/interconnect/update_port_spec.rb
@@ -2,6 +2,7 @@ require_relative './../../../spec_helper'
 
 describe 'oneview_test::interconnect_update_port' do
   let(:resource_name) { 'interconnect' }
+  let(:target_class) { OneviewSDK::API200::Interconnect }
   include_context 'chef context'
 
   let(:port_to_update) { { 'name' => 'X1', 'enabled' => false } }
@@ -14,10 +15,10 @@ describe 'oneview_test::interconnect_update_port' do
       { 'name' => 'X3', 'enabled' => true }
     ]
 
-    allow_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::Interconnect).to receive(:[]).with('name')
-    allow_any_instance_of(OneviewSDK::Interconnect).to receive(:[]).with('ports').and_return(ports)
-    expect_any_instance_of(OneviewSDK::Interconnect).to receive(:update_port).with('X1', anything).and_return(true)
+    allow_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(target_class).to receive(:[]).with('name')
+    allow_any_instance_of(target_class).to receive(:[]).with('ports').and_return(ports)
+    expect_any_instance_of(target_class).to receive(:update_port).with('X1', anything).and_return(true)
 
     expect(real_chef_run).to update_oneview_interconnect_port('Interconnect5')
   end
@@ -28,10 +29,10 @@ describe 'oneview_test::interconnect_update_port' do
       { 'name' => 'X2', 'enabled' => false },
       { 'name' => 'X3', 'enabled' => false }
     ]
-    allow_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::Interconnect).to receive(:[]).with('name')
-    allow_any_instance_of(OneviewSDK::Interconnect).to receive(:[]).with('ports').and_return(ports)
-    expect_any_instance_of(OneviewSDK::Interconnect).to_not receive(:update_port)
+    allow_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(target_class).to receive(:[]).with('name')
+    allow_any_instance_of(target_class).to receive(:[]).with('ports').and_return(ports)
+    expect_any_instance_of(target_class).to_not receive(:update_port)
     expect(real_chef_run).to update_oneview_interconnect_port('Interconnect5')
   end
 
@@ -39,14 +40,14 @@ describe 'oneview_test::interconnect_update_port' do
     ports = [
       { 'name' => 'Z0', 'enabled' => true }
     ]
-    allow_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(true)
-    allow_any_instance_of(OneviewSDK::Interconnect).to receive(:[]).with('name')
-    allow_any_instance_of(OneviewSDK::Interconnect).to receive(:[]).with('ports').and_return(ports)
+    allow_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(target_class).to receive(:[]).with('name')
+    allow_any_instance_of(target_class).to receive(:[]).with('ports').and_return(ports)
     expect { real_chef_run }.to raise_error(RuntimeError, /Could not find port/)
   end
 
   it 'fails if the resource is not found' do
-    expect_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(false)
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
     expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
   end
 end
@@ -56,7 +57,7 @@ describe 'oneview_test::interconnect_update_port_invalid' do
   include_context 'chef context'
 
   it 'fails if port_options property is not set' do
-    allow_any_instance_of(OneviewSDK::Interconnect).to receive(:retrieve!).and_return(true)
+    allow_any_instance_of(OneviewSDK::API200::Interconnect).to receive(:retrieve!).and_return(true)
     expect { real_chef_run }.to raise_error(RuntimeError, /Unspecified property: 'port_options'/)
   end
 end

--- a/spec/unit/resources/logical_interconnect/reapply_configuration_spec.rb
+++ b/spec/unit/resources/logical_interconnect/reapply_configuration_spec.rb
@@ -4,14 +4,7 @@ describe 'oneview_test::logical_interconnect_reapply_configuration' do
   let(:resource_name) { 'logical_interconnect' }
   include_context 'chef context'
 
-  it 'reapplies the configuration in all teh associated interconnects' do
-    allow_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:retrieve!).and_return(true)
-    expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:configuration).and_return(true)
-    expect(real_chef_run).to reapply_oneview_logical_interconnect_configuration('LogicalInterconnect-reapply_configuration')
-  end
-
-  it 'fails if the resource is not found' do
-    expect_any_instance_of(OneviewSDK::LogicalInterconnect).to receive(:retrieve!).and_return(false)
-    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
-  end
+  let(:target_class) { OneviewSDK::API200::LogicalInterconnect }
+  let(:target_match_method) { [:reapply_oneview_logical_interconnect_configuration, 'LogicalInterconnect-reapply_configuration'] }
+  it_behaves_like 'action :reapply_configuration'
 end

--- a/spec/unit/resources/matchers_spec.rb
+++ b/spec/unit/resources/matchers_spec.rb
@@ -97,6 +97,7 @@ describe 'oneview_test::default' do
     expect(chef_run).to_not reset_oneview_interconnect_port_protection('')
     expect(chef_run).to_not reset_oneview_interconnect('')
     expect(chef_run).to_not update_oneview_interconnect_port('')
+    expect(chef_run).to_not reapply_oneview_interconnect_configuration('')
 
     # oneview_logical_enclosure
     expect(chef_run).to_not update_oneview_logical_enclosure_from_group('')

--- a/spec/unit/resources/sas_logical_interconnect/reapply_configuration_spec.rb
+++ b/spec/unit/resources/sas_logical_interconnect/reapply_configuration_spec.rb
@@ -2,12 +2,9 @@ require_relative './../../../spec_helper'
 
 describe 'oneview_test_api300_synergy::sas_logical_interconnect_reapply_configuration' do
   let(:resource_name) { 'sas_logical_interconnect' }
-  let(:base_sdk) { OneviewSDK::API300::Synergy }
   include_context 'chef context'
 
-  it 'reapplies the configuration in all teh associated interconnects' do
-    allow_any_instance_of(base_sdk::SASLogicalInterconnect).to receive(:retrieve!).and_return(true)
-    expect_any_instance_of(base_sdk::SASLogicalInterconnect).to receive(:configuration).and_return(true)
-    expect(real_chef_run).to reapply_oneview_sas_logical_interconnect_configuration('SASLogicalInterconnect-reapply_configuration')
-  end
+  let(:target_class) { OneviewSDK::API300::Synergy::SASLogicalInterconnect }
+  let(:target_match_method) { [:reapply_oneview_sas_logical_interconnect_configuration, 'SASLogicalInterconnect-reapply_configuration'] }
+  it_behaves_like 'action :reapply_configuration'
 end

--- a/spec/unit/shared_examples/reapply_configuration.rb
+++ b/spec/unit/shared_examples/reapply_configuration.rb
@@ -1,0 +1,29 @@
+# (C) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+# NOTE:
+# This shared example requires the following variables:
+#  target_class - Full name of the OneView resource to be tested
+#  target_match_method - Array with name of match method called and with the argument of the match method,
+#    e.g: let(:target_match_method) { [:add_oneview_enclosure_to_scopes, 'EnclosureName'] }
+
+RSpec.shared_examples 'action :reapply_configuration' do
+  it 'reapplies the configuration' do
+    allow_any_instance_of(target_class).to receive(:retrieve!).and_return(true)
+    expect_any_instance_of(target_class).to receive(:configuration).and_return(true)
+    expect(real_chef_run).to public_send(*target_match_method)
+  end
+
+  it 'fails if the resource is not found' do
+    expect_any_instance_of(target_class).to receive(:retrieve!).and_return(false)
+    expect { real_chef_run }.to raise_error(RuntimeError, /not found/)
+  end
+end


### PR DESCRIPTION
### Description
The action :reapply_configuration was added to oneview_interconnect.
It was created a new module with `reapply_configuration` method to be included when some provider need have the reapply_configuration action, avoiding duplicated code.

ATTENTION: 
- This PR cannot be merge for now, because the [PR 288](https://github.com/HewlettPackard/oneview-sdk-ruby/pull/288) of `oneview-sdk-ruby` must be merge before.
- The tests (consequently the build) will work properly because the new action is mocked in unit test.
- The example will not work properly due the reason cited above.
- For run the example you must change the path to oneview-sdk gem into your Gemfile, like code below:
```ruby
gem 'oneview-sdk', path: '/oneview-sdk-ruby'
```
and, with code up-to-date with master branch, run `bundle update` before run the example.

### Issues Resolved
Fixes #346 

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [x] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [x] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [x] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
