### PR TITLE
Api600 fcoe network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.1.0 (Unreleased)
 Adds API 600 support to the following HPE OneView resources:
 - oneview_server_hardware
+- oneview_fcoe_network
 
 ## Enhancements:
 - [#346](https://github.com/HewlettPackard/oneview-chef/issues/346) Add action to reapply configuration of oneview_interconnect API500

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 3.1.0 (Unreleased)
 Adds API 600 support to the following HPE OneView resources:
-- oneview_server_hardware
 - oneview_fcoe_network
+- oneview_server_hardware
 
 ## Enhancements:
 - [#346](https://github.com/HewlettPackard/oneview-chef/issues/346) Add action to reapply configuration of oneview_interconnect API500

--- a/examples/fcoe_network.rb
+++ b/examples/fcoe_network.rb
@@ -36,6 +36,7 @@ oneview_fcoe_network 'FCoE1' do
 end
 
 # Adds 'FCoE1' to 'Scope1' and 'Scope2'
+# Available only in Api300 and Api500
 oneview_fcoe_network 'FCoE1' do
   client my_client
   scopes ['Scope1', 'Scope2']
@@ -43,6 +44,7 @@ oneview_fcoe_network 'FCoE1' do
 end
 
 # Removes 'FCoE1' from 'Scope1'
+# Available only in Api300 and Api500
 oneview_fcoe_network 'FCoE1' do
   client my_client
   scopes ['Scope1']
@@ -50,6 +52,7 @@ oneview_fcoe_network 'FCoE1' do
 end
 
 # Replaces scopes to 'Scope1' and 'Scope2'
+# Available only in Api300 and Api500
 oneview_fcoe_network 'FCoE1' do
   client my_client
   scopes ['Scope1', 'Scope2']
@@ -57,6 +60,7 @@ oneview_fcoe_network 'FCoE1' do
 end
 
 # Replaces all scopes to empty list of scopes
+# Available only in Api300 and Api500
 oneview_fcoe_network 'FCoE1' do
   client my_client
   operation 'replace'
@@ -71,6 +75,7 @@ oneview_fcoe_network 'FCoE1' do
   action :reset_connection_template
 end
 
+#Deletes 'FCoE1' network
 oneview_fcoe_network 'FCoE1' do
   client my_client
   action :delete

--- a/libraries/resource_providers/api600/c7000/fcoe_network_provider.rb
+++ b/libraries/resource_providers/api600/c7000/fcoe_network_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2018 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # FCoENetwork API600 C7000 provider
+      class FCoENetworkProvider < API500::C7000::FCoENetworkProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/fcoe_network_provider.rb
+++ b/libraries/resource_providers/api600/synergy/fcoe_network_provider.rb
@@ -1,0 +1,20 @@
+# (c) Copyright 2018 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # FCoENetwork API600 Synergy provider
+      class FCoENetworkProvider < API500::Synergy::FCoENetworkProvider
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description
Extends api600 support for fcoe-network resource

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
  - [] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [X] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [X] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
