### PR TITLE
Add API600 Resource and use latest version of oneview-sdk-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'chef', chef_version
 gem 'chefspec'
 gem 'codeclimate-test-reporter'
 gem 'foodcritic', '~> 7.1.0'
-gem 'oneview-sdk', '~> 5.2.0'
+gem 'oneview-sdk', '~> 5.4.0'
 gem 'pry'
 gem 'rubocop', '~> 0.49.1'
 gem 'simplecov'

--- a/libraries/resource_providers/api600.rb
+++ b/libraries/resource_providers/api600.rb
@@ -1,0 +1,31 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative 'api300'
+
+module OneviewCookbook
+  # Module for Oneview API 600 Resources
+  module API600
+    SUPPORTED_VARIANTS ||= %w[C7000 Synergy].freeze
+
+    # Get resource class that matches the type given
+    # @param [String] type Name of the desired class type
+    # @param [String] variant Variant (C7000 or Synergy)
+    # @raise [RuntimeError] if resource class not found
+    # @return [Class] Resource class
+    def self.provider_named(type, variant)
+      OneviewCookbook::Helper.get_provider_named(type, self, variant)
+    end
+  end
+end
+
+# Load all API-specific resources:
+Dir[File.dirname(__FILE__) + '/api600/*.rb'].each { |file| require file }

--- a/libraries/resource_providers/api600/c7000.rb
+++ b/libraries/resource_providers/api600/c7000.rb
@@ -1,0 +1,21 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API500
+    # Module for API500 C7000
+    module C7000
+    end
+  end
+end
+
+# Load all API-specific resources:
+Dir[File.dirname(__FILE__) + '/c7000/*.rb'].each { |file| require file }

--- a/libraries/resource_providers/api600/c7000.rb
+++ b/libraries/resource_providers/api600/c7000.rb
@@ -10,8 +10,8 @@
 # language governing permissions and limitations under the License.
 
 module OneviewCookbook
-  module API500
-    # Module for API500 C7000
+  module API600
+    # Module for API600 C7000
     module C7000
     end
   end

--- a/libraries/resource_providers/api600/c7000/connection_template_provider.rb
+++ b/libraries/resource_providers/api600/c7000/connection_template_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # ConnectionTemplate API600 C7000 provider
+      class ConnectionTemplateProvider < API300::C7000::ConnectionTemplateProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/datacenter_provider.rb
+++ b/libraries/resource_providers/api600/c7000/datacenter_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # Datacenter API600 C7000 provider
+      class DatacenterProvider < API300::C7000::DatacenterProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/enclosure_group_provider.rb
+++ b/libraries/resource_providers/api600/c7000/enclosure_group_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # EnclosureGroup API600 C7000 provider
+      class EnclosureGroupProvider < API300::C7000::EnclosureGroupProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/enclosure_provider.rb
+++ b/libraries/resource_providers/api600/c7000/enclosure_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # Enclosure API600 C7000 provider
+      class EnclosureProvider < API300::C7000::EnclosureProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/ethernet_network_provider.rb
+++ b/libraries/resource_providers/api600/c7000/ethernet_network_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # EthernetNetworkProvider API600 C7000 provider
+      class EthernetNetworkProvider < API300::C7000::EthernetNetworkProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/event_provider.rb
+++ b/libraries/resource_providers/api600/c7000/event_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # EventProvider API600 C7000 provider
+      class EventProvider < API300::C7000::EventProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/fc_network_provider.rb
+++ b/libraries/resource_providers/api600/c7000/fc_network_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # FCNetwork API600 C7000 provider
+      class FCNetworkProvider < OneviewCookbook::API300::C7000::FCNetworkProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/fcoe_network_provider.rb
+++ b/libraries/resource_providers/api600/c7000/fcoe_network_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # FCoENetwork API600 C7000 provider
+      class FCoENetworkProvider < API300::C7000::FCoENetworkProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/firmware_driver_provider.rb
+++ b/libraries/resource_providers/api600/c7000/firmware_driver_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # Firmware API600 C7000 provider
+      class FirmwareDriverProvider < API300::C7000::FirmwareDriverProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/id_pool_provider.rb
+++ b/libraries/resource_providers/api600/c7000/id_pool_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # IDPool API600 C7000 provider
+      class IDPoolProvider < OneviewCookbook::API300::C7000::IDPoolProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/interconnect_provider.rb
+++ b/libraries/resource_providers/api600/c7000/interconnect_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # Interconnect API600 C7000 provider
+      class InterconnectProvider < API300::C7000::InterconnectProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/logical_enclosure_provider.rb
+++ b/libraries/resource_providers/api600/c7000/logical_enclosure_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # LogicalEnclosure API600 C7000 provider
+      class LogicalEnclosureProvider < API300::C7000::LogicalEnclosureProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/logical_interconnect_group_provider.rb
+++ b/libraries/resource_providers/api600/c7000/logical_interconnect_group_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # LogicalInterconnectGroup API600 C7000 provider
+      class LogicalInterconnectGroupProvider < API300::C7000::LogicalInterconnectGroupProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api600/c7000/logical_interconnect_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # LogicalInterconnect API600 C7000 provider
+      class LogicalInterconnectProvider < API300::C7000::LogicalInterconnectProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/logical_switch_group_provider.rb
+++ b/libraries/resource_providers/api600/c7000/logical_switch_group_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # LogicalSwitchGroup API600 C7000 provider
+      class LogicalSwitchGroupProvider < API300::C7000::LogicalSwitchGroupProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/logical_switch_provider.rb
+++ b/libraries/resource_providers/api600/c7000/logical_switch_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # LogicalSwitch API600 C7000 provider
+      class LogicalSwitchProvider < API300::C7000::LogicalSwitchProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/managed_san_provider.rb
+++ b/libraries/resource_providers/api600/c7000/managed_san_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # ManagedSAN API600 C7000 provider
+      class ManagedSANProvider < OneviewCookbook::API300::C7000::ManagedSANProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/network_set_provider.rb
+++ b/libraries/resource_providers/api600/c7000/network_set_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # NetworkSet API600 C7000 provider
+      class NetworkSetProvider < API300::C7000::NetworkSetProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/power_device_provider.rb
+++ b/libraries/resource_providers/api600/c7000/power_device_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # PowerDevice API600 C7000 provider
+      class PowerDeviceProvider < API300::C7000::PowerDeviceProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/rack_provider.rb
+++ b/libraries/resource_providers/api600/c7000/rack_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # Rack API600 C7000 provider
+      class RackProvider < API300::C7000::RackProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/san_manager_provider.rb
+++ b/libraries/resource_providers/api600/c7000/san_manager_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # SANManager API600 C7000 provider
+      class SANManagerProvider < OneviewCookbook::API300::C7000::SANManagerProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/scope_provider.rb
+++ b/libraries/resource_providers/api600/c7000/scope_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # Scope API600 C7000 provider
+      class ScopeProvider < OneviewCookbook::API300::C7000::ScopeProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/server_hardware_provider.rb
+++ b/libraries/resource_providers/api600/c7000/server_hardware_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # ServerHardware API600 C7000 provider
+      class ServerHardwareProvider < API300::C7000::ServerHardwareProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/server_hardware_type_provider.rb
+++ b/libraries/resource_providers/api600/c7000/server_hardware_type_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # ServerHardwareType API600 C7000 provider
+      class ServerHardwareTypeProvider < API300::C7000::ServerHardwareTypeProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/server_profile_provider.rb
+++ b/libraries/resource_providers/api600/c7000/server_profile_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # Server Profile API600 C7000 provider
+      class ServerProfileProvider < API300::C7000::ServerProfileProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/server_profile_template_provider.rb
+++ b/libraries/resource_providers/api600/c7000/server_profile_template_provider.rb
@@ -1,0 +1,30 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # Server Profile Template API600 C7000 provider
+      class ServerProfileTemplateProvider < API300::C7000::ServerProfileTemplateProvider
+        # Override create method to allow creation from a template
+        def create(method)
+          if @new_resource.server_profile_name
+            sp_as_template = load_resource(:ServerProfile, @new_resource.server_profile_name)
+            Chef::Log.info "Using Server profile '#{@new_resource.server_profile_name}' as template to #{method} #{@resource_name} '#{@name}'"
+            new_spt_data = sp_as_template.get_profile_template.data
+            @item.data = new_spt_data.merge(@item.data)
+          end
+          super
+        end
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/storage_pool_provider.rb
+++ b/libraries/resource_providers/api600/c7000/storage_pool_provider.rb
@@ -1,0 +1,80 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+require_relative 'storage_system_provider'
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # StoragePool API600 C7000 provider
+      class StoragePoolProvider < API300::C7000::StoragePoolProvider
+        include OneviewCookbook::RefreshActions::RequestRefresh
+
+        def refresh
+          load_storage_system
+          super
+        end
+
+        def load_storage_system
+          raise("Unspecified property: 'storage_system'. Please set it before attempting this action.") unless @new_resource.storage_system
+          @item.set_storage_system(load_resource(:StorageSystem, hostname: @new_resource.storage_system, name: @new_resource.storage_system))
+        end
+
+        def update_manage_state(managed)
+          managed_text = managed ? 'managed' : 'unmanaged'
+          return Chef::Log.info("#{@resource_name} '#{@name}' is already #{managed_text}") if @item['isManaged'] == managed
+          @context.converge_by "#{@resource_name} '#{@name}' is now #{managed_text}" do
+            @item.manage(managed)
+          end
+        end
+
+        def add_for_management
+          load_storage_system
+          @item.retrieve! || raise("Resource not found: The #{@resource_name} '#{@name}' could not be found")
+          update_manage_state(true)
+        end
+
+        def remove_from_management
+          load_storage_system
+          @item.retrieve! || raise("Resource not found: The #{@resource_name} '#{@name}' could not be found")
+          update_manage_state(false)
+        end
+
+        def add_if_missing
+          Chef::Log.warn("The #{@resource_name} in API #{@sdk_api_version} variant #{@sdk_variant} cannot perform 'add_if_missing' operation. Performing 'add_for_management' instead...")
+          add_for_management
+        end
+
+        def remove
+          Chef::Log.warn("The #{@resource_name} in API #{@sdk_api_version} variant #{@sdk_variant} cannot perform 'remove' operation. Performing 'remove_from_management' instead...")
+          remove_from_management
+        end
+
+        def update
+          load_storage_system
+          desired_state = Marshal.load(Marshal.dump(@item.data))
+          @item.retrieve! || raise("Resource not found: The #{@resource_name} '#{@name}' could not be found")
+          update_manage_state(desired_state['isManaged']) unless desired_state['isManaged'].nil?
+          return Chef::Log.info("#{@resource_name} '#{@name}' has no need to update") if @item.like? desired_state
+          diff = get_diff(@item, desired_state)
+          Chef::Log.info "Update #{@resource_name} '#{@name}'#{diff}"
+          Chef::Log.debug "#{@resource_name} '#{@name}' Chef resource differs from OneView resource."
+          Chef::Log.debug "Current state: #{JSON.pretty_generate(@item.data)}"
+          Chef::Log.debug "Desired state: #{JSON.pretty_generate(desired_state)}"
+          @context.converge_by "Updated #{@resource_name} '#{@name}'" do
+            @item.update(desired_state)
+          end
+          save_res_info
+        end
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/storage_system_provider.rb
+++ b/libraries/resource_providers/api600/c7000/storage_system_provider.rb
@@ -1,0 +1,21 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # StorageSystem API600 C7000 provider
+      class StorageSystemProvider < API300::C7000::StorageSystemProvider
+        include OneviewCookbook::RefreshActions::RequestRefresh
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/switch_provider.rb
+++ b/libraries/resource_providers/api600/c7000/switch_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # Switch API600 C7000 provider
+      class SwitchProvider < API300::C7000::SwitchProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/unmanaged_device_provider.rb
+++ b/libraries/resource_providers/api600/c7000/unmanaged_device_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # UnmanagedDevice API600 C7000 provider
+      class UnmanagedDeviceProvider < OneviewCookbook::API300::C7000::UnmanagedDeviceProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/uplink_set_provider.rb
+++ b/libraries/resource_providers/api600/c7000/uplink_set_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # UplinkSet API600 C7000 provider
+      class UplinkSetProvider < API300::C7000::UplinkSetProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/user_provider.rb
+++ b/libraries/resource_providers/api600/c7000/user_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # User API600 C7000 provider
+      class UserProvider < OneviewCookbook::API300::C7000::UserProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/volume_provider.rb
+++ b/libraries/resource_providers/api600/c7000/volume_provider.rb
@@ -1,0 +1,90 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # Volume API600 C7000 provider
+      class VolumeProvider < API300::C7000::VolumeProvider
+        def load_resource_with_associated_resources
+          if @new_resource.volume_template
+            load_volume_template
+          else
+            validate_required_properties(:storage_system, :storage_pool)
+            storage_system_uri = load_resource(:StorageSystem, { hostname: @new_resource.storage_system, name: @new_resource.storage_system }, 'uri')
+            @item.set_storage_pool(resource_named(:StoragePool).new(@item.client, name: @new_resource.storage_pool, storageSystemUri: storage_system_uri))
+            @item.set_snapshot_pool(resource_named(:StoragePool).new(@item.client, name: @new_resource.snapshot_pool, storageSystemUri: storage_system_uri)) if @new_resource.snapshot_pool
+          end
+          @item['properties']['name'] = @new_resource.name
+          @item.exists? ? @item.data.delete('properties') : set_properties
+        end
+
+        def load_volume_template
+          template = resource_named(:VolumeTemplate).new(@item.client, name: @new_resource.volume_template)
+          @item.set_storage_volume_template(template)
+          @item.set_storage_pool(resource_named(:StoragePool).new(@item.client, uri: template['storagePoolUri']))
+          @item.set_snapshot_pool(resource_named(:StoragePool).new(@item.client, uri: template['properties']['snapshotPool']['default'])) if template['family'] == 'StoreServ'
+        end
+
+        def create_from_snapshot
+          validate_required_properties(:properties)
+          raise("#{@resource_name} '#{@name}' not found!") unless @item.retrieve!
+          properties = convert_keys(@new_resource.properties, :to_s)
+          return Chef::Log.info "Volume '#{properties['name']}' already exists" if resource_named(:Volume).new(@item.client, name: properties['name']).exists?
+          snapshot_name = properties['snapshotName']
+          properties.delete('snapshotName')
+          volume_template = nil
+          volume_template = resource_named(:VolumeTemplate).new(@item.client, name: @new_resource.volume_template) if @new_resource.volume_template
+          Chef::Log.info "Creating #{@resource_name} '#{properties['name']}' from snapshot #{snapshot_name}"
+          @context.converge_by "Created #{@resource_name} '#{properties['name']}' from snapshot #{snapshot_name}" do
+            @item.create_from_snapshot(snapshot_name, properties, volume_template, @new_resource.is_permanent)
+          end
+        end
+
+        def add_if_missing
+          validate_required_properties(:storage_system) unless @item['storageSystemUri']
+          return Chef::Log.info("#{@resource_name} '#{@name}' already exists.") if @item.exists?
+          @item['storageSystemUri'] ||= load_resource(:StorageSystem, { hostname: @new_resource.storage_system, name: @new_resource.storage_system }, 'uri')
+          @item['deviceVolumeName'] ||= @name
+          Chef::Log.info "Adding #{@resource_name} '#{@name}'"
+          @context.converge_by "Added #{@resource_name} '#{@name}'" do
+            @item.add
+          end
+        end
+
+        # Delete the OneView resource if it exists
+        # @param [Symbol] method Delete or remove method
+        # @return [TrueClass, FalseClass] Returns true if the resource was deleted/removed
+        def delete
+          return false unless @item.retrieve!
+          flag = @new_resource.delete_from_appliance_only ? :oneview : :all
+          msg = @new_resource.delete_from_appliance_only ? 'only' : 'and the storage system'
+          Chef::Log.info "Deleting #{@resource_name} '#{@name}' from appliance #{msg}"
+          @context.converge_by "Deleted #{@resource_name} '#{@name}' from appliance #{msg}" do
+            @item.delete(flag)
+          end
+          true
+        end
+
+        def set_properties
+          @item['isPermanent'] ||= @new_resource.is_permanent
+          @item['properties']['description'] ||= @item['description']
+          @item['properties']['provisioningType'] ||= @item['provisioningType']
+          @item['properties']['size'] ||= @item['size']
+          @item['properties']['dataProtectionLevel'] ||= @item['dataProtectionLevel'] if @item['dataProtectionLevel']
+          @item['properties']['isShareable'] ||= @item['isShareable']
+          attrs = ['name', 'description', 'storagePool', 'provisioningType', 'size', 'isShareable', 'dataProtectionLevel', 'storagePoolUri', 'snapshotPoolUri']
+          attrs.each { |attr| @item.data.delete(attr) }
+        end
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/c7000/volume_template_provider.rb
+++ b/libraries/resource_providers/api600/c7000/volume_template_provider.rb
@@ -1,0 +1,30 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # VolumeTemplate API600 C7000 provider
+      class VolumeTemplateProvider < API300::C7000::VolumeTemplateProvider
+        def load_resource_with_associated_resources
+          validate_required_properties(:storage_system, :storage_pool)
+          storage_system_data = { hostname: @new_resource.storage_system, name: @new_resource.storage_system }
+          storage_system = load_resource(:StorageSystem, storage_system_data)
+          root_template = storage_system.get_templates.find { |i| i['isRoot'] }
+
+          @item.set_root_template(root_template)
+          @item.set_default_value('storagePool', load_resource(:StoragePool, name: @new_resource.storage_pool, storageSystemUri: storage_system['uri']))
+          @item.set_default_value('snapshotPool', load_resource(:StoragePool, name: @new_resource.snapshot_pool, storageSystemUri: storage_system['uri'])) if @new_resource.snapshot_pool
+        end
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy.rb
+++ b/libraries/resource_providers/api600/synergy.rb
@@ -1,0 +1,23 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+require_relative 'c7000'
+
+module OneviewCookbook
+  module API600
+    # Module for API500 Synergy
+    module Synergy
+    end
+  end
+end
+
+# Load all API-specific resources:
+Dir[File.dirname(__FILE__) + '/synergy/*.rb'].each { |file| require file }

--- a/libraries/resource_providers/api600/synergy/connection_template_provider.rb
+++ b/libraries/resource_providers/api600/synergy/connection_template_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # ConnectionTemplate API600 Synergy provider
+      class ConnectionTemplateProvider < API300::Synergy::ConnectionTemplateProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/datacenter_provider.rb
+++ b/libraries/resource_providers/api600/synergy/datacenter_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # Datacenter API600 Synergy provider
+      class DatacenterProvider < API300::Synergy::DatacenterProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/drive_enclosure_provider.rb
+++ b/libraries/resource_providers/api600/synergy/drive_enclosure_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # Drive Enclosure API600 Synergy provider
+      class DriveEnclosureProvider < API300::Synergy::DriveEnclosureProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/enclosure_group_provider.rb
+++ b/libraries/resource_providers/api600/synergy/enclosure_group_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # EnclosureGroup API600 Synergy provider
+      class EnclosureGroupProvider < API300::Synergy::EnclosureGroupProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/enclosure_provider.rb
+++ b/libraries/resource_providers/api600/synergy/enclosure_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # Enclosure API600 Synergy provider
+      class EnclosureProvider < API300::Synergy::EnclosureProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/ethernet_network_provider.rb
+++ b/libraries/resource_providers/api600/synergy/ethernet_network_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # EthernetNetworkProvider API300 Synergy provider
+      class EthernetNetworkProvider < API300::Synergy::EthernetNetworkProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/event_provider.rb
+++ b/libraries/resource_providers/api600/synergy/event_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # EventProvider API600 Synergy provider
+      class EventProvider < API300::Synergy::EventProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/fabric_provider.rb
+++ b/libraries/resource_providers/api600/synergy/fabric_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # Fabric API600 Synergy provider
+      class FabricProvider < API300::Synergy::FabricProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/fc_network_provider.rb
+++ b/libraries/resource_providers/api600/synergy/fc_network_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # FCNetwork API600 Synergy provider
+      class FCNetworkProvider < OneviewCookbook::API300::Synergy::FCNetworkProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/fcoe_network_provider.rb
+++ b/libraries/resource_providers/api600/synergy/fcoe_network_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # FCoENetwork API600 Synergy resource provider methods
+      class FCoENetworkProvider < API300::Synergy::FCoENetworkProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/firmware_driver_provider.rb
+++ b/libraries/resource_providers/api600/synergy/firmware_driver_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # Firmware API600 Synergy provider
+      class FirmwareDriverProvider < API300::Synergy::FirmwareDriverProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/id_pool_provider.rb
+++ b/libraries/resource_providers/api600/synergy/id_pool_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # IDPool API600 Synergy provider
+      class IDPoolProvider < OneviewCookbook::API300::Synergy::IDPoolProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/interconnect_provider.rb
+++ b/libraries/resource_providers/api600/synergy/interconnect_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # Interconnect API600 Synergy provider
+      class InterconnectProvider < API300::Synergy::InterconnectProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/logical_enclosure_provider.rb
+++ b/libraries/resource_providers/api600/synergy/logical_enclosure_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # LogicalEnclosure API600 Synergy provider
+      class LogicalEnclosureProvider < API300::Synergy::LogicalEnclosureProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/logical_interconnect_group_provider.rb
+++ b/libraries/resource_providers/api600/synergy/logical_interconnect_group_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # LogicalInterconnectGroup API600 Synergy provider
+      class LogicalInterconnectGroupProvider < API300::Synergy::LogicalInterconnectGroupProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api600/synergy/logical_interconnect_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # LogicalInterconnect API600 Synergy provider
+      class LogicalInterconnectProvider < API300::Synergy::LogicalInterconnectProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/managed_san_provider.rb
+++ b/libraries/resource_providers/api600/synergy/managed_san_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # ManagedSAN API600 Synergy provider
+      class ManagedSANProvider < OneviewCookbook::API300::Synergy::ManagedSANProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/network_set_provider.rb
+++ b/libraries/resource_providers/api600/synergy/network_set_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # NetworkSet API600 Synergy provider
+      class NetworkSetProvider < API300::Synergy::NetworkSetProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/power_device_provider.rb
+++ b/libraries/resource_providers/api600/synergy/power_device_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # PowerDevice API600 Synergy provider
+      class PowerDeviceProvider < API300::Synergy::PowerDeviceProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/rack_provider.rb
+++ b/libraries/resource_providers/api600/synergy/rack_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # Rack API600 Synergy resource provider methods
+      class RackProvider < API300::Synergy::RackProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/san_manager_provider.rb
+++ b/libraries/resource_providers/api600/synergy/san_manager_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # SANManager API600 Synergy provider
+      class SANManagerProvider < OneviewCookbook::API300::Synergy::SANManagerProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/sas_interconnect_provider.rb
+++ b/libraries/resource_providers/api600/synergy/sas_interconnect_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # SAS Interconnect API600 Synergy provider
+      class SASInterconnectProvider < OneviewCookbook::API300::Synergy::SASInterconnectProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/sas_logical_interconnect_group_provider.rb
+++ b/libraries/resource_providers/api600/synergy/sas_logical_interconnect_group_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # SASLogicalInterconnectGroup API600 Synergy provider
+      class SASLogicalInterconnectGroupProvider < API300::Synergy::SASLogicalInterconnectGroupProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/sas_logical_interconnect_provider.rb
+++ b/libraries/resource_providers/api600/synergy/sas_logical_interconnect_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # SASLogicalInterconnect API600 Synergy provider
+      class SASLogicalInterconnectProvider < API300::Synergy::SASLogicalInterconnectProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/scope_provider.rb
+++ b/libraries/resource_providers/api600/synergy/scope_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # Scope API600 Synergy provider
+      class ScopeProvider < OneviewCookbook::API300::Synergy::ScopeProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/server_hardware_provider.rb
+++ b/libraries/resource_providers/api600/synergy/server_hardware_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # ServerHardware API600 Synergy provider
+      class ServerHardwareProvider < API300::Synergy::ServerHardwareProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/server_hardware_type_provider.rb
+++ b/libraries/resource_providers/api600/synergy/server_hardware_type_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # ServerHardwareType API600 Synergy provider
+      class ServerHardwareTypeProvider < API300::Synergy::ServerHardwareTypeProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/server_profile_provider.rb
+++ b/libraries/resource_providers/api600/synergy/server_profile_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # Server Profile API600 Synergy provider
+      class ServerProfileProvider < API300::Synergy::ServerProfileProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/server_profile_template_provider.rb
+++ b/libraries/resource_providers/api600/synergy/server_profile_template_provider.rb
@@ -1,0 +1,25 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # Server Profile Template API600 Synergy provider
+      class ServerProfileTemplateProvider < API600::C7000::ServerProfileTemplateProvider
+        include OneviewCookbook::API300::Synergy::ServerProfileHelpers
+        def create_or_update
+          load_os_deployment_plan
+          super
+        end
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/storage_pool_provider.rb
+++ b/libraries/resource_providers/api600/synergy/storage_pool_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # StoragePool API600 C7000 provider
+      class StoragePoolProvider < API600::C7000::StoragePoolProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/storage_system_provider.rb
+++ b/libraries/resource_providers/api600/synergy/storage_system_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # StorageSystem API600 Synergy provider
+      class StorageSystemProvider < API600::C7000::StorageSystemProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/unmanaged_device_provider.rb
+++ b/libraries/resource_providers/api600/synergy/unmanaged_device_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # UnmanagedDevice API600 Synergy provider
+      class UnmanagedDeviceProvider < OneviewCookbook::API300::Synergy::UnmanagedDeviceProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/uplink_set_provider.rb
+++ b/libraries/resource_providers/api600/synergy/uplink_set_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # UplinkSet API600 Synergy provider
+      class UplinkSetProvider < API300::Synergy::UplinkSetProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/user_provider.rb
+++ b/libraries/resource_providers/api600/synergy/user_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # User API600 Synergy provider
+      class UserProvider < OneviewCookbook::API300::Synergy::UserProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/volume_provider.rb
+++ b/libraries/resource_providers/api600/synergy/volume_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # Volume API600 Synergy provider
+      class VolumeProvider < API600::C7000::VolumeProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/volume_template_provider.rb
+++ b/libraries/resource_providers/api600/synergy/volume_template_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # VolumeTemplate API600 Synergy provider
+      class VolumeTemplateProvider < API600::C7000::VolumeTemplateProvider
+      end
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ license          'Apache-2.0'
 description      'Provides HPE OneView & Image Streamer resources'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version          '3.0.0'
+version          '3.0.1'
 
 source_url       'https://github.com/HewlettPackard/oneview-chef' if respond_to?(:source_url)
 issues_url       'https://github.com/HewlettPackard/oneview-chef/issues' if respond_to?(:issues_url)


### PR DESCRIPTION
### Description
[Describe what this change achieves]
Add api600 resource and use latest version of the oneview-sdk-ruby.

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [ ] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
