### PR TITLE
Automation for network resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.3.1
   - 2.4
   - 2.5
 

--- a/examples/ethernet_network.rb
+++ b/examples/ethernet_network.rb
@@ -12,6 +12,8 @@
 # NOTE 1: This example requires two Scopes named "Scope1" and "Scope2" to be present in the appliance.
 # NOTE 2: The api_version client should be 300 or greater if you run the examples using Scopes
 
+OneviewCookbook::Helper.load_sdk(self)
+
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
   user: ENV['ONEVIEWSDK_USER'],
@@ -47,56 +49,16 @@ oneview_ethernet_network 'Eth1' do
   action :create_if_missing
 end
 
-# Only for API1800 or greater
 # Example: Bulk deletes ethernet networks.
+# Provide networks names as id values
 oneview_ethernet_network 'None' do
   client my_client
+  test1 = OneviewCookbook::Helper.load_resource(my_client, type: 'EthernetNetwork', id: 'Test1')
+  test2 = OneviewCookbook::Helper.load_resource(my_client, type: 'EthernetNetwork', id: 'Test2')
   data(
-    networkUris: [
-      '/rest/ethernet-networks/8ae63676-eb46-4fb8-8e76-5f31a71d85b3',
-      '/rest/ethernet-networks/9b198fb1-a1ee-4bc1-9ebc-f6c9f8de7344'
-    ]
+     networkUris: [ test1['uri'], test2['uri'] ]
   )
   action :delete_bulk
-  only_if { client[:api_version] >= 1800 }
-end
-
-# Only for V300 and V500
-# Example: Adds 'Eth1' to 'Scope1' and 'Scope2'
-oneview_ethernet_network 'Eth1' do
-  client my_client
-  scopes ['Scope1', 'Scope2']
-  action :add_to_scopes
-  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
-end
-
-# Only for V300 and V500
-# Example: Removes 'Eth1' from 'Scope1'
-oneview_ethernet_network 'Eth1' do
-  client my_client
-  scopes ['Scope1']
-  action :remove_from_scopes
-  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
-end
-
-# Only for V300 and V500
-# Example: Replaces 'Scope1' and 'Scope2' for 'Eth1'
-oneview_ethernet_network 'Eth1' do
-  client my_client
-  scopes ['Scope1', 'Scope2']
-  action :replace_scopes
-  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
-end
-
-# Only for V300 and V500
-# Example: Replaces all scopes to empty list of scopes
-oneview_ethernet_network 'Eth1' do
-  client my_client
-  operation 'replace'
-  path '/scopeUris'
-  value []
-  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
-  action :patch
 end
 
 # Example: Reset the connection template for a network

--- a/examples/ethernet_network.rb
+++ b/examples/ethernet_network.rb
@@ -54,9 +54,9 @@ end
 oneview_ethernet_network 'None' do
   client my_client
   test1 = OneviewCookbook::Helper.load_resource(my_client, type: 'EthernetNetwork', id: 'Test1')
-  test2 = OneviewCookbook::Helper.load_resource(my_client, type: 'EthernetNetwork', id: 'Test2')
+  test = OneviewCookbook::Helper.load_resource(my_client, type: 'EthernetNetwork', id: 'Test2')
   data(
-     networkUris: [ test1['uri'], test2['uri'] ]
+     networkUris: [ test1['uri'], test['uri'] ]
   )
   action :delete_bulk
   only_if { client[:api_version] >= 1800 }

--- a/examples/ethernet_network.rb
+++ b/examples/ethernet_network.rb
@@ -49,8 +49,8 @@ oneview_ethernet_network 'Eth1' do
   action :create_if_missing
 end
 
+# Only for API1800 or greater
 # Example: Bulk deletes ethernet networks.
-# Provide networks names as id values
 oneview_ethernet_network 'None' do
   client my_client
   test1 = OneviewCookbook::Helper.load_resource(my_client, type: 'EthernetNetwork', id: 'Test1')
@@ -59,6 +59,45 @@ oneview_ethernet_network 'None' do
      networkUris: [ test1['uri'], test2['uri'] ]
   )
   action :delete_bulk
+  only_if { client[:api_version] >= 1800 }
+end
+
+# Only for V300 and V500
+# Example: Adds 'Eth1' to 'Scope1' and 'Scope2'
+oneview_ethernet_network 'Eth1' do
+  client my_client
+  scopes ['Scope1', 'Scope2']
+  action :add_to_scopes
+  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
+end
+
+# Only for V300 and V500
+# Example: Removes 'Eth1' from 'Scope1'
+oneview_ethernet_network 'Eth1' do
+  client my_client
+  scopes ['Scope1']
+  action :remove_from_scopes
+  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
+end
+
+# Only for V300 and V500
+# Example: Replaces 'Scope1' and 'Scope2' for 'Eth1'
+oneview_ethernet_network 'Eth1' do
+  client my_client
+  scopes ['Scope1', 'Scope2']
+  action :replace_scopes
+  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
+end
+
+# Only for V300 and V500
+# Example: Replaces all scopes to empty list of scopes
+oneview_ethernet_network 'Eth1' do
+  client my_client
+  operation 'replace'
+  path '/scopeUris'
+  value []
+  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
+  action :patch
 end
 
 # Example: Reset the connection template for a network

--- a/examples/fc_network.rb
+++ b/examples/fc_network.rb
@@ -41,10 +41,12 @@ oneview_fc_network 'Fc1' do
       maximumBandwidth: 9000
     }
   )
+  associated_san 'SAN1_0'
   client my_client
   action :create_if_missing
 end
 
+# This examples works only from API1800
 # Example: Bulk deletes fc networks.
 oneview_fc_network 'None' do
   client my_client
@@ -53,6 +55,45 @@ oneview_fc_network 'None' do
      networkUris: [ test1['uri'] ]
   )
   action :delete_bulk
+  only_if { client[:api_version] >= 1800 }
+end
+
+# Example: Adds 'Fc1' to 'Scope1' and 'Scope2'
+# Available only in Api300 and Api500
+oneview_fc_network 'Fc1' do
+  client my_client
+  scopes ['Scope1', 'Scope2']
+  action :add_to_scopes
+  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
+end
+
+# Example: Removes 'Fc1' from 'Scope1'
+# Available only in Api300 and Api500
+oneview_fc_network 'Fc1' do
+  client my_client
+  scopes ['Scope1']
+  action :remove_from_scopes
+  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
+end
+
+# Example: Replaces 'Scope1' and 'Scope2' for 'Fc1'
+# Available only in Api300 and Api500
+oneview_fc_network 'Fc1' do
+  client my_client
+  scopes ['Scope1', 'Scope2']
+  action :replace_scopes
+  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
+end
+
+# Example: Replaces all scopes to empty list of scopes
+# Available only in Api300 and Api500
+oneview_fc_network 'Fc1' do
+  client my_client
+  operation 'replace'
+  path '/scopeUris'
+  value []
+  action :patch
+  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
 end
 
 # Example: Reset the connection template for a fc network

--- a/examples/fc_network.rb
+++ b/examples/fc_network.rb
@@ -11,7 +11,8 @@
 
 # NOTE 1: This example requires two Scopes named "Scope1" and "Scope2" to be present in the appliance.
 # NOTE 2: The api_version client should be 300 or greater if you run the examples using Scopes
-# NOTE 3: As a pre-requisite, create SAN1_0
+
+OneviewCookbook::Helper.load_sdk(self)
 
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
@@ -40,61 +41,18 @@ oneview_fc_network 'Fc1' do
       maximumBandwidth: 9000
     }
   )
-  associated_san 'SAN1_0'
   client my_client
   action :create_if_missing
 end
 
-# This examples works only from API1800
 # Example: Bulk deletes fc networks.
 oneview_fc_network 'None' do
   client my_client
+  test1 = OneviewCookbook::Helper.load_resource(my_client, type: 'FCNetwork', id: 'FcTest1')
   data(
-    networkUris: [
-      '/rest/fc-networks/af98dc4a-0982-4324-9700-5aed3245615b',
-      '/rest/fc-networks/40e9e41d-31c2-40dc-878c-7a7f0720ea8a'
-    ]
+     networkUris: [ test1['uri'] ]
   )
   action :delete_bulk
-  only_if { client[:api_version] >= 1800 }
-end
-
-# Example: Adds 'Fc1' to 'Scope1' and 'Scope2'
-# Available only in Api300 and Api500
-oneview_fc_network 'Fc1' do
-  client my_client
-  scopes ['Scope1', 'Scope2']
-  action :add_to_scopes
-  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
-end
-
-# Example: Removes 'Fc1' from 'Scope1'
-# Available only in Api300 and Api500
-oneview_fc_network 'Fc1' do
-  client my_client
-  scopes ['Scope1']
-  action :remove_from_scopes
-  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
-end
-
-# Example: Replaces 'Scope1' and 'Scope2' for 'Fc1'
-# Available only in Api300 and Api500
-oneview_fc_network 'Fc1' do
-  client my_client
-  scopes ['Scope1', 'Scope2']
-  action :replace_scopes
-  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
-end
-
-# Example: Replaces all scopes to empty list of scopes
-# Available only in Api300 and Api500
-oneview_fc_network 'Fc1' do
-  client my_client
-  operation 'replace'
-  path '/scopeUris'
-  value []
-  action :patch
-  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
 end
 
 # Example: Reset the connection template for a fc network

--- a/examples/fcoe_network.rb
+++ b/examples/fcoe_network.rb
@@ -14,7 +14,8 @@
 # Scopes: Scope1, Scope2
 
 # NOTE 2: The api_version client should be 300 or greater if you run the examples using Scopes
-# NOTE 3: As a pre-requisite, VSAN10 should be added to oneview
+
+OneviewCookbook::Helper.load_sdk(self)
 
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
@@ -31,61 +32,18 @@ oneview_fcoe_network 'FCoE1' do
       maximumBandwidth: 9000
     }
   )
-  associated_san 'VSAN10'
   client my_client
   action :create
 end
 
-# Only from API1800
 # Example: Bulk deletes fcoe networks.
 oneview_fcoe_network 'None' do
   client my_client
+  test1 = OneviewCookbook::Helper.load_resource(my_client, type: 'FCoENetwork', id: 'FcoeTest1')
   data(
-    networkUris: [
-      '/rest/fcoe-networks/a3534c47-ae3b-490d-aa0d-7615b66b8756',
-      '/rest/fcoe-networks/89c89197-6228-4757-9f1b-2117ad24831d'
-    ]
+    networkUris: [ test1['uri'] ]
   )
   action :delete_bulk
-  only_if { client[:api_version] >= 1800 }
-end
-
-# Adds 'FCoE1' to 'Scope1' and 'Scope2'
-# Available only in Api300 and Api500
-oneview_fcoe_network 'FCoE1' do
-  client my_client
-  scopes ['Scope1', 'Scope2']
-  action :add_to_scopes
-  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
-end
-
-# Removes 'FCoE1' from 'Scope1'
-# Available only in Api300 and Api500
-oneview_fcoe_network 'FCoE1' do
-  client my_client
-  scopes ['Scope1']
-  action :remove_from_scopes
-  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
-end
-
-# Replaces scopes to 'Scope1' and 'Scope2'
-# Available only in Api300 and Api500
-oneview_fcoe_network 'FCoE1' do
-  client my_client
-  scopes ['Scope1', 'Scope2']
-  action :replace_scopes
-  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
-end
-
-# Replaces all scopes to empty list of scopes
-# Available only in Api300 and Api500
-oneview_fcoe_network 'FCoE1' do
-  client my_client
-  operation 'replace'
-  path '/scopeUris'
-  value []
-  action :patch
-  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
 end
 
 # Reset the connection template for 'FCoE1'

--- a/examples/fcoe_network.rb
+++ b/examples/fcoe_network.rb
@@ -32,10 +32,12 @@ oneview_fcoe_network 'FCoE1' do
       maximumBandwidth: 9000
     }
   )
+  associated_san 'VSAN10'
   client my_client
   action :create
 end
 
+# Only from API1800
 # Example: Bulk deletes fcoe networks.
 oneview_fcoe_network 'None' do
   client my_client
@@ -44,6 +46,45 @@ oneview_fcoe_network 'None' do
     networkUris: [ test1['uri'] ]
   )
   action :delete_bulk
+  only_if { client[:api_version] >= 1800 }
+end
+
+# Adds 'FCoE1' to 'Scope1' and 'Scope2'
+# Available only in Api300 and Api500
+oneview_fcoe_network 'FCoE1' do
+  client my_client
+  scopes ['Scope1', 'Scope2']
+  action :add_to_scopes
+  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
+end
+
+# Removes 'FCoE1' from 'Scope1'
+# Available only in Api300 and Api500
+oneview_fcoe_network 'FCoE1' do
+  client my_client
+  scopes ['Scope1']
+  action :remove_from_scopes
+  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
+end
+
+# Replaces scopes to 'Scope1' and 'Scope2'
+# Available only in Api300 and Api500
+oneview_fcoe_network 'FCoE1' do
+  client my_client
+  scopes ['Scope1', 'Scope2']
+  action :replace_scopes
+  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
+end
+
+# Replaces all scopes to empty list of scopes
+# Available only in Api300 and Api500
+oneview_fcoe_network 'FCoE1' do
+  client my_client
+  operation 'replace'
+  path '/scopeUris'
+  value []
+  action :patch
+  only_if { client[:api_version] == 300 || client[:api_version] == 500 }
 end
 
 # Reset the connection template for 'FCoE1'

--- a/examples/uplink_set.rb
+++ b/examples/uplink_set.rb
@@ -19,7 +19,7 @@
 my_client = {
   url: ENV['ONEVIEWSDK_URL'],
   user: ENV['ONEVIEWSDK_USER'],
-  password: ENV['ONEVIEWSDK_PASSWORD']
+  password: ENV['ONEVIEWSDK_PASSWORD'],
   api_version: 2200
 }
 
@@ -46,17 +46,17 @@ oneview_uplink_set 'UplinkSet1' do
       {
         locationEntries:
         [
-	  { value: '3', type: 'Bay'},
+          { value: '3', type: 'Bay'},
           { value: '/rest/enclosures/0000000000A66101', type: 'Enclosure' },
           { value: 'Q3:1', type: 'Port'}
         ]
       }
     ]
   )
-  logical_interconnect 'LogicalInterconnect1' # Name of the associated logical interconnect
-  networks ['Ethernet1', 'Ethernet2'] # Array of strings containing the name of the associated ethernet networks (can be empty - [])
-  fc_networks ['FCNetwork1'] # Array of strings containing the name of the associated fc networks (can be empty - [])
-  fcoe_networks ['FCoENetwork1'] # Array of strings containing the name of the associated fcoe networks (can be empty - [])
+  logical_interconnect 'LE-LIG' # Name of the associated logical interconnect
+  networks ['Eth1_uplink', 'Eth2_uplink'] # Array of strings containing the name of the associated ethernet networks (can be empty - [])
+  #fc_networks ['FC_FA'] # Array of strings containing the name of the associated fc networks (can be empty - [])
+  #fcoe_networks ['FCoENetwork1'] # Array of strings containing the name of the associated fcoe networks (can be empty - [])
   native_network nil # Name of the native network (can be nil)
 end
 


### PR DESCRIPTION
### Description
Automation for network resources

### Issues Resolved

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass (`$ rake test`).
  - [ ] New resources and/or actions have are included in the [matchers.rb](https://github.com/HewlettPackard/oneview-chef/blob/master/libraries/matchers.rb) and [matchers_spec](https://github.com/HewlettPackard/oneview-chef/blob/master/spec/unit/resources/matchers_spec.rb).
- [ ] New functionality has been documented in the README if applicable.
  - [x] New functionality has been thoroughly documented in [examples](https://github.com/HewlettPackard/oneview-chef/tree/master/examples/) (please include helpful comments).
- [ ] Changes documented in the [CHANGELOG](https://github.com/HewlettPackard/oneview-chef/blob/master/CHANGELOG.md).
