### PR TITLE
network sets for v600.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Adds API 600 support to the following HPE OneView resources:
   - oneview_logical_interconnect_group
   - oneview_logical_switch
   - oneview_logical_switch_group
+  - oneview_network_set
   - oneview_sas_interconnect
   - oneview_sas_logical_interconnect
   - oneview_sas_logical_interconnect_group

--- a/examples/network_set.rb
+++ b/examples/network_set.rb
@@ -1,4 +1,4 @@
-# (c) Copyright 2016 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2018 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ oneview_network_set 'ChefNetworkSet_2' do
 end
 
 # Example: Adds 'ChefNetworkSet_1' to 'Scope1' and 'Scope2'
+# Only for API300 and API500
 oneview_network_set 'ChefNetworkSet_1' do
   client my_client
   scopes ['Scope1', 'Scope2']
@@ -68,6 +69,7 @@ oneview_network_set 'ChefNetworkSet_1' do
 end
 
 # Example: Removes 'ChefNetworkSet_1' from 'Scope1'
+# Only for API300 and API500
 oneview_network_set 'ChefNetworkSet_1' do
   client my_client
   scopes ['Scope1']
@@ -75,6 +77,7 @@ oneview_network_set 'ChefNetworkSet_1' do
 end
 
 # Example: Replaces 'Scope1' and 'Scope2' for 'ChefNetworkSet_1'
+# Only for API300 and API500
 oneview_network_set 'ChefNetworkSet_1' do
   client my_client
   scopes ['Scope1', 'Scope2']
@@ -82,6 +85,7 @@ oneview_network_set 'ChefNetworkSet_1' do
 end
 
 # Example: Replaces all scopes to empty list of scopes
+# Only for API300 and API500
 oneview_network_set 'ChefNetworkSet_1' do
   client my_client
   operation 'replace'

--- a/libraries/resource_providers/api600/c7000/network_set_provider.rb
+++ b/libraries/resource_providers/api600/c7000/network_set_provider.rb
@@ -1,0 +1,20 @@
+# Copyright 2018 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module C7000
+      # NetworkSet API600 C7000 provider
+      class NetworkSetProvider < OneviewCookbook::API500::C7000::NetworkSetProvider
+      end
+    end
+  end
+end

--- a/libraries/resource_providers/api600/synergy/network_set_provider.rb
+++ b/libraries/resource_providers/api600/synergy/network_set_provider.rb
@@ -1,0 +1,20 @@
+# Copyright 2018 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+module OneviewCookbook
+  module API600
+    module Synergy
+      # NetworkSet API600 Synergy provider
+      class NetworkSetProvider < OneviewCookbook::API500::Synergy::NetworkSetProvider
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description
network sets support for v600.

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [X] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [X] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
