### PR TITLE
Fix#355: Updating fauxhai redhat platform to avoid deprecate warning 

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ ChefSpec::Coverage.start!
 RSpec.configure do |config|
   # Set the default Fauxhai platform and version
   config.platform = 'redhat'
-  config.version = '7.2'
+  config.version = '7.4'
 
   config.before(:each) do
     # Mock appliance version and login api requests, as well as loading trusted certs


### PR DESCRIPTION
### Description
Updating fauxhai redhat platform to avoid deprecate warning for Redhat 7.2 platform

### Issues Resolved
#355

### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [ ] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [ ] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
